### PR TITLE
DM-48448: Add link to user docs from Times Square UI

### DIFF
--- a/.changeset/early-eagles-vanish.md
+++ b/.changeset/early-eagles-vanish.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/squared': minor
+---
+
+Added a new component, `IconPill`. This component creates an inline pill that acts as a link button. The contents of the pill are an easy-to-configure icon from FontAwesome alongside text. The colours of the pill are configurable by props, but by default the pill looks similar to to the button component.

--- a/.changeset/perfect-garlics-bathe.md
+++ b/.changeset/perfect-garlics-bathe.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+The Times Square interface now includes a link to its user documentation. The root of the environment-specific rsp.lsst.io site is configured through the new `docsBaseUrl` configuration parameter.

--- a/.changeset/sixty-books-sneeze.md
+++ b/.changeset/sixty-books-sneeze.md
@@ -1,0 +1,8 @@
+---
+'@lsst-sqre/global-css': minor
+'squareone': minor
+---
+
+Migrated Squareone CSS custom properties / design tokens to global-css from the globals.css file in the Squareone app
+
+With this change, any app as well as the Squared component library can use CSS custom properties such as the elevations (box-shadows, e.g. `--sqo-elevation-md`) and transitions (`--sqo-transition-basic`) that are included as global CSS custom properties.

--- a/apps/squareone/.storybook/preview.js
+++ b/apps/squareone/.storybook/preview.js
@@ -10,7 +10,6 @@ import '@fontsource/source-sans-pro/700.css';
 // Global CSS
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import '@lsst-sqre/global-css/dist/next.css';
-import '../src/styles/globals.css';
 import '../src/styles/icons';
 
 export const parameters = {

--- a/apps/squareone/squareone.config.schema.json
+++ b/apps/squareone/squareone.config.schema.json
@@ -24,6 +24,12 @@
       "title": "Base URL for the public ingress",
       "description": "Used for computing absolute URLs"
     },
