### PR TITLE
DM-44392: Change Account settings item back to title case

### DIFF
--- a/.changeset/orange-roses-provide.md
+++ b/.changeset/orange-roses-provide.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+Change "Account settings" menu item to title case.

--- a/apps/squareone/src/components/Header/UserMenu.js
+++ b/apps/squareone/src/components/Header/UserMenu.js
@@ -12,7 +12,7 @@ export default function UserMenu({ pageUrl }) {
     <GafaelfawrUserMenu currentUrl={pageUrl}>
       {coManageRegistryUrl && (
         <GafaelfawrUserMenu.Link href={coManageRegistryUrl}>
-          Account Settings
+          Account settings
         </GafaelfawrUserMenu.Link>
       )}
       <GafaelfawrUserMenu.Link href="/auth/tokens">


### PR DESCRIPTION
This fixes a regression caused when migrating to the new GafaelfawrUserMenu.