### PR TITLE
Update TypeScript target to ES2022

### DIFF
--- a/.changeset/update-typescript-target-es2022.md
+++ b/.changeset/update-typescript-target-es2022.md
@@ -1,0 +1,5 @@
+---
+"@lsst-sqre/tsconfig": minor
+---
+
+Update TypeScript target to ES2022 for modern JavaScript features and Node 22 compatibility

--- a/packages/tsconfig/next.json
+++ b/packages/tsconfig/next.json
@@ -9,10 +9,10 @@
     "declarationMap": false,
     "incremental": true,
     "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "ES2022"],
     "module": "esnext",
     "noEmit": true,
     "resolveJsonModule": true,
-    "target": "es2017"
+    "target": "ES2022"
   }
 }

--- a/packages/tsconfig/react-library.json
+++ b/packages/tsconfig/react-library.json
@@ -4,9 +4,9 @@
   "extends": "./base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "lib": ["ES2015", "DOM"],
+    "lib": ["ES2022", "DOM"],
     "module": "ESNext",
-    "target": "es6",
+    "target": "ES2022",
     "plugins": [{ "name": "typescript-plugin-css-modules" }]
   }
 }


### PR DESCRIPTION
Updates shared TypeScript configurations to use ES2022 target and
library support for better compatibility with Node 22, React 19, and
Next.js 15. This enables modern JavaScript features like top-level
await, private fields, and logical assignment operators.

Changes:
- packages/tsconfig/next.json: target es2017 → ES2022
- packages/tsconfig/react-library.json: target es6 → ES2022
- Update lib arrays to include ES2022 features

Includes changeset for minor version bump of @lsst-sqre/tsconfig.