### PR TITLE
DM-44392: Prevent opening/closing GafaelfawrUserMenu on hover.

### DIFF
--- a/.changeset/many-moles-join.md
+++ b/.changeset/many-moles-join.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/squared': minor
+---
+
+Disable opening and closing the GafaelfawrUserMenu on hover. This is a better UX because it allows for less precise mousing when using the menu.

--- a/packages/squared/src/components/GafaelfawrUserMenu/GafaelfawrUserMenu.stories.tsx
+++ b/packages/squared/src/components/GafaelfawrUserMenu/GafaelfawrUserMenu.stories.tsx
@@ -73,7 +73,7 @@ export const Default: Story = {
     <SWRConfig value={{ provider: () => new Map() }}>
       <GafaelfawrUserMenu {...args}>
         <GafaelfawrUserMenu.Link href="#">
-          Account Settings
+          Account settings
         </GafaelfawrUserMenu.Link>
         <GafaelfawrUserMenu.Link href="#">
           Security tokens

--- a/packages/squared/src/components/GafaelfawrUserMenu/Menu.tsx
+++ b/packages/squared/src/components/GafaelfawrUserMenu/Menu.tsx
@@ -21,17 +21,28 @@ export const Menu = ({ children, logoutHref, username }: MenuProps) => {
     <MenuRoot>
       <MenuList>
         <RadixNavigationMenu.Item>
-          <MenuTrigger>
+          <MenuTrigger
+            onPointerMove={(event) => event.preventDefault()}
+            onPointerEnter={(event) => event.preventDefault()}
+            onPointerLeave={(event) => event.preventDefault()}
+          >
             {username} <ChevronDown />
           </MenuTrigger>
-          <MenuContent>
+          <MenuContent
+            onPointerMove={(event) => event.preventDefault()}
+            onPointerEnter={(event) => event.preventDefault()}
+            onPointerLeave={(event) => event.preventDefault()}
+          >
             {children}
             <MenuLink href={logoutHref}>Log out</MenuLink>
           </MenuContent>
         </RadixNavigationMenu.Item>
       </MenuList>
       <ViewportContainer>
-        <ContentViewport />
+        <ContentViewport
+          onPointerEnter={(event) => event.preventDefault()}
+          onPointerLeave={(event) => event.preventDefault()}
+        />
       </ViewportContainer>
     </MenuRoot>
   );


### PR DESCRIPTION
This disables opening the navigation menu on hover, and instead requires the user to click on the trigger to open it. This is generally a better UX because it means that the menu stays open without the user needing to have precise mousing.