### PR TITLE
DM-43461: Enable background page recomputation in Times Square

### DIFF
--- a/.changeset/brown-dingos-mix.md
+++ b/.changeset/brown-dingos-mix.md
@@ -1,0 +1,7 @@
+---
+'squareone': minor
+---
+
+Implement background recomputation for cached Times Square pages. The "Recompute" button submits a request to Times Square's `DELETE /v1/pages/:page/html?{params}` endpoint, which causes a background recomputation of the notebook and re-rendering of the cached HTML.
+
+The new `TimesSquareHtmlEventsProvider` is a React context provider that provides real-time updates from Times Square about the status of an HTML rendering for a given set of parameters using Times Square's `/v1/pages/:page/html/events/{params}` endpoint. Squareone uses `@microsoft/fetch-event-source` to subscribe to this server-sent events (SSE) endpoint. Using this provider, the UI is able to show new data to the user, including the status of the computation, and once the computation is complete, the date/age of computation and the execution time.

--- a/.changeset/chatty-bikes-unite.md
+++ b/.changeset/chatty-bikes-unite.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+The Times Square "Update" and "Reset" buttons are now disabled when appropriate. The Update button is disabled when the parameter inputs have not been changed relative to their current state. Likewise, the Reset button is disabled when the parameters are unchanged from the current state.

--- a/.changeset/seven-maps-drum.md
+++ b/.changeset/seven-maps-drum.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+New `TimesSquareUrlParametersProvider` component. This React context provides the URL-based state to Times Square components, such as the page being viewed, its notebook parameters values, and the display settings. This change simplifies the structure of the React pages by refactoring all of the URL parsing into a common component. As well, this context eliminates "prop drilling" to provide this URL-based state to all components in the Times Square application.

--- a/apps/squareone/package.json
+++ b/apps/squareone/package.json
@@ -42,6 +42,7 @@
     "@lsst-sqre/global-css": "workspace:*",
     "@lsst-sqre/rubin-style-dictionary": "workspace:*",
     "@lsst-sqre/squared": "workspace:*",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@reach/alert": "^0.17.0",
     "@reach/menu-button": "^0.17.0",
     "ajv": "^8.11.0",

--- a/apps/squareone/package.json
+++ b/apps/squareone/package.json
@@ -46,6 +46,7 @@
     "@reach/alert": "^0.17.0",
     "@reach/menu-button": "^0.17.0",
     "ajv": "^8.11.0",
+    "date-fns": "^3.6.0",
     "formik": "^2.2.9",
     "js-yaml": "^4.1.0",
     "next": "^12.2.4",

--- a/apps/squareone/src/components/Button/Button.js
+++ b/apps/squareone/src/components/Button/Button.js
@@ -16,6 +16,9 @@ const Button = styled.button`
   &:active {
     background-color: var(--sqo-primary-button-background-color-active);
   }
+  &:disabled {
+    cursor: not-allowed;
+  }
 `;
 
 export default Button;

--- a/apps/squareone/src/components/Button/Button.js
+++ b/apps/squareone/src/components/Button/Button.js
@@ -36,4 +36,12 @@ export const GhostButton = styled.button`
 
 export const RedGhostButton = styled(GhostButton)`
   --ghost-button-color: var(--rsd-color-red-500);
+
+  &:disabled {
+    // instead of setting opacity it'd be better to have a lighter red color
+    opacity: 0.5;
+    cursor: not-allowed;
+    background-color: transparent;
+    color: #000;
+  }
 `;

--- a/apps/squareone/src/components/TimesSquareApp/TimesSquareApp.js
+++ b/apps/squareone/src/components/TimesSquareApp/TimesSquareApp.js
@@ -26,9 +26,8 @@ const StyledLayout = styled.div`
 `;
 
 export default function TimesSquareApp({ children }) {
-  const { tsSlug, owner, repo, commit, githubSlug } = React.useContext(
-    TimesSquareUrlParametersContext
-  );
+  const { tsSlug, owner, repo, commit, githubSlug, urlQueryString } =
+    React.useContext(TimesSquareUrlParametersContext);
 
   const pageNav = commit ? (
     <TimesSquarePrGitHubNav owner={owner} repo={repo} commitSha={commit} />

--- a/apps/squareone/src/components/TimesSquareApp/TimesSquareApp.js
+++ b/apps/squareone/src/components/TimesSquareApp/TimesSquareApp.js
@@ -4,9 +4,14 @@
  * page, usually the page viewer, or a markdown view of the GitHub repository.
  */
 
+import React from 'react';
 import styled from 'styled-components';
 
 import Sidebar from './Sidebar';
+import { TimesSquareUrlParametersContext } from '../TimesSquareUrlParametersProvider';
+import TimesSquareMainGitHubNav from '../TimesSquareMainGitHubNav';
+import TimesSquarePrGitHubNav from '../TimesSquarePrGitHubNav';
+import TimesSquareGitHubPagePanel from '../TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel';
 
 const StyledLayout = styled.div`
   display: flex;
@@ -20,10 +25,23 @@ const StyledLayout = styled.div`
   }
 `;
 
