### PR TITLE
DM-34437: Show "info" broadcast messages in Rubin teal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,10 @@
 Change log
 ##########
 
-Unreleased
-==========
+0.6.0 (2022-04-14)
+==================
 
+- Informational broadcast messages are now displayed ith Rubin's primary teal as the background color (see `lsst-sqre/semaphore#29 <https://github.com/lsst-sqre/semaphore/pull/29>`__ for more information).
 - Replaced custom fetch hook for the Semaphore broadcast message data with swr, enabling us to automatically refresh broadcast data.
 - Updated the component layout in the source code.
 

--- a/src/components/BroadcastBannerStack/BroadcastBanner.js
+++ b/src/components/BroadcastBannerStack/BroadcastBanner.js
@@ -8,7 +8,10 @@ const StyledBroadcastContainer = styled.div`
   width: 100%;
   margin: 0;
   padding: 0.5em;
-  background-color: var(--rsd-color-red-500);
+  background-color: ${(props) =>
+    props.category === 'info'
+      ? 'var(--rsd-color-primary-600)'
+      : 'var(--rsd-color-red-500)'};
   color: white;
 
   aside {
@@ -97,7 +100,7 @@ export default function BroadcastBanner({ broadcast }) {
   /* eslint-disable react/no-danger */
   /* eslint-disable react/jsx-props-no-spreading */
   return (
-    <StyledBroadcastContainer>
+    <StyledBroadcastContainer category={broadcast.category || 'maintenance'}>
       <aside>
         <div className="summary">
           <div


### PR DESCRIPTION
Add support for broadcast message categories and display broadcasts differently based on that category.

In this initial support, "info" messages are displayed in Rubin primary teal. The default is to show the message using the "maintenance" category display, which is red.