### PR TITLE
DM-43859: Include link to notebook on GitHub

### DIFF
--- a/.changeset/calm-items-think.md
+++ b/.changeset/calm-items-think.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+Users can now download the Jupyter Notebook (ipynb) file that they are viewing, with the current parameters filled in. This enables further interactive exploration.

--- a/.changeset/smart-pandas-deny.md
+++ b/.changeset/smart-pandas-deny.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+Times Square notebook pages show a link to the source notebook on GitHub.

--- a/apps/squareone/package.json
+++ b/apps/squareone/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@fontsource/source-sans-pro": "^4.5.11",
     "@fortawesome/fontawesome-svg-core": "^6.3.0",
+    "@fortawesome/free-brands-svg-icons": "^6.5.2",
     "@fortawesome/free-solid-svg-icons": "^6.3.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@lsst-sqre/global-css": "workspace:*",

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/GitHubEditLink.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/GitHubEditLink.js
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export default function GitHubEditLink({ owner, repository, sourcePath }) {
+  if (!owner || !repository || !sourcePath) {
+    return null;
+  }
+
+  const editUrl = `https://github.com/${owner}/${repository}/blob/main/${sourcePath}`;
+
+  return (
+    <p>
+      <a href={editUrl}>
+        <StyledFontAwesomeIcon icon="fa-brands fa-github" />
+        {owner}/{repository}
+      </a>
+    </p>
+  );
+}
+
+const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
+  margin-right: 0.2em;
+  font-size: 1em;
+  color: ${(props) => props.color || 'inherit'};
+`;

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/GitHubEditLink.stories.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/GitHubEditLink.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import GitHubEditLink from './GitHubEditLink';
+
+export default {
+  component: GitHubEditLink,
+  title: 'Components/TimesSquare/GitHubEditLink',
+  parameters: {
+    viewport: {
+      viewports: {
+        sidebar: {
+          name: 'Sidebar',
+          styles: {
+            width: '280px',
+            height: '900px',
+          },
+        },
+      },
+    },
+    defaultViewport: 'sidebar',
+  },
+};
+
+const Template = (args) => <GitHubEditLink {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  owner: 'lsst-sqre',
+  repository: 'times-square-demo',
+  sourcePath: 'demo.ipynb',
+};

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/IpynbDownloadLink.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/IpynbDownloadLink.js
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export default function IpynbDownloadLink({ url, sourcePath }) {
+  // get the filename from the sourcePath
+  const filename = sourcePath.split('/').pop();
+
+  return (
+    <StyledP>
+      <a href={url} title={filename} download={filename}>
+        <StyledFontAwesomeIcon icon="download" /> Download notebook
+      </a>
+    </StyledP>
+  );
+}
+
+const StyledP = styled.p`
+  margin-top: 2rem;
+`;
+
+const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
+  margin-right: 0.2em;
+  font-size: 1em;
+  color: ${(props) => props.color || 'inherit'};
+`;

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
@@ -11,12 +11,15 @@ import Head from 'next/head';
 import Error from 'next/error';
 
 import useTimesSquarePage from '../../hooks/useTimesSquarePage';
+import { TimesSquareUrlParametersContext } from '../TimesSquareUrlParametersProvider';
 import TimesSquareParameters from '../TimesSquareParameters';
 import ExecStats from './ExecStats';
 import GitHubEditLink from './GitHubEditLink';
