### PR TITLE
DM-29972: Switch to Font Source from Google Fonts

### DIFF
--- a/components/meta.js
+++ b/components/meta.js
@@ -33,12 +33,6 @@ const Meta = () => {
         key="ogdescription"
         content={siteDescription}
       />
-
-      <link rel="preconnect" href="https://fonts.gstatic.com" />
-      <link
-        href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400&display=swap"
-        rel="stylesheet"
-      />
     </Head>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "squareone",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource/source-sans-pro": "^4.2.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
         "@fortawesome/react-fontawesome": "^0.1.14",
@@ -380,6 +381,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@fontsource/source-sans-pro": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-4.2.2.tgz",
+      "integrity": "sha512-ApmV5F1D32nmBspCJuijDNBV7TtazFC4L7BIilHj3e6IAW/ndQMXl1+4DUjOGVO/83tF/WXjOEMxROE0QxYDwQ=="
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "0.2.35",
@@ -6558,6 +6564,11 @@
           "dev": true
         }
       }
+    },
+    "@fontsource/source-sans-pro": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@fontsource/source-sans-pro/-/source-sans-pro-4.2.2.tgz",
+      "integrity": "sha512-ApmV5F1D32nmBspCJuijDNBV7TtazFC4L7BIilHj3e6IAW/ndQMXl1+4DUjOGVO/83tF/WXjOEMxROE0QxYDwQ=="
     },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.35",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,17 @@
     "prepare": "husky install"
   },
   "babel": {
-    "presets": ["next/babel"],
-    "plugins": [["styled-components", { "ssr": true }]]
+    "presets": [
+      "next/babel"
+    ],
+    "plugins": [
+      [
+        "styled-components",
+        {
+          "ssr": true
+        }
+      ]
+    ]
   },
   "eslintConfig": {
     "extends": [
@@ -37,6 +46,7 @@
     "*.js": "eslint"
   },
   "dependencies": {
+    "@fontsource/source-sans-pro": "^4.2.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,14 +2,22 @@ import PropTypes from 'prop-types';
 import getConfig from 'next/config';
 import { ThemeProvider } from 'next-themes';
 
+// Icons from Font Awesome
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faAngleDown } from '@fortawesome/free-solid-svg-icons';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 
+// Source Sans Pro Font from Font Source
+import '@fontsource/source-sans-pro/400.css';
+import '@fontsource/source-sans-pro/400-italic.css';
+import '@fontsource/source-sans-pro/700.css';
+
+// Global CSS
 import 'normalize.css';
 import '@lsst-sqre/rubin-style-dictionary/dist/tokens.css';
 import '@lsst-sqre/rubin-style-dictionary/dist/tokens.dark.css';
 import '../styles/globals.css';
+
 import { useLogin } from '../hooks/login';
 import Page from '../components/page';
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -9,7 +9,6 @@ export default function Home({ publicRuntimeConfig }) {
     <>
       <Head>
         <title>{publicRuntimeConfig.siteName}</title>
-        <link rel="icon" href="/favicon.ico" />
       </Head>
 
       <Hero />


### PR DESCRIPTION
This change allows us to package and deliver Source Sans Pro from the app itself rather than relying on a third-party service (Google Fonts).

Also solves a bug related to the default next favicon.