### PR TITLE
DM-48557: Improve efficiency of Times Square's use of the /events SSE endpoint

### DIFF
--- a/.changeset/nice-lizards-mate.md
+++ b/.changeset/nice-lizards-mate.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+The Times Square UI now closes its connection to the `/times-square/pages/:page/html/events?<qs>` SSE endpoint once the page instance's execution status is "complete" and the HTML hash is computed. With this change, the Times Square UI reduces its ongoing load on the API and also reduces network usage. The HTML page will still update to the latest version because the iframe component pings the Times Square `pages/:page/htmlstatus?<qs>` endpoint. We may back this off or convert the page update to an opt-in future in the future to further reduce network and API load from the front-end.

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.js
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.js
@@ -36,7 +36,12 @@ export default function TimesSquareHtmlEventsProvider({ children }) {
             }
           },
           onmessage(event) {
-            const parsedData = JSON.parse(event.data);
+            let parsedData;
+            try {
+              parsedData = JSON.parse(event.data);
+            } catch (error) {
+              return;
+            }
             setHtmlEvent(parsedData);
           },
           onclose() {},

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.js
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.js
@@ -32,7 +32,7 @@ export default function TimesSquareHtmlEventsProvider({ children }) {
           signal: abortController.signal,
           onopen(res) {
             if (res.status >= 400 && res.status < 500 && res.status !== 429) {
-              console.log(`Client side error ${fullHtmlEventsUrl}`, res);
+              console.error(`Client side error ${fullHtmlEventsUrl}`, res);
             }
           },
           onmessage(event) {
@@ -43,9 +43,21 @@ export default function TimesSquareHtmlEventsProvider({ children }) {
               return;
             }
             setHtmlEvent(parsedData);
+
+            if (
+              parsedData.execution_status == 'complete' &&
+              parsedData.html_hash
+            ) {
+              abortController.abort();
+            }
           },
           onclose() {},
-          onerror(err) {},
+          onerror(err) {
+            console.error(
+              `Error fetching Times Square events SSE ${fullHtmlEventsUrl}`,
+              err
+            );
+          },
         });
       }
     }


### PR DESCRIPTION
The Times Square UI now closes its connection to the `/times-square/pages/:page/html/events?<qs>` SSE endpoint once the page instance's execution status is "complete" and the HTML hash is computed. With this change, the Times Square UI reduces its ongoing load on the API and also reduces network usage. The HTML page will still update to the latest version because the iframe component pings the Times Square `pages/:page/htmlstatus?<qs>` endpoint. We may back this off or convert the page update to an opt-in future in the future to further reduce network and API load from the front-end.