-export default function TimesSquareApp({ children, pageNav, pagePanel }) {
+export default function TimesSquareApp({ children }) {
+  const { tsSlug, owner, repo, commit, githubSlug } = React.useContext(
+    TimesSquareUrlParametersContext
+  );
+
+  const pageNav = commit ? (
+    <TimesSquarePrGitHubNav owner={owner} repo={repo} commitSha={commit} />
+  ) : (
+    <TimesSquareMainGitHubNav pagePath={githubSlug} />
+  );
+
   return (
     <StyledLayout>
-      <Sidebar pageNav={pageNav} pagePanel={pagePanel} />
+      <Sidebar
+        pageNav={pageNav}
+        pagePanel={tsSlug ? <TimesSquareGitHubPagePanel /> : null}
+      />
       <main>{children}</main>
     </StyledLayout>
   );

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.js
@@ -1,0 +1,69 @@
+/*
+ * ExecStats provides a summary of the execution status and timing of the
+ * notebook execution. It also provides a button to request the recomputation
+ * of the already-executed notebook.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { parseISO, formatDistanceToNow } from 'date-fns';
+
+import { TimesSquareHtmlEventsContext } from '../TimesSquareHtmlEventsProvider';
+import { GhostButton } from '../Button';
+
+export default function ExecStats({}) {
+  const htmlEvent = React.useContext(TimesSquareHtmlEventsContext);
+
+  const handleRecompute = async (event) => {
+    event.preventDefault();
+
+    await fetch(htmlEvent.htmlUrl, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  };
+
+  if (htmlEvent.executionStatus == 'complete') {
+    const dateFinished = parseISO(htmlEvent.dateFinished);
+    const formattedDuration = Number(htmlEvent.executionDuration).toFixed(1);
+    return (
+      <StyledContainer>
+        <StyledContent>
+          Computed{' '}
+          <time
+            dateTime={htmlEvent.dateFinished}
+            title={htmlEvent.dateFinished}
+          >
+            {formatDistanceToNow(dateFinished, { addSuffix: true })}
+          </time>{' '}
+          in {formattedDuration} seconds.
+        </StyledContent>
+        <GhostButton onClick={handleRecompute}>Recompute</GhostButton>
+      </StyledContainer>
+    );
+  }
+
+  if (htmlEvent.executionStatus == 'in_progress') {
+    return (
+      <StyledContainer>
+        <p>Computing…</p>
+      </StyledContainer>
+    );
+  }
+
+  return null;
+}
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 2rem;
+`;
+
+const StyledContent = styled.p`
+  font-size: 0.8rem;
+  margin-bottom: 0;
+`;

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.stories.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.stories.js
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { TimesSquareHtmlEventsContext } from '../TimesSquareHtmlEventsProvider';
+import ExecStats from './ExecStats';
+
+export default {
+  component: ExecStats,
+  title: 'Components/TimesSquare/ExecStats',
+  parameters: {
+    viewport: {
+      viewports: {
+        sidebar: {
+          name: 'Sidebar',
+          styles: {
+            width: '280px',
+            height: '900px',
+          },
+        },
+      },
+    },
+    defaultViewport: 'sidebar',
+  },
+};
+
+const Template = (args) => (
+  <TimesSquareHtmlEventsContext.Provider value={args}>
+    <ExecStats />
+  </TimesSquareHtmlEventsContext.Provider>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  dateSubmitted: '2021-09-01T12:00:00Z',
+  dateStarted: '2021-09-01T12:00:01Z',
+  dateFinished: '2021-09-01T12:00:10Z',
+  executionStatus: 'complete',
+  executionDuration: 10.12,
+};
+
+export const InProgressNew = Template.bind({});
+InProgressNew.args = {
+  dateSubmitted: '2021-09-01T12:00:10Z',
+  dateStarted: null,
+  dateFinished: null,
+  executionStatus: 'in_progress',
+  executionDuration: null,
+};
+
+export const InProgressExisting = Template.bind({});
+InProgressExisting.args = {
+  dateSubmitted: '2021-09-01T12:00:00Z',
+  dateStarted: '2021-09-01T12:00:01Z',
+  dateFinished: '2021-09-01T12:00:10Z',
+  executionStatus: 'in_progress',
+  executionDuration: 10.12,
+};

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
@@ -4,9 +4,6 @@
  * the notebook content (NotebookIframe).
  */
 
-'use client';
-
-import React from 'react';
 import styled from 'styled-components';
 import getConfig from 'next/config';
 import Head from 'next/head';
@@ -17,7 +14,6 @@ import TimesSquareParameters from '../TimesSquareParameters';
 
 export default function TimesSquareGitHubPagePanel({}) {
   const { publicRuntimeConfig } = getConfig();
-
   const pageData = useTimesSquarePage();
 
   if (pageData.loading) {

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
@@ -4,6 +4,9 @@
  * the notebook content (NotebookIframe).
  */
 
+'use client';
+
+import React from 'react';
 import styled from 'styled-components';
 import getConfig from 'next/config';
 import Head from 'next/head';
@@ -12,13 +15,10 @@ import Error from 'next/error';
 import useTimesSquarePage from '../../hooks/useTimesSquarePage';
 import TimesSquareParameters from '../TimesSquareParameters';
 
-export default function TimesSquareGitHubPagePanel({
-  tsPageUrl,
-  userParameters,
-  displaySettings,
-}) {
+export default function TimesSquareGitHubPagePanel({}) {
   const { publicRuntimeConfig } = getConfig();
-  const pageData = useTimesSquarePage(tsPageUrl);
+
+  const pageData = useTimesSquarePage();
 
   if (pageData.loading) {
     return <p>Loading...</p>;
@@ -39,11 +39,7 @@ export default function TimesSquareGitHubPagePanel({
         {description && (
           <div dangerouslySetInnerHTML={{ __html: description.html }}></div>
         )}
-        <TimesSquareParameters
-          pageData={pageData}
-          userParameters={userParameters}
-          displaySettings={displaySettings}
-        />
+        <TimesSquareParameters />
       </div>
     </PagePanelContainer>
   );

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
@@ -12,13 +12,11 @@ import Error from 'next/error';
 
 import useTimesSquarePage from '../../hooks/useTimesSquarePage';
 import TimesSquareParameters from '../TimesSquareParameters';
-import { TimesSquareHtmlEventsContext } from '../TimesSquareHtmlEventsProvider';
+import ExecStats from './ExecStats';
 
 export default function TimesSquareGitHubPagePanel({}) {
   const { publicRuntimeConfig } = getConfig();
   const pageData = useTimesSquarePage();
-
-  const htmlEvent = React.useContext(TimesSquareHtmlEventsContext);
 
   if (pageData.loading) {
     return <p>Loading...</p>;
@@ -40,15 +38,8 @@ export default function TimesSquareGitHubPagePanel({}) {
           <div dangerouslySetInnerHTML={{ __html: description.html }}></div>
         )}
         <TimesSquareParameters />
-        {htmlEvent.executionStatus != 'complete' && (
-          <p>{htmlEvent.executionStatus}</p>
-        )}
-        {htmlEvent.executionStatus == 'complete' && (
-          <>
-            <p>Computed {htmlEvent.dateFinished}</p>
-            <p>Executed in {htmlEvent.executionDuration} seconds</p>
-          </>
-        )}
+
+        <ExecStats />
       </div>
     </PagePanelContainer>
   );

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
@@ -4,6 +4,7 @@
  * the notebook content (NotebookIframe).
  */
 
+import React from 'react';
 import styled from 'styled-components';
 import getConfig from 'next/config';
 import Head from 'next/head';
@@ -11,10 +12,13 @@ import Error from 'next/error';
 
 import useTimesSquarePage from '../../hooks/useTimesSquarePage';
 import TimesSquareParameters from '../TimesSquareParameters';
+import { TimesSquareHtmlEventsContext } from '../TimesSquareHtmlEventsProvider';
 
 export default function TimesSquareGitHubPagePanel({}) {
   const { publicRuntimeConfig } = getConfig();
   const pageData = useTimesSquarePage();
+
+  const htmlEvent = React.useContext(TimesSquareHtmlEventsContext);
 
   if (pageData.loading) {
     return <p>Loading...</p>;
@@ -36,6 +40,15 @@ export default function TimesSquareGitHubPagePanel({}) {
           <div dangerouslySetInnerHTML={{ __html: description.html }}></div>
         )}
         <TimesSquareParameters />
+        {htmlEvent.executionStatus != 'complete' && (
+          <p>{htmlEvent.executionStatus}</p>
+        )}
+        {htmlEvent.executionStatus == 'complete' && (
+          <>
+            <p>Computed {htmlEvent.dateFinished}</p>
+            <p>Executed in {htmlEvent.executionDuration} seconds</p>
+          </>
+        )}
       </div>
     </PagePanelContainer>
   );

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.js
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.js
@@ -1,0 +1,89 @@
+/*
+ * Context provider for the Times Square /pages/:page/html/events endpoint.
+ */
+
+import React from 'react';
+import { fetchEventSource } from '@microsoft/fetch-event-source';
+
+import useTimesSquarePage from '../../hooks/useTimesSquarePage';
+import { TimesSquareUrlParametersContext } from '../TimesSquareUrlParametersProvider';
+
+export const TimesSquareHtmlEventsContext = React.createContext();
+
+export default function TimesSquareHtmlEventsProvider({ children }) {
+  const [htmlEvent, setHtmlEvent] = React.useState(null);
+
+  const urlParameters = React.useContext(TimesSquareUrlParametersContext);
+  const timesSquarePage = useTimesSquarePage();
+
+  const urlQueryString = urlParameters.urlQueryString;
+  const htmlEventsUrl = timesSquarePage.htmlEventsUrl;
+  const fullHtmlEventsUrl = htmlEventsUrl
+    ? `${htmlEventsUrl}?${urlQueryString}`
+    : null;
+
+  React.useEffect(() => {
+    const abortController = new AbortController();
+
+    async function runEffect() {
+      if (htmlEventsUrl) {
+        console.log(`Running fetchEventSource ${fullHtmlEventsUrl}`);
+        await fetchEventSource(fullHtmlEventsUrl, {
+          method: 'GET',
+          signal: abortController.signal,
+          onopen(res) {
+            if (res.ok && res.status === 200) {
+              console.log(`Connection made to ${fullHtmlEventsUrl}`, res);
+            } else if (
+              res.status >= 400 &&
+              res.status < 500 &&
+              res.status !== 429
+            ) {
+              console.log(`Client side error ${fullHtmlEventsUrl}`, res);
+            }
+          },
+          onmessage(event) {
+            // console.log(event.data);
+            const parsedData = JSON.parse(event.data);
+            setHtmlEvent(parsedData);
+          },
+          onclose() {
+            console.log(
+              `Connection closed by the server to ${fullHtmlEventsUrl}`
+            );
+          },
+          onerror(err) {
+            console.log(
+              `There was an error from server for ${fullHtmlEventsUrl}`,
+              err
+            );
+          },
+        });
+      }
+    }
+    runEffect();
+
+    return () => {
+      // Clean up: close the event source connection
+      console.log(`❌ CLOSING CONNECTION TO ${fullHtmlEventsUrl}`);
+      abortController.abort();
+      console.log(`Aborted connection to ${fullHtmlEventsUrl}`);
+    };
+  }, [fullHtmlEventsUrl, htmlEventsUrl]);
+
+  const contextValue = {
+    dateSubmitted: htmlEvent ? htmlEvent.date_submitted : null,
+    dateStarted: htmlEvent ? htmlEvent.date_started : null,
+    dateFinished: htmlEvent ? htmlEvent.date_finished : null,
+    executionStatus: htmlEvent ? htmlEvent.execution_status : null,
+    executionDuration: htmlEvent ? htmlEvent.execution_duration : null,
+    htmlHash: htmlEvent ? htmlEvent.html_hash : null,
+    htmlUrl: htmlEvent ? htmlEvent.html_url : null,
+  };
+
+  return (
+    <TimesSquareHtmlEventsContext.Provider value={{ ...contextValue }}>
+      {children}
+    </TimesSquareHtmlEventsContext.Provider>
+  );
+}

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.js
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.js
@@ -27,37 +27,20 @@ export default function TimesSquareHtmlEventsProvider({ children }) {
 
     async function runEffect() {
       if (htmlEventsUrl) {
-        console.log(`Running fetchEventSource ${fullHtmlEventsUrl}`);
         await fetchEventSource(fullHtmlEventsUrl, {
           method: 'GET',
           signal: abortController.signal,
           onopen(res) {
-            if (res.ok && res.status === 200) {
-              console.log(`Connection made to ${fullHtmlEventsUrl}`, res);
-            } else if (
-              res.status >= 400 &&
-              res.status < 500 &&
-              res.status !== 429
-            ) {
+            if (res.status >= 400 && res.status < 500 && res.status !== 429) {
               console.log(`Client side error ${fullHtmlEventsUrl}`, res);
             }
           },
           onmessage(event) {
-            // console.log(event.data);
             const parsedData = JSON.parse(event.data);
             setHtmlEvent(parsedData);
           },
-          onclose() {
-            console.log(
-              `Connection closed by the server to ${fullHtmlEventsUrl}`
-            );
-          },
-          onerror(err) {
-            console.log(
-              `There was an error from server for ${fullHtmlEventsUrl}`,
-              err
-            );
-          },
+          onclose() {},
+          onerror(err) {},
         });
       }
     }
@@ -65,9 +48,7 @@ export default function TimesSquareHtmlEventsProvider({ children }) {
 
     return () => {
       // Clean up: close the event source connection
-      console.log(`❌ CLOSING CONNECTION TO ${fullHtmlEventsUrl}`);
       abortController.abort();
-      console.log(`Aborted connection to ${fullHtmlEventsUrl}`);
     };
   }, [fullHtmlEventsUrl, htmlEventsUrl]);
 

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/index.js
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/index.js
@@ -1,0 +1,2 @@
+export * from './TimesSquareHtmlEventsProvider';
+export { default } from './TimesSquareHtmlEventsProvider';

--- a/apps/squareone/src/components/TimesSquareNotebookViewer/TimesSquareNotebookViewer.js
+++ b/apps/squareone/src/components/TimesSquareNotebookViewer/TimesSquareNotebookViewer.js
@@ -3,9 +3,11 @@
  * from Times Square with a notebook render.
  */
 
+import React from 'react';
 import styled from 'styled-components';
 
 import useHtmlStatus from './useHtmlStatus';
+import { TimesSquareUrlParametersContext } from '../TimesSquareUrlParametersProvider';
 
 const StyledIframe = styled.iframe`
   /* --shadow-color: 0deg 0% 74%;
@@ -19,12 +21,9 @@ const StyledIframe = styled.iframe`
   height: 100%;
 `;
 
-export default function TimesSquareNotebookViewer({
-  tsPageUrl,
-  parameters,
-  displaySettings,
-}) {
-  const htmlStatus = useHtmlStatus(tsPageUrl, parameters, displaySettings);
+export default function TimesSquareNotebookViewer({}) {
+  const { tsPageUrl } = React.useContext(TimesSquareUrlParametersContext);
+  const htmlStatus = useHtmlStatus();
 
   if (htmlStatus.error) {
     return (

--- a/apps/squareone/src/components/TimesSquareNotebookViewer/useHtmlStatus.js
+++ b/apps/squareone/src/components/TimesSquareNotebookViewer/useHtmlStatus.js
@@ -4,8 +4,10 @@
  * dynamic refreshing of data about a page's HTML rendering.
  */
 
+import React from 'react';
 import useSWR from 'swr';
 import useTimesSquarePage from '../../hooks/useTimesSquarePage';
+import { TimesSquareUrlParametersContext } from '../TimesSquareUrlParametersProvider';
 
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
@@ -20,8 +22,11 @@ export function parameterizeUrl(baseUrl, parameters, displaySettings) {
   return url.toString();
 }
 
-function useHtmlStatus(pageUrl, parameters, displaySettings) {
-  const pageData = useTimesSquarePage(pageUrl);
+function useHtmlStatus() {
+  const { notebookParameters: parameters, displaySettings } = React.useContext(
+    TimesSquareUrlParametersContext
+  );
+  const pageData = useTimesSquarePage();
 
   const { data, error } = useSWR(
     () => parameterizeUrl(pageData.htmlStatusUrl, parameters, displaySettings),

--- a/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
+++ b/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
@@ -142,7 +142,7 @@ export default function TimesSquareParameters({}) {
             </li>
           </StyledParameterList>
           <ButtonGroup>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting || !dirty}>
               Update
             </Button>
             <ResetButton

--- a/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
+++ b/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
@@ -117,6 +117,7 @@ export default function TimesSquareParameters({}) {
         handleSubmit,
         handleReset,
         isSubmitting,
+        dirty,
       }) => (
         <form onSubmit={handleSubmit} onReset={handleReset}>
           <StyledParameterList>
@@ -147,7 +148,7 @@ export default function TimesSquareParameters({}) {
             <ResetButton
               type="reset"
               onClick={handleReset}
-              disabled={isSubmitting}
+              disabled={isSubmitting || !dirty}
             >
               Reset
             </ResetButton>

--- a/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
+++ b/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
@@ -104,6 +104,7 @@ export default function TimesSquareParameters({}) {
 
   return (
     <Formik
+      enableReinitialize
       initialValues={initialValues}
       onSubmit={handleFormSubmit}
       validate={validate}

--- a/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
+++ b/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { Formik, Field } from 'formik';
@@ -6,6 +7,9 @@ import Ajv from 'ajv';
 import Button, { RedGhostButton } from '../Button';
 import StringInput from './StringInput';
 import ParameterInput from './ParameterInput';
+
+import { TimesSquareUrlParametersContext } from '../TimesSquareUrlParametersProvider';
+import useTimesSquarePage from '../../hooks/useTimesSquarePage';
 
 // Create input components based on the parameter's JSON schema
 function inputFactory(props) {
@@ -28,13 +32,13 @@ function inputFactory(props) {
   );
 }
 
-export default function TimesSquareParameters({
-  pageData,
-  userParameters,
-  displaySettings,
-}) {
+export default function TimesSquareParameters({}) {
   const router = useRouter();
-  const { parameters } = pageData;
+
+  const { displaySettings, notebookParameters: userParameters } =
+    React.useContext(TimesSquareUrlParametersContext);
+  const { parameters } = useTimesSquarePage();
+
   const ajv = new Ajv({ coerceTypes: true });
 
   // Merge userParameters with defaults

--- a/apps/squareone/src/components/TimesSquareUrlParametersProvider/TimesSquareUrlParametersProvider.js
+++ b/apps/squareone/src/components/TimesSquareUrlParametersProvider/TimesSquareUrlParametersProvider.js
@@ -1,0 +1,68 @@
+/*
+ * Context provider for the current page's notebook and display parameters
+ * that come from the URL path and query parameters.
+ */
+
+import React from 'react';
+import getConfig from 'next/config';
+import { useRouter } from 'next/router';
+
+export const TimesSquareUrlParametersContext = React.createContext();
+
+export default function TimesSquareUrlParametersProvider({ children }) {
+  const { publicRuntimeConfig } = getConfig();
+  const { timesSquareUrl } = publicRuntimeConfig;
+  const router = useRouter();
+
+  // Get components out of the URL path. Only /github-pr/ pages have owner,
+  // repo, and commit components in the path. In /github/ pages the owner
+  // and repo are part of tsSlug.
+  const { tsSlug, owner = null, repo = null, commit = null } = router.query;
+
+  // Since the page's path is a [...tsSlug], we need to join the parts of the
+  // path to get the full slug. This combines the owner, repo, directory, and
+  // notebook name for regular /github/ pages, or just the directory and
+  // notebook name for /github-pr/ pages.
+  const githubSlug = tsSlug ? tsSlug.join('/') : null;
+
+  // Construct the URL for the Times Square API endpoint that gives information
+  // about the page. GitHub PR pages (github-pr) have different API URLs than
+  // regular GitHub pages.
+  const tsPageUrl = router.pathname.startsWith('/times-square/github-pr')
+    ? `${timesSquareUrl}/v1/github-pr/${owner}/${repo}/${commit}/${githubSlug}`
+    : `${timesSquareUrl}/v1/github/${githubSlug}`;
+
+  // Get the user query parameters from the URL. In next 13 we can use the
+  // useSearchParams hook (https://nextjs.org/docs/app/api-reference/functions/use-search-params)
+  // to get these directly, but for now we have to filter them out of the
+  // router.query object. Even if path components leak in, we can still filter
+  // them out in the UI for setting parameters because we only show parameters
+  // matching the parameter schema.
+  const userParameters = Object.fromEntries(
+    Object.entries(router.query)
+      .filter((item) => item[0] != 'tsSlug')
+      .map((item) => item)
+  );
+
+  // pop display settings from the user parameters and to also separate out
+  // the notebook parameters.
+  const { ts_hide_code = '1', ...notebookParameters } = userParameters;
+  const displaySettings = { ts_hide_code };
+
+  return (
+    <TimesSquareUrlParametersContext.Provider
+      value={{
+        tsPageUrl,
+        displaySettings,
+        notebookParameters,
+        owner,
+        repo,
+        commit,
+        tsSlug,
+        githubSlug,
+      }}
+    >
+      {children}
+    </TimesSquareUrlParametersContext.Provider>
+  );
+}

--- a/apps/squareone/src/components/TimesSquareUrlParametersProvider/TimesSquareUrlParametersProvider.js
+++ b/apps/squareone/src/components/TimesSquareUrlParametersProvider/TimesSquareUrlParametersProvider.js
@@ -44,6 +44,8 @@ export default function TimesSquareUrlParametersProvider({ children }) {
       .map((item) => item)
   );
 
+  const queryString = new URLSearchParams(userParameters).toString();
+
   // pop display settings from the user parameters and to also separate out
   // the notebook parameters.
   const { ts_hide_code = '1', ...notebookParameters } = userParameters;
@@ -60,6 +62,7 @@ export default function TimesSquareUrlParametersProvider({ children }) {
         commit,
         tsSlug,
         githubSlug,
+        urlQueryString: queryString,
       }}
     >
       {children}

--- a/apps/squareone/src/components/TimesSquareUrlParametersProvider/index.js
+++ b/apps/squareone/src/components/TimesSquareUrlParametersProvider/index.js
@@ -1,0 +1,2 @@
+export * from './TimesSquareUrlParametersProvider';
+export { default } from './TimesSquareUrlParametersProvider';

--- a/apps/squareone/src/hooks/useTimesSquarePage.js
+++ b/apps/squareone/src/hooks/useTimesSquarePage.js
@@ -1,9 +1,13 @@
+import React from 'react';
 import useSWR from 'swr';
+
+import { TimesSquareUrlParametersContext } from '../components/TimesSquareUrlParametersProvider';
 
 const fetcher = (...args) => fetch(...args).then((res) => res.json());
 
-function useTimesSquarePage(pageUrl) {
-  const { data, error } = useSWR(pageUrl, fetcher);
+function useTimesSquarePage() {
+  const { tsPageUrl } = React.useContext(TimesSquareUrlParametersContext);
+  const { data, error } = useSWR(tsPageUrl, fetcher);
 
   return {
     error: error,

--- a/apps/squareone/src/hooks/useTimesSquarePage.js
+++ b/apps/squareone/src/hooks/useTimesSquarePage.js
@@ -17,6 +17,7 @@ function useTimesSquarePage() {
     description: data ? data.description : null,
     htmlUrl: data ? data.html_url : null,
     htmlStatusUrl: data ? data.html_status_url : null,
+    htmlEventsUrl: data ? data.html_events_url : null,
   };
 }
 

--- a/apps/squareone/src/pages/times-square/github-pr/[owner]/[repo]/[commit]/[...tsSlug].js
+++ b/apps/squareone/src/pages/times-square/github-pr/[owner]/[repo]/[commit]/[...tsSlug].js
@@ -4,13 +4,16 @@ import TimesSquareApp from '../../../../../../components/TimesSquareApp';
 import WideContentLayout from '../../../../../../components/WideContentLayout';
 import TimesSquareNotebookViewer from '../../../../../../components/TimesSquareNotebookViewer';
 import TimesSquareUrlParametersProvider from '../../../../../../components/TimesSquareUrlParametersProvider';
+import TimesSquareHtmlEventsProvider from '../../../../../../components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider';
 
 export default function GitHubPrNotebookViewPage({}) {
   return (
     <TimesSquareUrlParametersProvider>
-      <TimesSquareApp>
-        <TimesSquareNotebookViewer />
-      </TimesSquareApp>
+      <TimesSquareHtmlEventsProvider>
+        <TimesSquareApp>
+          <TimesSquareNotebookViewer />
+        </TimesSquareApp>
+      </TimesSquareHtmlEventsProvider>
     </TimesSquareUrlParametersProvider>
   );
 }

--- a/apps/squareone/src/pages/times-square/github-pr/[owner]/[repo]/[commit]/[...tsSlug].js
+++ b/apps/squareone/src/pages/times-square/github-pr/[owner]/[repo]/[commit]/[...tsSlug].js
@@ -1,54 +1,17 @@
 import getConfig from 'next/config';
-import { useRouter } from 'next/router';
 
 import TimesSquareApp from '../../../../../../components/TimesSquareApp';
 import WideContentLayout from '../../../../../../components/WideContentLayout';
-import TimesSquarePrGitHubNav from '../../../../../../components/TimesSquarePrGitHubNav';
 import TimesSquareNotebookViewer from '../../../../../../components/TimesSquareNotebookViewer';
-import TimesSquareGitHubPagePanel from '../../../../../../components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel';
-
-export function TimesSquareGitHubPrNav({ pagePath }) {
-  return <div>Nav component</div>;
-}
+import TimesSquareUrlParametersProvider from '../../../../../../components/TimesSquareUrlParametersProvider';
 
 export default function GitHubPrNotebookViewPage({}) {
-  const { publicRuntimeConfig } = getConfig();
-  const { timesSquareUrl } = publicRuntimeConfig;
-  const router = useRouter();
-  const { owner, repo, commit, tsSlug } = router.query;
-  const tsPageUrl = `${timesSquareUrl}/v1/github-pr/${owner}/${repo}/${commit}/${tsSlug.join(
-    '/'
-  )}`;
-
-  const userParameters = Object.fromEntries(
-    Object.entries(router.query)
-      .filter((item) => item[0] != 'tsSlug')
-      .map((item) => item)
-  );
-
-  const { ts_hide_code = '1' } = userParameters;
-  const displaySettings = { ts_hide_code };
-
-  const pageNav = (
-    <TimesSquarePrGitHubNav owner={owner} repo={repo} commitSha={commit} />
-  );
-
-  const pagePanel = (
-    <TimesSquareGitHubPagePanel
-      tsPageUrl={tsPageUrl}
-      userParameters={userParameters}
-      displaySettings={displaySettings}
-    />
-  );
-
   return (
-    <TimesSquareApp pageNav={pageNav} pagePanel={pagePanel}>
-      <TimesSquareNotebookViewer
-        tsPageUrl={tsPageUrl}
-        parameters={userParameters}
-        displaySettings={displaySettings}
-      />
-    </TimesSquareApp>
+    <TimesSquareUrlParametersProvider>
+      <TimesSquareApp>
+        <TimesSquareNotebookViewer />
+      </TimesSquareApp>
+    </TimesSquareUrlParametersProvider>
   );
 }
 

--- a/apps/squareone/src/pages/times-square/github/[...tsSlug].js
+++ b/apps/squareone/src/pages/times-square/github/[...tsSlug].js
@@ -1,47 +1,17 @@
 import getConfig from 'next/config';
-import { useRouter } from 'next/router';
 
 import TimesSquareApp from '../../../components/TimesSquareApp';
 import WideContentLayout from '../../../components/WideContentLayout';
-import TimesSquareMainGitHubNav from '../../../components/TimesSquareMainGitHubNav';
 import TimesSquareNotebookViewer from '../../../components/TimesSquareNotebookViewer';
-import TimesSquareGitHubPagePanel from '../../../components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel';
+import TimesSquareUrlParametersProvider from '../../../components/TimesSquareUrlParametersProvider';
 
 export default function GitHubNotebookViewPage({}) {
-  const { publicRuntimeConfig } = getConfig();
-  const { timesSquareUrl } = publicRuntimeConfig;
-  const router = useRouter();
-  const { tsSlug } = router.query;
-  const githubSlug = tsSlug.join('/');
-  const tsPageUrl = `${timesSquareUrl}/v1/github/${githubSlug}`;
-
-  const userParameters = Object.fromEntries(
-    Object.entries(router.query)
-      .filter((item) => item[0] != 'tsSlug')
-      .map((item) => item)
-  );
-
-  const { ts_hide_code = '1' } = userParameters;
-  const displaySettings = { ts_hide_code };
-
-  const pageNav = <TimesSquareMainGitHubNav pagePath={githubSlug} />;
-
-  const pagePanel = (
-    <TimesSquareGitHubPagePanel
-      tsPageUrl={tsPageUrl}
-      userParameters={userParameters}
-      displaySettings={displaySettings}
-    />
-  );
-
   return (
-    <TimesSquareApp pageNav={pageNav} pagePanel={pagePanel}>
-      <TimesSquareNotebookViewer
-        tsPageUrl={tsPageUrl}
-        parameters={userParameters}
-        displaySettings={displaySettings}
-      />
-    </TimesSquareApp>
+    <TimesSquareUrlParametersProvider>
+      <TimesSquareApp>
+        <TimesSquareNotebookViewer />
+      </TimesSquareApp>
+    </TimesSquareUrlParametersProvider>
   );
 }
 
@@ -50,7 +20,7 @@ GitHubNotebookViewPage.getLayout = function getLayout(page) {
 };
 
 export async function getServerSideProps() {
-  const { serverRuntimeConfig, publicRuntimeConfig } = getConfig();
+  const { publicRuntimeConfig } = getConfig();
 
   // Make the page return a 404 if Times Square is not configured
   const notFound = publicRuntimeConfig.timesSquareUrl ? false : true;

--- a/apps/squareone/src/pages/times-square/github/[...tsSlug].js
+++ b/apps/squareone/src/pages/times-square/github/[...tsSlug].js
@@ -4,13 +4,16 @@ import TimesSquareApp from '../../../components/TimesSquareApp';
 import WideContentLayout from '../../../components/WideContentLayout';
 import TimesSquareNotebookViewer from '../../../components/TimesSquareNotebookViewer';
 import TimesSquareUrlParametersProvider from '../../../components/TimesSquareUrlParametersProvider';
+import TimesSquareHtmlEventsProvider from '../../../components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider';
 
 export default function GitHubNotebookViewPage({}) {
   return (
     <TimesSquareUrlParametersProvider>
-      <TimesSquareApp>
-        <TimesSquareNotebookViewer />
-      </TimesSquareApp>
+      <TimesSquareHtmlEventsProvider>
+        <TimesSquareApp>
+          <TimesSquareNotebookViewer />
+        </TimesSquareApp>
+      </TimesSquareHtmlEventsProvider>
     </TimesSquareUrlParametersProvider>
   );
 }

--- a/apps/squareone/src/pages/times-square/index.js
+++ b/apps/squareone/src/pages/times-square/index.js
@@ -2,108 +2,110 @@ import Head from 'next/head';
 import getConfig from 'next/config';
 import PropTypes from 'prop-types';
 
-import TimesSquareMainGitHubNav from '../../components/TimesSquareMainGitHubNav';
 import TimesSquareApp from '../../components/TimesSquareApp';
 import WideContentLayout from '../../components/WideContentLayout';
+import TimesSquareUrlParametersProvider from '../../components/TimesSquareUrlParametersProvider';
 
 export default function TimesSquareHome({ publicRuntimeConfig }) {
-  const pageNav = <TimesSquareMainGitHubNav />;
-
   return (
-    <TimesSquareApp pageNav={pageNav}>
-      <Head>
-        <title>Times Square | {publicRuntimeConfig.siteName}</title>
-      </Head>
-      <h1>Easily share Jupyter Notebooks on the Rubin Science Platform</h1>
-      <p>
-        Times Square lets you view computed Jupyter Notebooks in your browser,
-        without spinning up a JupyterLab server. To share a notebook, simply
-        copy a URL.
-      </p>
-      <p>
-        All Times Square pages are computed on the Rubin Science Platform. Any
-        software (like the LSST Science Pipelines) or data source (such as the
-        Butler and EFD) available in interactive JupyterLab sessions are
-        available to Times Square notebooks.
-      </p>
-      <p>
-        Times Square is great for sharing engineering and observatory reports,
-        dashboards, and analyses.
-      </p>
+    <TimesSquareUrlParametersProvider>
+      <TimesSquareApp>
+        <Head>
+          <title>Times Square | {publicRuntimeConfig.siteName}</title>
+        </Head>
+        <h1>Easily share Jupyter Notebooks on the Rubin Science Platform</h1>
+        <p>
+          Times Square lets you view computed Jupyter Notebooks in your browser,
+          without spinning up a JupyterLab server. To share a notebook, simply
+          copy a URL.
+        </p>
+        <p>
+          All Times Square pages are computed on the Rubin Science Platform. Any
+          software (like the LSST Science Pipelines) or data source (such as the
+          Butler and EFD) available in interactive JupyterLab sessions are
+          available to Times Square notebooks.
+        </p>
+        <p>
+          Times Square is great for sharing engineering and observatory reports,
+          dashboards, and analyses.
+        </p>
 
-      <h2>Edit on GitHub...</h2>
-      <p>
-        You can collaboratively maintain collections of notebooks in GitHub
-        repositories. When you push to the default branch of a repository where
-        the Times Square’s GitHub App is installed, Times Square syncs and
-        computes those notebooks on the Rubin Science Platform. Check out{' '}
-        <a href="https://github.com/lsst-sqre/times-square-demo">
-          lsst-sqre/times-square-demo
-        </a>{' '}
-        for an example.
-      </p>
-      <h2>... or upload a notebook directly (coming soon)</h2>
-      <p>
-        Are you working on a notebook and not ready to commit it to GitHub yet
-        (or ever)? You can directly upload a notebook to your personal
-        collection of <em>fliers</em>. These are still published and you can
-        share links to your fliers. Just keep in mind that any notebook that the
-        team relies on and will use in the long term should get moved over to
-        GitHub for better collaboration and maintainability.
-      </p>
-      <h2>Tweak parameters on the fly</h2>
-      <p>
-        You can use Jinja2 syntax in Markdown and code cells to{' '}
-        <em>parameterize</em> Jupyter Notebooks with user inputs.
-        Parameterizations are great for changing the date in a nightly report,
-        or changing the input dataset for a basic data analysis. You, and other
-        users, can change those parameters and see the notebook recomputed
-        on-the-fly. Notebook parameterizations are shareable: just copy the URL.
-      </p>
-      <h2>In beta</h2>
-      <p>
-        Times Square is currently in beta, meaning that we’re still implementing
-        basic features and writing documentation. There’s also a chance that we
-        might need to reset databases. You can try Times Square out, but don’t
-        rely on it for critical applications just yet.
-      </p>
-      <p>
-        Reach out to us on Slack at{' '}
-        <a href="https://lsstc.slack.com/archives/C2JP8GGVC">#dm-square</a> if
-        you have questions.
-      </p>
-      <h2>Behind the scenes</h2>
-      <p>The Times Square app is built largely from three components:</p>
-      <ul>
-        <li>
-          <a href="https://github.com/lsst-sqre/squareone">squareone</a>{' '}
-          contains the user interface
-        </li>
-        <li>
-          <a href="https://github.com/lsst-sqre/times-square">times-square</a>{' '}
-          is the API service that manages notebooks
-        </li>
-        <li>
-          <a href="https://github.com/lsst-sqre/noteburst">noteburst</a> is the
-          API service that runs Jupyter Notebooks on the Rubin Science Platform.
-        </li>
-      </ul>
-      <p>These documents cover Times Square’s architecture:</p>
-      <ul>
-        <li>
-          <a href="https://sqr-062.lsst.io">
-            SQR-062: The Times Square service for publishing parameterized
-            Jupyter Notebooks in the Rubin Science platform
-          </a>
-        </li>
-        <li>
-          <a href="https://sqr-065.lsst.io">
-            SQR-065: Design of Noteburst, a programatic JupyterLab notebook
-            execution service for the Rubin Science Platform
-          </a>
-        </li>
-      </ul>
-    </TimesSquareApp>
+        <h2>Edit on GitHub...</h2>
+        <p>
+          You can collaboratively maintain collections of notebooks in GitHub
+          repositories. When you push to the default branch of a repository
+          where the Times Square’s GitHub App is installed, Times Square syncs
+          and computes those notebooks on the Rubin Science Platform. Check out{' '}
+          <a href="https://github.com/lsst-sqre/times-square-demo">
+            lsst-sqre/times-square-demo
+          </a>{' '}
+          for an example.
+        </p>
+        <h2>... or upload a notebook directly (coming soon)</h2>
+        <p>
+          Are you working on a notebook and not ready to commit it to GitHub yet
+          (or ever)? You can directly upload a notebook to your personal
+          collection of <em>fliers</em>. These are still published and you can
+          share links to your fliers. Just keep in mind that any notebook that
+          the team relies on and will use in the long term should get moved over
+          to GitHub for better collaboration and maintainability.
+        </p>
+        <h2>Tweak parameters on the fly</h2>
+        <p>
+          You can use Jinja2 syntax in Markdown and code cells to{' '}
+          <em>parameterize</em> Jupyter Notebooks with user inputs.
+          Parameterizations are great for changing the date in a nightly report,
+          or changing the input dataset for a basic data analysis. You, and
+          other users, can change those parameters and see the notebook
+          recomputed on-the-fly. Notebook parameterizations are shareable: just
+          copy the URL.
+        </p>
+        <h2>In beta</h2>
+        <p>
+          Times Square is currently in beta, meaning that we’re still
+          implementing basic features and writing documentation. There’s also a
+          chance that we might need to reset databases. You can try Times Square
+          out, but don’t rely on it for critical applications just yet.
+        </p>
+        <p>
+          Reach out to us on Slack at{' '}
+          <a href="https://lsstc.slack.com/archives/C2JP8GGVC">#dm-square</a> if
+          you have questions.
+        </p>
+        <h2>Behind the scenes</h2>
+        <p>The Times Square app is built largely from three components:</p>
+        <ul>
+          <li>
+            <a href="https://github.com/lsst-sqre/squareone">squareone</a>{' '}
+            contains the user interface
+          </li>
+          <li>
+            <a href="https://github.com/lsst-sqre/times-square">times-square</a>{' '}
+            is the API service that manages notebooks
+          </li>
+          <li>
+            <a href="https://github.com/lsst-sqre/noteburst">noteburst</a> is
+            the API service that runs Jupyter Notebooks on the Rubin Science
+            Platform.
+          </li>
+        </ul>
+        <p>These documents cover Times Square’s architecture:</p>
+        <ul>
+          <li>
+            <a href="https://sqr-062.lsst.io">
+              SQR-062: The Times Square service for publishing parameterized
+              Jupyter Notebooks in the Rubin Science platform
+            </a>
+          </li>
+          <li>
+            <a href="https://sqr-065.lsst.io">
+              SQR-065: Design of Noteburst, a programatic JupyterLab notebook
+              execution service for the Rubin Science Platform
+            </a>
+          </li>
+        </ul>
+      </TimesSquareApp>
+    </TimesSquareUrlParametersProvider>
   );
 }
 

--- a/packages/squared/package.json
+++ b/packages/squared/package.json
@@ -45,7 +45,7 @@
     "@storybook/addon-onboarding": "^1.0.8",
     "@storybook/addon-styling": "^1.3.5",
     "@storybook/blocks": "^7.2.1",
-    "@storybook/jest": "^0.2.0",
+    "@storybook/jest": "^0.2.3",
     "@storybook/react": "^7.2.1",
     "@storybook/react-vite": "^7.2.1",
     "@storybook/test-runner": "^0.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@lsst-sqre/squared':
         specifier: workspace:*
         version: link:../../packages/squared
+      '@microsoft/fetch-event-source':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@reach/alert':
         specifier: ^0.17.0
         version: 0.17.0(react-dom@17.0.2)(react@17.0.2)
@@ -4094,6 +4097,10 @@ packages:
       '@types/react': 18.2.19
       react: 17.0.2
 
+  /@microsoft/fetch-event-source@2.0.1:
+    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
+    dev: false
+
   /@mswjs/cookies@0.2.2:
     resolution: {integrity: sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==}
     engines: {node: '>=14'}
@@ -6596,8 +6603,8 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/expect@27.5.2-0:
-    resolution: {integrity: sha512-cP99mhWN/JeCp7VSIiymvj5tmuMY050iFohvp8Zq+kewKsBSZ6/qpTJAGCCZk6pneTcp4S0Fm5BSqyxzbyJ3gw==}
+  /@storybook/expect@28.1.3-5:
+    resolution: {integrity: sha512-lS1oJnY1qTAxnH87C765NdfvGhksA6hBcbUVI5CHiSbNsEtr456wtg/z+dT9XlPriq1D5t2SgfNL9dBAoIGyIA==}
     dependencies:
       '@types/jest': 28.1.3
     dev: true
@@ -6640,7 +6647,7 @@ packages:
   /@storybook/jest@0.2.0:
     resolution: {integrity: sha512-z0S+tMWEfV5rK4drIaPaDcOdnJ02Rs/A8gfLnrZXrlYZiDWC7CvPIhpJDwBYnR6MZ3udn8lOD8V/fbTbSEV7Rg==}
     dependencies:
-      '@storybook/expect': 27.5.2-0
+      '@storybook/expect': 28.1.3-5
       '@testing-library/jest-dom': 5.17.0
       '@types/jest': 28.1.3
       jest-mock: 27.5.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       ajv:
         specifier: ^8.11.0
         version: 8.11.0
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       formik:
         specifier: ^2.2.9
         version: 2.2.9(react@17.0.2)
@@ -9959,6 +9962,10 @@ packages:
   /dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
     dev: true
+
+  /date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,8 @@ importers:
         specifier: ^7.2.1
         version: 7.2.1(@types/react-dom@18.2.7)(@types/react@18.2.19)(react-dom@17.0.2)(react@17.0.2)
       '@storybook/jest':
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.3
+        version: 0.2.3(jest@28.1.3)
       '@storybook/react':
         specifier: ^7.2.1
         version: 7.2.1(react-dom@17.0.2)(react@17.0.2)(typescript@5.1.6)
@@ -331,6 +331,10 @@ packages:
 
   /@adobe/css-tools@4.3.0:
     resolution: {integrity: sha512-+RNNcQvw2V1bmnBTPAtOLfW/9mhH2vC67+rUSi5T8EtEWt6lEnGNY2GuhZ1/YwbgikT1TkhvidCDmN5Q5YCo/w==}
+    dev: true
+
+  /@adobe/css-tools@4.3.3:
+    resolution: {integrity: sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==}
     dev: true
 
   /@ampproject/remapping@2.2.1:
@@ -6644,13 +6648,18 @@ packages:
       '@storybook/preview-api': 7.2.1
     dev: true
 
-  /@storybook/jest@0.2.0:
-    resolution: {integrity: sha512-z0S+tMWEfV5rK4drIaPaDcOdnJ02Rs/A8gfLnrZXrlYZiDWC7CvPIhpJDwBYnR6MZ3udn8lOD8V/fbTbSEV7Rg==}
+  /@storybook/jest@0.2.3(jest@28.1.3):
+    resolution: {integrity: sha512-ov5izrmbAFObzKeh9AOC5MlmFxAcf0o5i6YFGae9sDx6DGh6alXsRM+chIbucVkUwVHVlSzdfbLDEFGY/ShaYw==}
     dependencies:
       '@storybook/expect': 28.1.3-5
-      '@testing-library/jest-dom': 5.17.0
+      '@testing-library/jest-dom': 6.4.2(@types/jest@28.1.3)(jest@28.1.3)
       '@types/jest': 28.1.3
       jest-mock: 27.5.1
+    transitivePeerDependencies:
+      - '@jest/globals'
+      - '@types/bun'
+      - jest
+      - vitest
     dev: true
 
   /@storybook/manager-api@7.1.1(react-dom@17.0.2)(react@17.0.2):
@@ -7370,17 +7379,35 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/jest-dom@5.17.0:
-    resolution: {integrity: sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==}
-    engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
+  /@testing-library/jest-dom@6.4.2(@types/jest@28.1.3)(jest@28.1.3):
+    resolution: {integrity: sha512-CzqH0AFymEMG48CpzXFriYYkOjk6ZGPCLMhW9e9jg3KMCn5OfJecF8GtGW7yGfR/IgCe3SX8BSwjdzI6BBbZLw==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+    peerDependencies:
+      '@jest/globals': '>= 28'
+      '@types/bun': latest
+      '@types/jest': '>= 28'
+      jest: '>= 28'
+      vitest: '>= 0.32'
+    peerDependenciesMeta:
+      '@jest/globals':
+        optional: true
+      '@types/bun':
+        optional: true
+      '@types/jest':
+        optional: true
+      jest:
+        optional: true
+      vitest:
+        optional: true
     dependencies:
-      '@adobe/css-tools': 4.3.0
+      '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.22.6
-      '@types/testing-library__jest-dom': 5.14.9
+      '@types/jest': 28.1.3
       aria-query: 5.3.0
       chalk: 3.0.0
       css.escape: 1.5.1
-      dom-accessibility-api: 0.5.16
+      dom-accessibility-api: 0.6.3
+      jest: 28.1.3(@types/node@20.5.0)
       lodash: 4.17.21
       redent: 3.0.0
     dev: true
@@ -7838,12 +7865,6 @@ packages:
       '@types/hoist-non-react-statics': 3.3.1
       '@types/react': 18.2.19
       csstype: 3.1.2
-    dev: true
-
-  /@types/testing-library__jest-dom@5.14.9:
-    resolution: {integrity: sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==}
-    dependencies:
-      '@types/jest': 28.1.3
     dev: true
 
   /@types/through@0.0.30:
@@ -10231,6 +10252,10 @@ packages:
 
   /dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+    dev: true
+
+  /dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
     dev: true
 
   /dom-converter@0.2.0:
@@ -13293,7 +13318,7 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 20.4.5
+      '@types/node': 20.5.0
     dev: true
 
   /jest-mock@28.1.3:


### PR DESCRIPTION
- [x] Add `TimesSquareParametersProvider`. This context and provider lets us wrap up the concerns around taking URL path and query parameters and breaking those down into the Times Square API URL, notebook parameters, and display settings. This dramatically simplifies the page components and lets us reuse code between the regular and github-pr pages. It also lets us avoid prop drilling to pass this info to the several components that consume this info.
- [x] Add `TimesSquareHtmlEventsProvider`. This context and provider gives access to the Times Square `/v1/pages/:page/html/events?{param}` server-sent events endpoint.
- [x] Add button that sends a `DELETE /v1/pages/:page/html?{param}` request.