### PR TITLE
DM-30727: Display broadcasts from Semaphore's REST API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Change log
 ##########
 
+0.4.0 (2021-08-11)
+==================
+
+- Broadcast messages are now sourced through `Semaphore <https://github/lsst-sqre/semaphore>`_, a service that is installed in the science platform and sources messages from GitHub.
+  With this update, messages can also have additional information that is visible if a user clicks on a "Read more" button.
+  This disclosure is powered by `react-a11y-disclosure <https://github.com/KittyGiraudel/react-a11y-disclosure>`_.
+
+- There is a new configuration field, ``semaphoreUrl``, to configure the root URL for the Semaphore API service.
+  The ``broadcastMarkdown`` field is removed.
+
 0.3.1 (2021-08-04)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -9,8 +9,9 @@ Squareone
 
 Squareone is the next-generation landing page for the `Rubin Observatory`_ Science Platform.
 It's where you start on your journey to use the RSP's portal, notebooks, and APIs to do science with Rubin/LSST data.
+Squareone is also a visual interface for user notifications from the `Semaphore`_ service.
 
-Squareone is deployed with `Phalanx <https://phalanx.lsst.io>`_.
+Squareone is deployed with `Phalanx`_.
 
 **Documentation:** https://squareone.lsst.io
 
@@ -99,3 +100,5 @@ You can serve the production build locally::
 .. _Rubin Observatory: https://www.lsst.org
 .. _React: https://reactjs.org
 .. _styled-components: https://styled-components.com
+.. _Semaphore: https://github.com/lsst-sqre/semaphore
+.. _Phalanx: https://phalanx.lsst.io

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. image:: https://github.com/lsst-sqre/squareone/actions/workflows/ci.yaml/badge.svg
-   :target: https://github.com/lsst-sqre/sqr-060/actions/
+   :target: https://github.com/lsst-sqre/squareone/actions/
 .. image:: https://img.shields.io/badge/squareone-lsst.io-brightgreen.svg
    :target: https://squareone.lsst.io
 

--- a/components/broadcastBanner.js
+++ b/components/broadcastBanner.js
@@ -33,21 +33,21 @@ const StyledBroadcastContainer = styled.div`
 /*
  * A broadcast message banner.
  */
-export default function BroadcastBanner({ broadcastSummary }) {
+export default function BroadcastBanner({ broadcast }) {
   // If there isn't any broadcast content, don't show a banner
-  if (!broadcastSummary) {
+  if (!broadcast) {
     return <></>;
   }
 
   /* eslint-disable react/no-danger */
   return (
     <StyledBroadcastContainer>
-      <aside dangerouslySetInnerHTML={{ __html: broadcastSummary }} />
+      <aside dangerouslySetInnerHTML={{ __html: broadcast.summary.html }} />
     </StyledBroadcastContainer>
   );
   /* eslint-enable react/no-danger */
 }
 
 BroadcastBanner.propTypes = {
-  broadcastSummary: PropTypes.string,
+  broadcast: PropTypes.object,
 };

--- a/components/broadcastBanner.js
+++ b/components/broadcastBanner.js
@@ -33,21 +33,21 @@ const StyledBroadcastContainer = styled.div`
 /*
  * A broadcast message banner.
  */
