### PR TITLE
DM-48923: Provide Times Square support for date and date-time parameters

### DIFF
--- a/.changeset/seven-buckets-brake.md
+++ b/.changeset/seven-buckets-brake.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+Times Square now supports date and date-time parameter types.

--- a/apps/squareone/package.json
+++ b/apps/squareone/package.json
@@ -46,6 +46,7 @@
     "@microsoft/fetch-event-source": "^2.0.1",
     "@sentry/nextjs": "^8",
     "ajv": "^8.11.0",
+    "ajv-formats": "^3.0.1",
     "date-fns": "^3.6.0",
     "formik": "^2.2.9",
     "js-yaml": "^4.1.0",

--- a/apps/squareone/src/components/TimesSquareParameters/ParameterInput.js
+++ b/apps/squareone/src/components/TimesSquareParameters/ParameterInput.js
@@ -7,14 +7,15 @@ export default function ParameterInput({
   touched,
   errors,
 }) {
+  const errorMessage = computeErrorMessage(errors, paramSchema);
   return (
     <>
       <label htmlFor={`${paramName}`}>
         <ParameterName>{paramName}</ParameterName>
         {children}
-        {errors && (
+        {errorMessage && (
           <ErrorMessage id={`tsparam-${paramName}-error`} type="polite">
-            {errors}
+            {errorMessage}
           </ErrorMessage>
         )}
         <Description id={`tsparam-${paramName}-description`}>
@@ -23,6 +24,21 @@ export default function ParameterInput({
       </label>
     </>
   );
+}
+
+function computeErrorMessage(errors, paramSchema) {
+  if (errors) {
+    if (paramSchema.type === 'string' && paramSchema.format === 'date') {
+      return 'Expecting YYYY-MM-DD';
+    } else if (
+      paramSchema.type === 'string' &&
+      paramSchema.format === 'date-time'
+    ) {
+      return 'Expecting YYYY-MM-DDTHH:MM:SS-HH:MM';
+    }
+    return errors;
+  }
+  return null;
 }
 
 const ParameterName = styled.p`

--- a/apps/squareone/src/components/TimesSquareParameters/ParameterInput.js
+++ b/apps/squareone/src/components/TimesSquareParameters/ParameterInput.js
@@ -12,7 +12,7 @@ export default function ParameterInput({
       <label htmlFor={`${paramName}`}>
         <ParameterName>{paramName}</ParameterName>
         {children}
-        {errors && touched && (
+        {errors && (
           <ErrorMessage id={`tsparam-${paramName}-error`} type="polite">
             {errors}
           </ErrorMessage>

--- a/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
+++ b/apps/squareone/src/components/TimesSquareParameters/TimesSquareParameters.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { Formik, Field } from 'formik';
 import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
 
 import Button, { RedGhostButton } from '../Button';
 import StringInput from './StringInput';
@@ -40,6 +41,7 @@ export default function TimesSquareParameters({}) {
   const { parameters } = useTimesSquarePage();
 
   const ajv = new Ajv({ coerceTypes: true });
+  addFormats(ajv);
 
   // Merge userParameters with defaults
   const initialValues = {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       ajv:
         specifier: ^8.11.0
         version: 8.11.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.11.0)
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
@@ -3535,7 +3538,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.21.0
       ignore: 5.2.4
@@ -9081,6 +9084,17 @@ packages:
       ajv: 8.11.0
     dev: true
 
+  /ajv-formats@3.0.1(ajv@8.11.0):
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+    dependencies:
+      ajv: 8.11.0
+    dev: false
+
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -11898,7 +11912,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -20035,7 +20049,7 @@ packages:
       esbuild: 0.18.20
       less: 4.2.0
       postcss: 8.4.27
-      rollup: 3.28.0
+      rollup: 3.29.5
     optionalDependencies:
       fsevents: 2.3.2
     dev: true


### PR DESCRIPTION
Times Square now supports string parameters with date and date-time formats. The error messages remind the user about the ISO 8601 date / datetime formats. A timezone is required for date-time parameters.