+    "docsBaseUrl": {
+      "type": "string",
+      "default": "https://rsp.lsst.io",
+      "title": "Base URL for the user documentation site.",
+      "description": "Used for computing URLs for user documentation pages for this RSP instance. The default is for the public RSP. For USDF, use `https://rsp.lsst.io/v/usdfprod`. Does not end in /."
+    },
     "semaphoreUrl": {
       "type": "string",
       "title": "Semaphore URL",

--- a/apps/squareone/squareone.config.yaml
+++ b/apps/squareone/squareone.config.yaml
@@ -2,6 +2,7 @@ siteName: 'Squareone Development Site'
 baseUrl: 'http://localhost:3000'
 siteDescription: |
   The site description.
+docsBaseUrl: 'https://rsp.lsst.io'
 semaphoreUrl: 'https://data-dev.lsst.cloud/semaphore'
 timesSquareUrl: 'http://localhost:3000/times-square/api'
 coManageRegistryUrl: 'https://id.lsst.cloud'

--- a/apps/squareone/src/components/TimesSquareApp/Sidebar.js
+++ b/apps/squareone/src/components/TimesSquareApp/Sidebar.js
@@ -5,6 +5,8 @@
 import Link from 'next/link';
 import styled from 'styled-components';
 
+import { getDocsUrl } from '../../lib/utils/docsUrls';
+
 const StyledSidebar = styled.div`
   border-right: 1px solid var(--rsd-color-primary-600);
   padding: 0 var(--size-screen-padding-min) 2rem 0.5rem;
@@ -21,6 +23,8 @@ const AppTitle = styled.p`
 `;
 
 export default function Sidebar({ pageNav, pagePanel }) {
+  const docsUrl = getDocsUrl('/guides/times-square/index.html');
+
   return (
     <StyledSidebar>
       <Link href="/times-square">
@@ -28,6 +32,8 @@ export default function Sidebar({ pageNav, pagePanel }) {
           <AppTitle>Times Square</AppTitle>
         </a>
       </Link>
+
+      <a href={docsUrl}>Documentation</a>
 
       {pagePanel && pagePanel}
 

--- a/apps/squareone/src/components/TimesSquareApp/Sidebar.js
+++ b/apps/squareone/src/components/TimesSquareApp/Sidebar.js
@@ -5,6 +5,8 @@
 import Link from 'next/link';
 import styled from 'styled-components';
 
+import { IconPill } from '@lsst-sqre/squared';
+
 import { getDocsUrl } from '../../lib/utils/docsUrls';
 
 const StyledSidebar = styled.div`
@@ -33,7 +35,13 @@ export default function Sidebar({ pageNav, pagePanel }) {
         </a>
       </Link>
 
-      <a href={docsUrl}>Documentation</a>
+      <IconPill
+        icon={['fas', 'book']}
+        text="Documentation"
+        url={docsUrl}
+        textColor="#ffffff"
+        backgroundColor="var(--rsd-color-primary-600)"
+      />
 
       {pagePanel && pagePanel}
 

--- a/apps/squareone/src/lib/utils/docsUrls.js
+++ b/apps/squareone/src/lib/utils/docsUrls.js
@@ -1,0 +1,11 @@
+import getConfig from 'next/config';
+
+/**
+ * Get the full URL to a documentation page.
+ * @param path The path to the documentation page, starting with "/"
+ * @returns The full URL to the documentation page
+ */
+export function getDocsUrl(path) {
+  const { publicRuntimeConfig } = getConfig();
+  return `${publicRuntimeConfig.docsBaseUrl}${path}`;
+}

--- a/apps/squareone/src/pages/_app.js
+++ b/apps/squareone/src/pages/_app.js
@@ -11,7 +11,6 @@ import '@fontsource/source-sans-pro/400-italic.css';
 import '@fontsource/source-sans-pro/700.css';
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import '@lsst-sqre/global-css/dist/next.css';
-import '../styles/globals.css';
 import '../styles/icons';
 
 import Page from '../components/Page';

--- a/apps/squareone/src/styles/icons.js
+++ b/apps/squareone/src/styles/icons.js
@@ -14,6 +14,7 @@ import {
   faCircleMinus,
   faCodeCommit,
   faDownload,
+  faBook,
 } from '@fortawesome/free-solid-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
@@ -27,4 +28,5 @@ library.add(faCircleCheck);
 library.add(faCircleMinus);
 library.add(faCodeCommit);
 library.add(faDownload);
+library.add(faBook);
 library.add(faGithub);

--- a/packages/global-css/src/next.css
+++ b/packages/global-css/src/next.css
@@ -1,19 +1,15 @@
 /*
-Base stylesheet for Squareone Next.js apps. This is intended to be imported
-from _app.js.
+ * Base stylesheet for Squareone Next.js apps. This is intended to be imported
+ * from _app.js.
 */
+@import './reset.css';
+
 /*
-@import './reset.css';
-@import '@lsst-sqre/rubin-style-dictionary/dist/tokens.css';
-@import '@lsst-sqre/rubin-style-dictionary/dist/tokens.dark.css';
-@import './base.css';
-*/
-
-@import './reset.css';
-
-/* Lightning CSS doesn't resolve imports to node_modules, so we have to
-   import the tokens.css file from the node_modules directory. */
+ * Lightning CSS doesn't resolve imports to node_modules, so we have to
+ * import the tokens.css file from the node_modules directory.
+ */
 @import '../node_modules/@lsst-sqre/rubin-style-dictionary/dist/tokens.css';
 @import '../node_modules/@lsst-sqre/rubin-style-dictionary/dist/tokens.dark.css';
 
+@import './tokens.css';
 @import './base.css';

--- a/packages/global-css/src/tokens.css
+++ b/packages/global-css/src/tokens.css
@@ -1,3 +1,9 @@
+/*
+ * Custom properties that implement design tokens.
+ *
+ * These tokens build upon base properties from the `@lsst-sqre/rubin-style-dictionary`.
+ */
+
 :root {
   --rsd-component-image-invert: 0;
   --size-screen-padding-min: 1rem;

--- a/packages/squared/package.json
+++ b/packages/squared/package.json
@@ -26,6 +26,9 @@
   },
   "dependencies": {
     "@fontsource/source-sans-pro": "^4.5.11",
+    "@fortawesome/fontawesome-svg-core": "^6.3.0",
+    "@fortawesome/free-solid-svg-icons": "^6.3.0",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "@lsst-sqre/global-css": "workspace:*",
     "@lsst-sqre/rubin-style-dictionary": "workspace:*",
     "@radix-ui/react-dropdown-menu": "^2.0.5",

--- a/packages/squared/src/components/IconPill/IconPill.stories.tsx
+++ b/packages/squared/src/components/IconPill/IconPill.stories.tsx
@@ -26,10 +26,18 @@ export const Default: Story = {
     text: 'Documentation',
     url: '#',
     textColor: '#ffffff',
-    backgroundColor: '#000000',
+    backgroundColor: 'var(--sqo-primary-button-background-color)',
+    hoverBackgroundColor: 'var(--sqo-primary-button-background-color-hover)',
   },
 
-  render: ({ icon, text, url, textColor, backgroundColor }) => {
+  render: ({
+    icon,
+    text,
+    url,
+    textColor,
+    backgroundColor,
+    hoverBackgroundColor,
+  }) => {
     return (
       <IconPill
         icon={icon}
@@ -37,6 +45,7 @@ export const Default: Story = {
         url={url}
         textColor={textColor}
         backgroundColor={backgroundColor}
+        hoverBackgroundColor={hoverBackgroundColor}
       />
     );
   },

--- a/packages/squared/src/components/IconPill/IconPill.stories.tsx
+++ b/packages/squared/src/components/IconPill/IconPill.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconPill } from './IconPill';
+
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faBook } from '@fortawesome/free-solid-svg-icons';
+
+// Add icons to the global Font Awesome library
+library.add(faBook);
+
+const meta: Meta<typeof IconPill> = {
+  title: 'Components/IconPill',
+  component: IconPill,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof IconPill>;
+
+export const Default: Story = {
+  args: {
+    icon: ['fas', 'book'],
+    text: 'Documentation',
+    url: '#',
+    textColor: '#ffffff',
+    backgroundColor: '#000000',
+  },
+
+  render: ({ icon, text, url, textColor, backgroundColor }) => {
+    return (
+      <IconPill
+        icon={icon}
+        text={text}
+        url={url}
+        textColor={textColor}
+        backgroundColor={backgroundColor}
+      />
+    );
+  },
+};

--- a/packages/squared/src/components/IconPill/IconPill.tsx
+++ b/packages/squared/src/components/IconPill/IconPill.tsx
@@ -8,20 +8,25 @@ export interface IconPillProps {
   url: string;
   icon: [IconPrefix, IconName];
   backgroundColor?: string;
+  hoverBackgroundColor?: string;
   textColor?: string;
 }
 
 const PillContainer = styled.span<{
   backgroundColor: string;
+  hoverBackgroundColor: string;
   textColor: string;
 }>`
   display: inline-block;
-  padding: 2px 10px;
-  border-radius: 0.5em;
+  padding: var(--sqo-space-xxxs) var(--sqo-space-unit);
+  border: 1px solid transparent;
+  border-radius: var(--sqo-border-radius-2);
   color: ${(props) => props.textColor};
   background-color: ${(props) => props.backgroundColor};
   font-size: 0.9rem;
   font-weight: 700;
+  transition: var(--sqo-transition-basic);
+  box-shadow: var(--sqo-elevation-sm);
 
   a {
     text-decoration: none;
@@ -29,7 +34,8 @@ const PillContainer = styled.span<{
   }
 
   &:hover {
-    box-shadow: 0 10px 15px -10px rgba(22, 23, 24, 0.35);
+    background-color: ${(props) => props.hoverBackgroundColor};
+    box-shadow: var(--sqo-elevation-lg);
   }
 `;
 
@@ -39,15 +45,33 @@ const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
   font-size: 0.9em;
 `;
 
+/**
+ * A pill-shaped button component that combines an icon and text with a link.
+ *
+ * @component
+ * @param {Object} props - The component props
+ * @param {IconDefinition} props.icon - The FontAwesome icon to display
+ * @param {string} props.text - The text to display next to the icon
+ * @param {string} props.url - The URL that the pill links to
+ * @param {string} [props.backgroundColor='var(--sqo-primary-button-background-color)'] - The background color of the pill
+ * @param {string} [props.hoverBackgroundColor='var(--sqo-primary-button-background-color-hover)'] - The background color of the pill on hover
+ * @param {string} [props.textColor='#ffffff'] - The color of the text and icon
+ * @returns {JSX.Element} A pill-shaped button containing an icon and text that links to a URL
+ */
 export const IconPill: React.FC<IconPillProps> = ({
   icon,
   text,
   url,
-  backgroundColor = '#e0e0e0',
-  textColor = '#000000',
+  backgroundColor = 'var(--sqo-primary-button-background-color)',
+  hoverBackgroundColor = 'var(--sqo-primary-button-background-color-hover)',
+  textColor = '#ffffff',
 }) => {
   return (
-    <PillContainer backgroundColor={backgroundColor} textColor={textColor}>
+    <PillContainer
+      textColor={textColor}
+      backgroundColor={backgroundColor}
+      hoverBackgroundColor={hoverBackgroundColor}
+    >
       <a href={url}>
         <StyledFontAwesomeIcon icon={icon} />
         {text}

--- a/packages/squared/src/components/IconPill/IconPill.tsx
+++ b/packages/squared/src/components/IconPill/IconPill.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconPrefix, IconName } from '@fortawesome/fontawesome-svg-core';
+
+export interface IconPillProps {
+  text: string;
+  url: string;
+  icon: [IconPrefix, IconName];
+  backgroundColor?: string;
+  textColor?: string;
+}
+
+const PillContainer = styled.span<{
+  backgroundColor: string;
+  textColor: string;
+}>`
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 0.5em;
+  color: ${(props) => props.textColor};
+  background-color: ${(props) => props.backgroundColor};
+  font-size: 0.9rem;
+  font-weight: 700;
+
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  &:hover {
+    box-shadow: 0 10px 15px -10px rgba(22, 23, 24, 0.35);
+  }
+`;
+
+const StyledFontAwesomeIcon = styled(FontAwesomeIcon)`
+  display: inline-block;
+  margin-right: 0.4em;
+  font-size: 0.9em;
+`;
+
+export const IconPill: React.FC<IconPillProps> = ({
+  icon,
+  text,
+  url,
+  backgroundColor = '#e0e0e0',
+  textColor = '#000000',
+}) => {
+  return (
+    <PillContainer backgroundColor={backgroundColor} textColor={textColor}>
+      <a href={url}>
+        <StyledFontAwesomeIcon icon={icon} />
+        {text}
+      </a>
+    </PillContainer>
+  );
+};
+
+export default IconPill;

--- a/packages/squared/src/components/IconPill/index.ts
+++ b/packages/squared/src/components/IconPill/index.ts
@@ -1,0 +1,2 @@
+export * from './IconPill';
+export { default } from './IconPill';

--- a/packages/squared/src/index.ts
+++ b/packages/squared/src/index.ts
@@ -8,6 +8,7 @@ export {
   default as GafaelfawrUserMenu,
   type GafaelfawrUserMenuProps,
 } from './components/GafaelfawrUserMenu';
+export { default as IconPill, type IconPillProps } from './components/IconPill';
 
 /* Hooks */
 export { default as useCurrentUrl } from './hooks/useCurrentUrl';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,15 @@ importers:
       '@fontsource/source-sans-pro':
         specifier: ^4.5.11
         version: 4.5.11
+      '@fortawesome/fontawesome-svg-core':
+        specifier: ^6.3.0
+        version: 6.3.0
+      '@fortawesome/free-solid-svg-icons':
+        specifier: ^6.3.0
+        version: 6.3.0
+      '@fortawesome/react-fontawesome':
+        specifier: ^0.2.2
+        version: 0.2.2(@fortawesome/fontawesome-svg-core@6.3.0)(react@17.0.2)
       '@lsst-sqre/global-css':
         specifier: workspace:*
         version: link:../global-css
@@ -3640,6 +3649,17 @@ packages:
 
   /@fortawesome/react-fontawesome@0.2.0(@fortawesome/fontawesome-svg-core@6.3.0)(react@17.0.2):
     resolution: {integrity: sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==}
+    peerDependencies:
+      '@fortawesome/fontawesome-svg-core': ~1 || ~6
+      react: '>=16.3'
+    dependencies:
+      '@fortawesome/fontawesome-svg-core': 6.3.0
+      prop-types: 15.8.1
+      react: 17.0.2
+    dev: false
+
+  /@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.3.0)(react@17.0.2):
+    resolution: {integrity: sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==}
     peerDependencies:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6
       react: '>=16.3'
@@ -11110,6 +11130,7 @@ packages:
   /eslint@8.47.0:
     resolution: {integrity: sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.47.0)


### PR DESCRIPTION
- The Times Square UI includes a link to its environment-specific user documentation
- The new configuration `docsBaseUrl` sets the root of the rsp.lsst.io docs for that environment (e.g. can be `https://rsp.lsst.io/v/usdfprod` for USDF). We use that configuration to compute the instance-relevant link to the user documentation for Times Square.
- The Squared component library includes  a new reusable component called the IconPill that provides an inline pill-shaped link. The pill's content includes an icon specified from FontAwesome and text content.
- The CSS custom properties formerly from the Squareone app's `globals.css` file are now included in the global-css package. This allows these custom properties to be used by components in the Squared package.