-export default function BroadcastBanner({ broadcast }) {
+export default function BroadcastBanner({ broadcastSummary }) {
   // If there isn't any broadcast content, don't show a banner
-  if (!broadcast) {
+  if (!broadcastSummary) {
     return <></>;
   }
 
   /* eslint-disable react/no-danger */
   return (
     <StyledBroadcastContainer>
-      <aside dangerouslySetInnerHTML={{ __html: broadcast }} />
+      <aside dangerouslySetInnerHTML={{ __html: broadcastSummary }} />
     </StyledBroadcastContainer>
   );
   /* eslint-enable react/no-danger */
 }
 
 BroadcastBanner.propTypes = {
-  broadcast: PropTypes.string,
+  broadcastSummary: PropTypes.string,
 };

--- a/components/broadcastBanner.js
+++ b/components/broadcastBanner.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import useDisclosure from 'react-a11y-disclosure';
 
 import { ContentMaxWidth } from '../styles/sizes';
 
@@ -20,6 +21,16 @@ const StyledBroadcastContainer = styled.div`
     }
   }
 
+  .disclosure {
+    transition: 250ms;
+  }
+
+  .disclosure[aria-hidden='true'] {
+    max-height: 0;
+    opacity: 0;
+    visibility: hidden;
+  }
+
   a {
     color: white;
     text-decoration: underline;
@@ -34,18 +45,38 @@ const StyledBroadcastContainer = styled.div`
  * A broadcast message banner.
  */
 export default function BroadcastBanner({ broadcast }) {
+  const { toggleProps, contentProps, isExpanded } = useDisclosure({
+    id: `broadcast-${broadcast.id}`,
+    isExpanded: false,
+  });
+
   // If there isn't any broadcast content, don't show a banner
   if (!broadcast) {
     return <></>;
   }
 
   /* eslint-disable react/no-danger */
+  /* eslint-disable react/jsx-props-no-spreading */
   return (
     <StyledBroadcastContainer>
-      <aside dangerouslySetInnerHTML={{ __html: broadcast.summary.html }} />
+      <aside>
+        <div dangerouslySetInnerHTML={{ __html: broadcast.summary.html }} />
+        {broadcast.body && (
+          <>
+            <button type="button" {...toggleProps}>
+              {isExpanded ? 'Show less' : 'Show more'}
+            </button>
+
+            <div className="disclosure" {...contentProps}>
+              <div dangerouslySetInnerHTML={{ __html: broadcast.body.html }} />
+            </div>
+          </>
+        )}
+      </aside>
     </StyledBroadcastContainer>
   );
   /* eslint-enable react/no-danger */
+  /* eslint-enable react/jsx-props-no-spreading */
 }
 
 BroadcastBanner.propTypes = {

--- a/components/broadcastBanner.js
+++ b/components/broadcastBanner.js
@@ -53,12 +53,20 @@ const StyledBroadcastContainer = styled.div`
 
   .disclosure {
     transition: 250ms;
+    margin-top: 0.5em;
+    max-height: 15em;
+    overflow-y: scroll;
   }
 
   .disclosure[aria-hidden='true'] {
+    height: 0;
     max-height: 0;
     opacity: 0;
+    margin-top: 0;
+    padding-top: 0;
+    padding-bottom: 0;
     visibility: hidden;
+    background-color: transparent;
   }
 
   a {

--- a/components/broadcastBanner.js
+++ b/components/broadcastBanner.js
@@ -12,13 +12,43 @@ const StyledBroadcastContainer = styled.div`
   color: white;
 
   aside {
-    margin: 0 auto;
+    margin: 0.5rem auto;
     max-width: ${ContentMaxWidth};
     padding: 0 var(--size-screen-padding-min);
 
     @media (min-width: ${ContentMaxWidth}) {
       padding: 0;
     }
+  }
+
+  .summary {
+    width: 100%;
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: flex-start;
+  }
+
+  .summary p {
+    margin: 0;
+  }
+
+  .disclosure-button-area {
+    margin-left: 1.5rem;
+    align-self: flex-end;
+  }
+
+  .disclosure-button-area button {
+    font-size: 0.8rem;
+    cursor: pointer;
+    background-color: transparent;
+    color: white;
+    border: 1px solid white;
+    border-radius: 5px;
+    transition: 250ms;
+  }
+
+  .disclosure-button-area button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
   }
 
   .disclosure {
@@ -60,17 +90,23 @@ export default function BroadcastBanner({ broadcast }) {
   return (
     <StyledBroadcastContainer>
       <aside>
-        <div dangerouslySetInnerHTML={{ __html: broadcast.summary.html }} />
-        {broadcast.body && (
-          <>
-            <button type="button" {...toggleProps}>
-              {isExpanded ? 'Show less' : 'Show more'}
-            </button>
-
-            <div className="disclosure" {...contentProps}>
-              <div dangerouslySetInnerHTML={{ __html: broadcast.body.html }} />
+        <div className="summary">
+          <div
+            className="summary-content"
+            dangerouslySetInnerHTML={{ __html: broadcast.summary.html }}
+          />
+          {broadcast.body && (
+            <div className="disclosure-button-area">
+              <button type="button" {...toggleProps}>
+                {isExpanded ? 'Show less' : 'Show more'}
+              </button>
             </div>
-          </>
+          )}
+        </div>
+        {broadcast.body && (
+          <div className="disclosure" {...contentProps}>
+            <div dangerouslySetInnerHTML={{ __html: broadcast.body.html }} />
+          </div>
         )}
       </aside>
     </StyledBroadcastContainer>

--- a/components/page.js
+++ b/components/page.js
@@ -35,7 +35,7 @@ const StyledLayout = styled.div`
  * content, and footer.
  */
 export default function Page({ children, loginData, semaphoreUrl }) {
-  const broadcastsUrl = `${semaphoreUrl}/v1/broadcasts`;
+  const broadcastsUrl = semaphoreUrl ? `${semaphoreUrl}/v1/broadcasts` : null;
   const { data: broadcastData } = useFetch(broadcastsUrl);
 
   return (

--- a/components/page.js
+++ b/components/page.js
@@ -44,10 +44,7 @@ export default function Page({ children, loginData, semaphoreUrl }) {
       <div className="upper-container">
         <Header loginData={loginData} />
         {broadcastData.map((broadcast) => (
-          <BroadcastBanner
-            broadcastSummary={broadcast.summary.html}
-            key={broadcast.id}
-          />
+          <BroadcastBanner broadcast={broadcast} key={broadcast.id} />
         ))}
         <MainContent>{children}</MainContent>
       </div>

--- a/components/page.js
+++ b/components/page.js
@@ -6,6 +6,7 @@ import MainContent from './mainContent';
 import Footer from './footer';
 import Meta from './meta';
 import BroadcastBanner from './broadcastBanner';
+import { useFetch } from '../hooks/fetch';
 
 /*
  * Layout wrapper div.
@@ -33,13 +34,21 @@ const StyledLayout = styled.div`
  * Page wapper component that provides the default layout of navigation,
  * content, and footer.
  */
-export default function Page({ children, loginData, broadcast }) {
+export default function Page({ children, loginData, semaphoreUrl }) {
+  const broadcastsUrl = `${semaphoreUrl}/v1/broadcasts`;
+  const { data: broadcastData } = useFetch(broadcastsUrl);
+
   return (
     <StyledLayout>
       <Meta />
       <div className="upper-container">
         <Header loginData={loginData} />
-        <BroadcastBanner broadcast={broadcast} />
+        {broadcastData.map((broadcast) => (
+          <BroadcastBanner
+            broadcastSummary={broadcast.summary.html}
+            key={broadcast.id}
+          />
+        ))}
         <MainContent>{children}</MainContent>
       </div>
       <div className="sticky-footer-container">
@@ -52,5 +61,5 @@ export default function Page({ children, loginData, broadcast }) {
 Page.propTypes = {
   children: PropTypes.node,
   loginData: PropTypes.object.isRequired,
-  broadcast: PropTypes.string,
+  semaphoreUrl: PropTypes.string,
 };

--- a/hooks/fetch.js
+++ b/hooks/fetch.js
@@ -1,0 +1,64 @@
+/*
+ * useFetch hook that fetches data and caches it to avoid re-requests.
+ *
+ * This hook is from the article:
+ * https://www.smashingmagazine.com/2020/07/custom-react-hook-fetch-cache-data/
+ * https://github.com/ooade/use-fetch-hook
+ */
+
+import { useEffect, useRef, useReducer } from 'react';
+
+export const useFetch = (url) => {
+  const cache = useRef({});
+
+  const initialState = {
+    status: 'idle',
+    error: null,
+    data: [],
+  };
+
+  const [state, dispatch] = useReducer((currentState, action) => {
+    switch (action.type) {
+      case 'FETCHING':
+        return { ...initialState, status: 'fetching' };
+      case 'FETCHED':
+        return { ...initialState, status: 'fetched', data: action.payload };
+      case 'FETCH_ERROR':
+        return { ...initialState, status: 'error', error: action.payload };
+      default:
+        return currentState;
+    }
+  }, initialState);
+
+  useEffect(() => {
+    let cancelRequest = false;
+    if (!url) return;
+
+    const fetchData = async () => {
+      dispatch({ type: 'FETCHING' });
+      if (cache.current[url]) {
+        const data = cache.current[url];
+        dispatch({ type: 'FETCHED', payload: data });
+      } else {
+        try {
+          const response = await fetch(url);
+          const data = await response.json();
+          cache.current[url] = data;
+          if (cancelRequest) return;
+          dispatch({ type: 'FETCHED', payload: data });
+        } catch (error) {
+          if (cancelRequest) return;
+          dispatch({ type: 'FETCH_ERROR', payload: error.message });
+        }
+      }
+    };
+
+    fetchData();
+
+    return function cleanup() {
+      cancelRequest = true;
+    };
+  }, [url]);
+
+  return state;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "squareone",
-  "version": "0.1.5",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "squareone",
-      "version": "0.1.5",
+      "version": "0.3.1",
       "dependencies": {
         "@fontsource/source-sans-pro": "^4.2.2",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
@@ -21,6 +21,7 @@
         "normalize.css": "^8.0.1",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
+        "react-a11y-disclosure": "^0.1.0",
         "react-dom": "^17.0.2",
         "remark": "^13.0.0",
         "remark-gfm": "^1.0.0",
@@ -6055,6 +6056,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-a11y-disclosure": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/react-a11y-disclosure/-/react-a11y-disclosure-0.1.0.tgz",
+      "integrity": "sha512-yJCHSWndUG0QyIKYkD5/Ce2ywmJKUc09TYYbozRzfEAOrrkfwvcgWAsVbmCsqe7tdFvXY4BUo9rJT7LcefL+EA==",
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -12213,6 +12222,12 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
+    },
+    "react-a11y-disclosure": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/react-a11y-disclosure/-/react-a11y-disclosure-0.1.0.tgz",
+      "integrity": "sha512-yJCHSWndUG0QyIKYkD5/Ce2ywmJKUc09TYYbozRzfEAOrrkfwvcgWAsVbmCsqe7tdFvXY4BUo9rJT7LcefL+EA==",
+      "requires": {}
     },
     "react-dom": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squareone",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "normalize.css": "^8.0.1",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
+    "react-a11y-disclosure": "^0.1.0",
     "react-dom": "^17.0.2",
     "remark": "^13.0.0",
     "remark-gfm": "^1.0.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -20,23 +20,17 @@ import '../styles/globals.css';
 
 import { useLogin } from '../hooks/login';
 import Page from '../components/page';
-import gfmToHtml from '../utils/gfmToHtml';
 
 // Add icons to the global Font Awesome library
 library.add(faAngleDown);
 
-function MyApp({ Component, pageProps, baseUrl, broadcast, semaphoreUrl }) {
+function MyApp({ Component, pageProps, baseUrl, semaphoreUrl }) {
   const loginData = useLogin(baseUrl);
 
   /* eslint-disable react/jsx-props-no-spreading */
   return (
     <ThemeProvider defaultTheme="system">
-      <Page
-        loginData={loginData}
-        baseUrl={baseUrl}
-        broadcast={broadcast}
-        semaphoreUrl={semaphoreUrl}
-      >
+      <Page loginData={loginData} baseUrl={baseUrl} semaphoreUrl={semaphoreUrl}>
         <Component {...pageProps} />
       </Page>
     </ThemeProvider>
@@ -46,19 +40,14 @@ function MyApp({ Component, pageProps, baseUrl, broadcast, semaphoreUrl }) {
 
 MyApp.getInitialProps = async () => {
   const { publicRuntimeConfig } = getConfig();
-  const { baseUrl, broadcastMarkdown, semaphoreUrl } = publicRuntimeConfig;
-  const broadcast = broadcastMarkdown
-    ? await gfmToHtml(broadcastMarkdown)
-    : null;
-  console.log(`broadcast: ${broadcast}`);
-  return { baseUrl, broadcast, semaphoreUrl };
+  const { baseUrl, semaphoreUrl } = publicRuntimeConfig;
+  return { baseUrl, semaphoreUrl };
 };
 
 MyApp.propTypes = {
   Component: PropTypes.elementType.isRequired,
   pageProps: PropTypes.object.isRequired,
   baseUrl: PropTypes.string.isRequired,
-  broadcast: PropTypes.string,
   semaphoreUrl: PropTypes.string,
 };
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -25,12 +25,18 @@ import gfmToHtml from '../utils/gfmToHtml';
 // Add icons to the global Font Awesome library
 library.add(faAngleDown);
 
-function MyApp({ Component, pageProps, baseUrl, broadcast }) {
+function MyApp({ Component, pageProps, baseUrl, broadcast, semaphoreUrl }) {
   const loginData = useLogin(baseUrl);
+
   /* eslint-disable react/jsx-props-no-spreading */
   return (
     <ThemeProvider defaultTheme="system">
-      <Page loginData={loginData} baseUrl={baseUrl} broadcast={broadcast}>
+      <Page
+        loginData={loginData}
+        baseUrl={baseUrl}
+        broadcast={broadcast}
+        semaphoreUrl={semaphoreUrl}
+      >
         <Component {...pageProps} />
       </Page>
     </ThemeProvider>
@@ -40,12 +46,12 @@ function MyApp({ Component, pageProps, baseUrl, broadcast }) {
 
 MyApp.getInitialProps = async () => {
   const { publicRuntimeConfig } = getConfig();
-  const { baseUrl, broadcastMarkdown } = publicRuntimeConfig;
+  const { baseUrl, broadcastMarkdown, semaphoreUrl } = publicRuntimeConfig;
   const broadcast = broadcastMarkdown
     ? await gfmToHtml(broadcastMarkdown)
     : null;
   console.log(`broadcast: ${broadcast}`);
-  return { baseUrl, broadcast };
+  return { baseUrl, broadcast, semaphoreUrl };
 };
 
 MyApp.propTypes = {
@@ -53,6 +59,7 @@ MyApp.propTypes = {
   pageProps: PropTypes.object.isRequired,
   baseUrl: PropTypes.string.isRequired,
   broadcast: PropTypes.string,
+  semaphoreUrl: PropTypes.string,
 };
 
 export default MyApp;

--- a/squareone.config.schema.json
+++ b/squareone.config.schema.json
@@ -28,6 +28,11 @@
       "type": "string",
       "title": "Broadcast markdown",
       "description": "Optional content for a broadcast notification in squareone. This setting will be supersceded by the semaphore API."
+    },
+    "semaphoreUrl": {
+      "type": "string",
+      "title": "Semaphore URL",
+      "description": "URL of the Semaphore API service for obtaining notifications and broadcasts"
     }
   }
 }

--- a/squareone.config.schema.json
+++ b/squareone.config.schema.json
@@ -24,11 +24,6 @@
       "title": "Base URL for the public ingress",
       "description": "Used for computing absolute URLs"
     },
-    "broadcastMarkdown": {
-      "type": "string",
-      "title": "Broadcast markdown",
-      "description": "Optional content for a broadcast notification in squareone. This setting will be supersceded by the semaphore API."
-    },
     "semaphoreUrl": {
       "type": "string",
       "title": "Semaphore URL",

--- a/squareone.config.yaml
+++ b/squareone.config.yaml
@@ -2,6 +2,4 @@ siteName: 'Squareone Development Site'
 baseUrl: 'http://localhost:3000'
 siteDescription: |
   The site description.
-broadcastMarkdown: |
-  👋 Hello world! I'm here to tell you about something important.
 semaphoreUrl: 'https://data-dev.lsst.cloud/semaphore'

--- a/squareone.config.yaml
+++ b/squareone.config.yaml
@@ -4,3 +4,4 @@ siteDescription: |
   The site description.
 broadcastMarkdown: |
   👋 Hello world! I'm here to tell you about something important.
+semaphoreUrl: 'https://data-dev.lsst.cloud/semaphore'


### PR DESCRIPTION
This replaces the previous work to obtain broadcast messages from the app's configuration. Now the Page component uses a `useFetch` hook to obtain broadcasts from Semaphore's `GET /v1/broadcasts` endpoint. Since multiple broadcasts can be active, we map over the broadcasts, creating a `BroadcastBanner` component for each.

The broadcast also makes use of a disclosure widget to "show more" when the message contains additional content beyond just the summary. This widget is powered by https://github.com/KittyGiraudel/react-a11y-disclosure