### PR TITLE
DM-35057: Add support for hide code cells display param

### DIFF
--- a/src/components/TimesSquareApp/TimesSquareApp.js
+++ b/src/components/TimesSquareApp/TimesSquareApp.js
@@ -21,7 +21,6 @@ const StyledLayout = styled.div`
 `;
 
 export default function TimesSquareApp({ children, pageNav, pagePanel }) {
-  console.log('Running TimesSquareApp');
   return (
     <StyledLayout>
       <Sidebar pageNav={pageNav} pagePanel={pagePanel} />

--- a/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
+++ b/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
@@ -15,6 +15,7 @@ import TimesSquareParameters from '../TimesSquareParameters';
 export default function TimesSquareGitHubPagePanel({
   tsPageUrl,
   userParameters,
+  displaySettings,
 }) {
   const { publicRuntimeConfig } = getConfig();
   const pageData = useTimesSquarePage(tsPageUrl);
@@ -41,6 +42,7 @@ export default function TimesSquareGitHubPagePanel({
         <TimesSquareParameters
           pageData={pageData}
           userParameters={userParameters}
+          displaySettings={displaySettings}
         />
       </div>
     </PagePanelContainer>

--- a/src/components/TimesSquareNotebookViewer/TimesSquareNotebookViewer.js
+++ b/src/components/TimesSquareNotebookViewer/TimesSquareNotebookViewer.js
@@ -19,8 +19,12 @@ const StyledIframe = styled.iframe`
   height: 100%;
 `;
 
-export default function TimesSquareNotebookViewer({ tsPageUrl, parameters }) {
-  const htmlStatus = useHtmlStatus(tsPageUrl, parameters);
+export default function TimesSquareNotebookViewer({
+  tsPageUrl,
+  parameters,
+  displaySettings,
+}) {
+  const htmlStatus = useHtmlStatus(tsPageUrl, parameters, displaySettings);
 
   if (htmlStatus.error) {
     return (

--- a/src/components/TimesSquareNotebookViewer/useHtmlStatus.js
+++ b/src/components/TimesSquareNotebookViewer/useHtmlStatus.js
@@ -9,19 +9,22 @@ import useTimesSquarePage from '../../hooks/useTimesSquarePage';
 
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
-export function parameterizeUrl(baseUrl, parameters) {
+export function parameterizeUrl(baseUrl, parameters, displaySettings) {
   const url = new URL(baseUrl);
   Object.entries(parameters).map((item) =>
+    url.searchParams.set(item[0], item[1])
+  );
+  Object.entries(displaySettings).map((item) =>
     url.searchParams.set(item[0], item[1])
   );
   return url.toString();
 }
 
-function useHtmlStatus(pageUrl, parameters) {
+function useHtmlStatus(pageUrl, parameters, displaySettings) {
   const pageData = useTimesSquarePage(pageUrl);
 
   const { data, error } = useSWR(
-    () => parameterizeUrl(pageData.htmlStatusUrl, parameters),
+    () => parameterizeUrl(pageData.htmlStatusUrl, parameters, displaySettings),
     fetcher,
     {
       // ping every 1 second while browser in focus.

--- a/src/pages/times-square/github/[...tsSlug].js
+++ b/src/pages/times-square/github/[...tsSlug].js
@@ -21,12 +21,16 @@ export default function GitHubNotebookViewPage({}) {
       .map((item) => item)
   );
 
+  const { ts_hide_code = '1' } = userParameters;
+  const displaySettings = { ts_hide_code };
+
   const pageNav = <TimesSquareGitHubNav pagePath={githubSlug} />;
 
   const pagePanel = (
     <TimesSquareGitHubPagePanel
       tsPageUrl={tsPageUrl}
       userParameters={userParameters}
+      displaySettings={displaySettings}
     />
   );
 
@@ -35,6 +39,7 @@ export default function GitHubNotebookViewPage({}) {
       <TimesSquareNotebookViewer
         tsPageUrl={tsPageUrl}
         parameters={userParameters}
+        displaySettings={displaySettings}
       />
     </TimesSquareApp>
   );


### PR DESCRIPTION
Adds a checkbox to toggle the `?ts_hide_code` query parameter to 1 or 0, related to https://github.com/lsst-sqre/times-square/pull/33

Generally adds support for display settings (introduced in https://github.com/lsst-sqre/times-square/pull/33), which are a different category of information that's also present in Times Square URL query strings.