### PR TITLE
DM-40262: Trigger Docker release on the release [published]

### DIFF
--- a/.changeset/polite-numbers-swim.md
+++ b/.changeset/polite-numbers-swim.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+The squareone Docker image release is now triggered by a GitHub Release being published.

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,11 +1,19 @@
 name: Docker release
 
 'on':
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
+  hello:
+    name: Hello world
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: echo "Hello world!"
+
+      - run: echo "The event that triggered this action was a ${{ github.event_name }} event, ref is ${{ github.ref }}."
+
   release-squareone:
     name: Release Squareone image
     runs-on: ubuntu-latest


### PR DESCRIPTION
The tag push event wasn't triggering the workflow (potentially because
the tag was being created via the API?). Instead we'll try triggering
the Docker releases from the GitHub Release event.