+import IpynbDownloadLink from './IpynbDownloadLink';
 
 export default function TimesSquareGitHubPagePanel({}) {
   const { publicRuntimeConfig } = getConfig();
+  const { urlQueryString } = React.useContext(TimesSquareUrlParametersContext);
   const pageData = useTimesSquarePage();
 
   if (pageData.loading) {
@@ -27,6 +30,8 @@ export default function TimesSquareGitHubPagePanel({}) {
   }
 
   const { title, description } = pageData;
+
+  const ipynbDownloadUrl = `${pageData.renderedIpynbUrl}?${urlQueryString}`;
 
   return (
     <PagePanelContainer>
@@ -45,6 +50,11 @@ export default function TimesSquareGitHubPagePanel({}) {
         />
 
         <TimesSquareParameters />
+
+        <IpynbDownloadLink
+          url={ipynbDownloadUrl}
+          sourcePath={pageData.github.sourcePath}
+        />
 
         <ExecStats />
       </div>

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanel.js
@@ -13,6 +13,7 @@ import Error from 'next/error';
 import useTimesSquarePage from '../../hooks/useTimesSquarePage';
 import TimesSquareParameters from '../TimesSquareParameters';
 import ExecStats from './ExecStats';
+import GitHubEditLink from './GitHubEditLink';
 
 export default function TimesSquareGitHubPagePanel({}) {
   const { publicRuntimeConfig } = getConfig();
@@ -37,6 +38,12 @@ export default function TimesSquareGitHubPagePanel({}) {
         {description && (
           <div dangerouslySetInnerHTML={{ __html: description.html }}></div>
         )}
+        <GitHubEditLink
+          owner={pageData.github.owner}
+          repository={pageData.github.repository}
+          sourcePath={pageData.github.sourcePath}
+        />
+
         <TimesSquareParameters />
 
         <ExecStats />

--- a/apps/squareone/src/hooks/useTimesSquarePage.js
+++ b/apps/squareone/src/hooks/useTimesSquarePage.js
@@ -9,12 +9,14 @@ function useTimesSquarePage() {
   const { tsPageUrl } = React.useContext(TimesSquareUrlParametersContext);
   const { data, error } = useSWR(tsPageUrl, fetcher);
 
-  const githubInfo = {
-    owner: data.github.owner ? data.github.owner : null,
-    repository: data.github.repository ? data.github.repository : null,
-    sourcePath: data.github.source_path ? data.github.source_path : null,
-    sidecarPath: data.github.sidecar_path ? data.github.sidecar_path : null,
-  };
+  const githubInfo = data
+    ? {
+        owner: data.github.owner ? data.github.owner : null,
+        repository: data.github.repository ? data.github.repository : null,
+        sourcePath: data.github.source_path ? data.github.source_path : null,
+        sidecarPath: data.github.sidecar_path ? data.github.sidecar_path : null,
+      }
+    : { owner: null, repository: null, sourcePath: null, sidecarPath: null };
 
   return {
     error: error,

--- a/apps/squareone/src/hooks/useTimesSquarePage.js
+++ b/apps/squareone/src/hooks/useTimesSquarePage.js
@@ -9,6 +9,13 @@ function useTimesSquarePage() {
   const { tsPageUrl } = React.useContext(TimesSquareUrlParametersContext);
   const { data, error } = useSWR(tsPageUrl, fetcher);
 
+  const githubInfo = {
+    owner: data.github.owner ? data.github.owner : null,
+    repository: data.github.repository ? data.github.repository : null,
+    sourcePath: data.github.source_path ? data.github.source_path : null,
+    sidecarPath: data.github.sidecar_path ? data.github.sidecar_path : null,
+  };
+
   return {
     error: error,
     loading: !error && !data,
@@ -18,6 +25,8 @@ function useTimesSquarePage() {
     htmlUrl: data ? data.html_url : null,
     htmlStatusUrl: data ? data.html_status_url : null,
     htmlEventsUrl: data ? data.html_events_url : null,
+    renderedIpynbUrl: data ? data.rendered_url : null,
+    github: githubInfo,
   };
 }
 

--- a/apps/squareone/src/styles/icons.js
+++ b/apps/squareone/src/styles/icons.js
@@ -14,6 +14,7 @@ import {
   faCircleMinus,
   faCodeCommit,
 } from '@fortawesome/free-solid-svg-icons';
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 // Add icons to the global Font Awesome library
 library.add(faAngleDown);
@@ -24,3 +25,4 @@ library.add(faCircleXmark);
 library.add(faCircleCheck);
 library.add(faCircleMinus);
 library.add(faCodeCommit);
+library.add(faGithub);

--- a/apps/squareone/src/styles/icons.js
+++ b/apps/squareone/src/styles/icons.js
@@ -13,6 +13,7 @@ import {
   faCircleCheck,
   faCircleMinus,
   faCodeCommit,
+  faDownload,
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
@@ -25,4 +26,5 @@ library.add(faCircleXmark);
 library.add(faCircleCheck);
 library.add(faCircleMinus);
 library.add(faCodeCommit);
+library.add(faDownload);
 library.add(faGithub);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@fortawesome/fontawesome-svg-core':
         specifier: ^6.3.0
         version: 6.3.0
+      '@fortawesome/free-brands-svg-icons':
+        specifier: ^6.5.2
+        version: 6.5.2
       '@fortawesome/free-solid-svg-icons':
         specifier: ^6.3.0
         version: 6.3.0
@@ -3605,12 +3608,26 @@ packages:
     requiresBuild: true
     dev: false
 
+  /@fortawesome/fontawesome-common-types@6.5.2:
+    resolution: {integrity: sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dev: false
+
   /@fortawesome/fontawesome-svg-core@6.3.0:
     resolution: {integrity: sha512-uz9YifyKlixV6AcKlOX8WNdtF7l6nakGyLYxYaCa823bEBqyj/U2ssqtctO38itNEwXb8/lMzjdoJ+aaJuOdrw==}
     engines: {node: '>=6'}
     requiresBuild: true
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.3.0
+    dev: false
+
+  /@fortawesome/free-brands-svg-icons@6.5.2:
+    resolution: {integrity: sha512-zi5FNYdmKLnEc0jc0uuHH17kz/hfYTg4Uei0wMGzcoCL/4d3WM3u1VMc0iGGa31HuhV5i7ZK8ZlTCQrHqRHSGQ==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      '@fortawesome/fontawesome-common-types': 6.5.2
     dev: false
 
   /@fortawesome/free-solid-svg-icons@6.3.0:


### PR DESCRIPTION
This component links to the notebook in GitHub. Currently it assumes we're referencing the "main" branch; to fix that we'd have to store the default branch in Times Square to serve from its API.

Also include a link to download the notebook file with parameters filled in so that a user can pick the analysis in their own JupyterLab pod.

![CleanShot 2024-04-12 at 13 55 53@2x](https://github.com/lsst-sqre/squareone/assets/349384/35aacf8b-d595-4b80-a4a3-0ac0b8ef79e3)
