### PR TITLE
DM-51547: Reorganize broadcast banners

### DIFF
--- a/.changeset/eleven-cycles-study.md
+++ b/.changeset/eleven-cycles-study.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+Add new "notice" and "outage" broadcast banners. This notice category replaces the earlier default ("maintenance") and is orange. Another new category, "outage", takes the red colour. This change is driven by Semaphore at https://github.com/lsst-sqre/semaphore/pull/109

--- a/.changeset/tiny-ads-send.md
+++ b/.changeset/tiny-ads-send.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/rubin-style-dictionary': patch
+---
+
+Use the project orange accent for color-orange-500 (was accidentally red before).

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,9 +38,7 @@ jobs:
         with:
           fetch-depth: 2 # partial depth for Turbo Repo
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - uses: pnpm/action-setup@v4
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,9 +15,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/run-chromatic.yaml
+++ b/.github/workflows/run-chromatic.yaml
@@ -24,9 +24,7 @@ jobs:
         with:
           fetch-depth: 0 # get full Git history
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - uses: pnpm/action-setup@v4
 
       - name: Set up node
         uses: actions/setup-node@v3

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.js
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.js
@@ -8,10 +8,13 @@ const StyledBroadcastContainer = styled.div`
   width: 100%;
   margin: 0;
   padding: 0.5em;
-  background-color: ${(props) =>
-    props.category === 'info'
-      ? 'var(--rsd-color-primary-600)'
-      : 'var(--rsd-color-red-500)'};
+  background-color: ${(props) => {
+    if (props.category === 'info') return 'var(--rsd-color-primary-600)';
+    if (props.category === 'outage') return 'var(--rsd-color-red-500)';
+    if (props.category === 'notice' || props.category === 'maintenance')
+      return 'var(--rsd-color-orange-500)';
+    return 'var(--rsd-color-gray-500)'; // default fallback
+  }};
   color: white;
 
   aside {
@@ -100,7 +103,7 @@ export default function BroadcastBanner({ broadcast }) {
   /* eslint-disable react/no-danger */
   /* eslint-disable react/jsx-props-no-spreading */
   return (
-    <StyledBroadcastContainer category={broadcast.category || 'maintenance'}>
+    <StyledBroadcastContainer category={broadcast.category || 'notice'}>
       <aside>
         <div className="summary">
           <div

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.stories.jsx
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.stories.jsx
@@ -18,9 +18,27 @@ const broadcastData = {
   active: true,
   enabled: true,
   stale: false,
-  category: 'maintenance',
+  category: 'other',
 };
 
 export const Default = {
   render: () => <BroadcastBanner broadcast={broadcastData} />,
+};
+
+export const Info = {
+  render: () => (
+    <BroadcastBanner broadcast={{ ...broadcastData, category: 'info' }} />
+  ),
+};
+
+export const Outage = {
+  render: () => (
+    <BroadcastBanner broadcast={{ ...broadcastData, category: 'outage' }} />
+  ),
+};
+
+export const Notice = {
+  render: () => (
+    <BroadcastBanner broadcast={{ ...broadcastData, category: 'notice' }} />
+  ),
 };

--- a/packages/rubin-style-dictionary/src/color/orange.yaml
+++ b/packages/rubin-style-dictionary/src/color/orange.yaml
@@ -1,4 +1,4 @@
 color:
   orange:
     '500':
-      value: '#ED4C4C'
+      value: '#E08D35'


### PR DESCRIPTION
This notice category replaces the earlier default ("maintenance") and is orange. Another new category, "outage", takes the red colour. This change is driven by Semaphore at https://github.com/lsst-sqre/semaphore/pull/109