### PR TITLE
DM-40262: Configure changesets to tag private packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,10 @@
     "@changesets/changelog-github",
     { "repo": "lsst-sqre/squareone" }
   ],
+  "privatePackages": {
+    "version": true,
+    "tag": true
+  },
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/docs/packages/rubin-style-dictionary/installation.rst
+++ b/docs/packages/rubin-style-dictionary/installation.rst
@@ -51,22 +51,6 @@ Finally, install the package:
 
    npm install @lsst-sqre/rubin-style-dictionary
 
-Using the token files
-=====================
-
-Once the package is installed, you can access token files in different formats in the :file:`dist` directory of the installed package:
-
-.. code-block:: text
-
-   node_modules/@lsst-sqre/rubin-style-dictionary/dist/
-
-For example, in a Next.js project you can directly import CSS into your app wrapper page:
-
-.. code-block:: js
-
-   import '@lsst-sqre/rubin-style-dictionary/dist/tokens.css';
-   import '@lsst-sqre/rubin-style-dictionary/dist/tokens.dark.css';
-
 Installing on GitHub Actions
 ============================
 


### PR DESCRIPTION
This means that we'll get the needed tag for the Squareone release