### PR TITLE
DM-38116: Add coManageRegistryUrl setting and menu link

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Change log
 ##########
 
+0.9.0 (2023-03-01)
+==================
+
+- Display an "Account settings" link in the user menu that goes to the COmanage Registry.
+  This registry URL, which is optional, can be configured in ``squareone.config.yaml`` with the ``coManageRegistryUrl`` field.
+
 0.8.1 (2022-08-25)
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squareone",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/squareone.config.schema.json
+++ b/squareone.config.schema.json
@@ -33,6 +33,10 @@
       "type": "string",
       "title": "Times Square API URL",
       "description": "URL prefix of the Times Square API service. Does not end in /. Omit or set as null to disable the /times-square/ pages."
+    },
+    "coManageRegistryUrl": {
+      "type": "string",
+      "title": "COmanage registry URL (e.g. https://id.lsst.cloud). Omit or set as null for non-COmanage deployments."
     }
   }
 }

--- a/squareone.config.yaml
+++ b/squareone.config.yaml
@@ -4,3 +4,4 @@ siteDescription: |
   The site description.
 semaphoreUrl: 'https://data-dev.lsst.cloud/semaphore'
 timesSquareUrl: 'http://localhost:3000/times-square/api'
+coManageRegistryUrl: 'https://id.lsst.cloud'

--- a/src/components/Header/UserMenu.js
+++ b/src/components/Header/UserMenu.js
@@ -2,6 +2,7 @@
 
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import getConfig from 'next/config';
 import { Menu, MenuList, MenuButton, MenuLink } from '@reach/menu-button';
 import '@reach/menu-button/styles.css';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -60,6 +61,8 @@ const StyledMenuList = styled(MenuList)`
 export default function UserMenu({ pageUrl }) {
   const { userInfo } = useUserInfo();
   const logoutUrl = getLogoutUrl(pageUrl);
+  const { publicRuntimeConfig } = getConfig();
+  const { coManageRegistryUrl } = publicRuntimeConfig;
 
   return (
     <Menu>
@@ -67,6 +70,9 @@ export default function UserMenu({ pageUrl }) {
         {userInfo.username} <StyledFontAwesomeIcon icon="angle-down" />
       </StyledMenuButton>
       <StyledMenuList>
+        {coManageRegistryUrl && (
+          <MenuLink href={coManageRegistryUrl}>Account settings</MenuLink>
+        )}
         <MenuLink href="/auth/tokens">Security tokens</MenuLink>
         <MenuLink href={logoutUrl}>Log out</MenuLink>
       </StyledMenuList>


### PR DESCRIPTION
This allows a deployer to optionally add a `coManageRegistryUrl` setting for deployments that use COmanage. If set, an "Account settings" link appears in their user menu.

<img width="324" alt="CleanShot 2023-03-01 at 18 50 18@2x" src="https://user-images.githubusercontent.com/349384/222293361-80c43a08-8655-4f5f-acd5-2946b2b1ecc4.png">
