### PR TITLE
DM-40262: Authenticate to gh package registry in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,14 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
 
+      - name: Authenticate GitHub Packages
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //npm.pkg.github.com/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install Dependencies
         run: pnpm install
 


### PR DESCRIPTION
Since .npmrc exists in the repo, changesets/action won't replace it.
Therefore we aren't logged into the github package registry.