### PR TITLE
DM-45786: Add Plausible.io tracking support

### DIFF
--- a/.changeset/eight-crabs-develop.md
+++ b/.changeset/eight-crabs-develop.md
@@ -1,0 +1,7 @@
+---
+'squareone': minor
+---
+
+Add support for Plausible.io analytics
+
+In Squareone, set the `plausibleDomain` configuration to the Plausible tracking domain. E.g. data.lsst.cloud for the RSP. To disable Plausible tracking where it isn't supported, set this configuration to `null`.

--- a/apps/squareone/package.json
+++ b/apps/squareone/package.json
@@ -50,6 +50,7 @@
     "js-yaml": "^4.1.0",
     "next": "^12.2.4",
     "next-mdx-remote": "^4.4.1",
+    "next-plausible": "^3.12.1",
     "next-themes": "^0.2.0",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",

--- a/apps/squareone/squareone.config.schema.json
+++ b/apps/squareone/squareone.config.schema.json
@@ -38,6 +38,11 @@
       "type": "string",
       "title": "COmanage registry URL (e.g. https://id.lsst.cloud). Omit or set as null for non-COmanage deployments."
     },
+    "plausibleDomain": {
+      "type": "string",
+      "title": "Plausible tracking domain",
+      "description": "Domain (e.g. data.lsst.cloud) for Plausible tracking. Omit to disable Plausible."
+    },
     "apiAspectPageMdx": {
       "type": "string",
       "title": "/api-aspect Page MDX content"

--- a/apps/squareone/src/pages/_app.js
+++ b/apps/squareone/src/pages/_app.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import getConfig from 'next/config';
 import { ThemeProvider } from 'next-themes';
+import PlausibleProvider from 'next-plausible';
 
 // Global CSS
 // Keep these imports in sync with .storybook/preview.js (Next can't import
@@ -15,13 +16,19 @@ import '../styles/icons';
 
 import Page from '../components/Page';
 
-function MyApp({ Component, pageProps, baseUrl, semaphoreUrl }) {
+function MyApp({
+  Component,
+  pageProps,
+  baseUrl,
+  semaphoreUrl,
+  plausibleDomain,
+}) {
   // Use the content layout defined by the page component, if avaialble.
   // Otherwise, the page itself is used as the content area layout container.
   const getLayout = Component.getLayout || ((page) => page);
 
   /* eslint-disable react/jsx-props-no-spreading */
-  return (
+  const coreApp = (
     <ThemeProvider defaultTheme="system">
       <Page baseUrl={baseUrl} semaphoreUrl={semaphoreUrl}>
         {getLayout(<Component {...pageProps} />)}
@@ -29,12 +36,18 @@ function MyApp({ Component, pageProps, baseUrl, semaphoreUrl }) {
     </ThemeProvider>
   );
   /* eslint-enable react/jsx-props-no-spreading */
+  if (!plausibleDomain) {
+    return coreApp;
+  }
+  return (
+    <PlausibleProvider domain={plausibleDomain}>{coreApp}</PlausibleProvider>
+  );
 }
 
 MyApp.getInitialProps = async () => {
   const { publicRuntimeConfig } = getConfig();
-  const { baseUrl, semaphoreUrl } = publicRuntimeConfig;
-  return { baseUrl, semaphoreUrl };
+  const { baseUrl, semaphoreUrl, plausibleDomain } = publicRuntimeConfig;
+  return { baseUrl, semaphoreUrl, plausibleDomain };
 };
 
 MyApp.propTypes = {
@@ -42,6 +55,7 @@ MyApp.propTypes = {
   pageProps: PropTypes.object.isRequired,
   baseUrl: PropTypes.string.isRequired,
   semaphoreUrl: PropTypes.string,
+  plausibleDomain: PropTypes.string,
 };
 
 export default MyApp;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       next-mdx-remote:
         specifier: ^4.4.1
         version: 4.4.1(react-dom@17.0.2)(react@17.0.2)
+      next-plausible:
+        specifier: ^3.12.1
+        version: 3.12.1(next@12.2.4)(react-dom@17.0.2)(react@17.0.2)
       next-themes:
         specifier: ^0.2.0
         version: 0.2.0(next@12.2.4)(react-dom@17.0.2)(react@17.0.2)
@@ -15212,6 +15215,18 @@ packages:
       vfile-matter: 3.0.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /next-plausible@3.12.1(next@12.2.4)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-DcQxB/oE8gOLuIU0SBbzN0dYYNibOXgKfnzPkO9SXug6B4Y95eT41JgbN3gjlcsqHWaDWJu/s3928O7ilo2sTg==}
+    peerDependencies:
+      next: ^11.1.0 || ^12.0.0 || ^13.0.0 || ^14.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      next: 12.2.4(@babel/core@7.22.0)(react-dom@17.0.2)(react@17.0.2)
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /next-themes@0.2.0(next@12.2.4)(react-dom@17.0.2)(react@17.0.2):


### PR DESCRIPTION
This enables sending analytics for Squareone usage to [Plausible.io](https://plausible.io).

Setting up Plausible's tracking is done with https://github.com/4lejandrito/next-plausible

Tracking is optional; by not setting the plausibleDomain configuration the tracking is not enabled.