### PR TITLE
DM-40262: Tweaks to the release process

### DIFF
--- a/.changeset/strange-doors-relate.md
+++ b/.changeset/strange-doors-relate.md
@@ -1,0 +1,7 @@
+---
+'@lsst-sqre/rubin-style-dictionary': patch
+---
+
+Tweaks to the release process:
+
+- Associate rubin-style-dictionary with the lsst-sqre/squareone monorepo in its package.json metadata.

--- a/.changeset/stupid-guests-pay.md
+++ b/.changeset/stupid-guests-pay.md
@@ -1,0 +1,7 @@
+---
+'squareone': patch
+---
+
+Tweaks to the release process:
+
+- Use a custom GITHUB_TOKEN for the changesets/action in order to trigger the Docker release workflow for Squareone.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ name: CI
       - 'renovate/**'
       - 'tickets/**'
       - 'u/**'
+      - 'changeset-release/**'
   pull_request: {}
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,5 +42,5 @@ jobs:
           publish: pnpm run ci:publish
           version: pnpm run ci:version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/rubin-style-dictionary/package.json
+++ b/packages/rubin-style-dictionary/package.json
@@ -32,5 +32,8 @@
   "bugs": {
     "url": "https://github.com/lsst-sqre/squareone/issues"
   },
-  "homepage": "https://squareone.lsst.io/packages/rubin-style-dictionary/"
+  "homepage": "https://squareone.lsst.io/packages/rubin-style-dictionary/",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
 }

--- a/packages/rubin-style-dictionary/package.json
+++ b/packages/rubin-style-dictionary/package.json
@@ -19,10 +19,7 @@
     "prepublishOnly": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/lsst-sqre/squareone.git"
-  },
+  "repository": "https://github.com/lsst-sqre/squareone",
   "keywords": [
     "rubin-observatory",
     "design-tokens"


### PR DESCRIPTION
- Use a custom GITHUB_TOKEN for the changesets/action in order to trigger the Docker release workflow for Squareone.
- Associate rubin-style-dictionary with the lsst-sqre/squareone monorepo in its package.json metadata.