### PR TITLE
DM-52792: Add a Badge component

### DIFF
--- a/.changeset/color-ramps-for-badge.md
+++ b/.changeset/color-ramps-for-badge.md
@@ -1,0 +1,27 @@
+---
+'@lsst-sqre/rubin-style-dictionary': minor
+---
+
+Add complete color ramps (100-800) for semantic colors
+
+Implements full color ramps for all semantic colors to support the Badge component and future UI components:
+
+- **Blue**: Complete 100-800 ramp with HSL-based color calculations
+- **Green**: Complete 100-800 ramp with HSL-based color calculations
+- **Orange**: Complete 100-800 ramp with HSL-based color calculations
+- **Purple**: Complete 100-800 ramp with HSL-based color calculations
+- **Red**: Complete 100-800 ramp with HSL-based color calculations
+- **Yellow**: Complete 100-800 ramp with HSL-based color calculations
+
+Each color ramp includes:
+- Shade 100-200: Light tints for soft variant backgrounds
+- Shade 300-500: Medium shades and base colors
+- Shade 600: Dark shade optimized for solid backgrounds and text (WCAG AA compliant)
+- Shade 700-800: Darker shades for depth and contrast
+
+All color combinations have been tested and verified to meet WCAG AA contrast requirements (4.5:1 minimum) for:
+- Solid variant: 600 shade on white background
+- Soft variant: 600 shade text on 200 shade background
+- Outline variant: 600 shade on page background
+
+These tokens are ready for use in Badge component variants and other UI elements requiring semantic color theming.

--- a/packages/rubin-style-dictionary/src/color/blue.yaml
+++ b/packages/rubin-style-dictionary/src/color/blue.yaml
@@ -1,4 +1,26 @@
 color:
   blue:
+    '100':
+      value: '#E5F4F9' # H:195 S:70% L:93%
+      comment: 'Lightest blue tint for soft backgrounds'
+    '200':
+      value: '#B8E3F2' # H:195 S:70% L:85%
+      comment: 'Light blue for soft variant backgrounds'
+    '300':
+      value: '#7BCFE8' # H:195 S:70% L:70%
+      comment: 'Medium light blue'
+    '400':
+      value: '#3FB8DB' # H:195 S:70% L:55%
+      comment: 'Medium blue'
     '500':
-      value: '#1C81A4'
+      value: '#1C81A4' # H:195 S:70% L:38%
+      comment: 'Base blue color (Visual Identity Manual)'
+    '600':
+      value: '#145F7A' # H:195 S:70% L:28%
+      comment: 'Dark blue for solid backgrounds and text'
+    '700':
+      value: '#0D4157' # H:195 S:70% L:20%
+      comment: 'Darker blue'
+    '800':
+      value: '#072633' # H:195 S:70% L:12%
+      comment: 'Darkest blue'

--- a/packages/rubin-style-dictionary/src/color/green.yaml
+++ b/packages/rubin-style-dictionary/src/color/green.yaml
@@ -1,4 +1,26 @@
 color:
   green:
+    '100':
+      value: '#E9F7E9' # H:121 S:48% L:93%
+      comment: 'Lightest green tint for soft backgrounds'
+    '200':
+      value: '#C6E8C7' # H:121 S:48% L:85%
+      comment: 'Light green for soft variant backgrounds'
+    '300':
+      value: '#96D498' # H:121 S:48% L:70%
+      comment: 'Medium light green'
+    '400':
+      value: '#66C069' # H:121 S:48% L:58%
+      comment: 'Medium green'
     '500':
-      value: '#3cae3F'
+      value: '#3CAE3F' # H:121 S:48% L:46%
+      comment: 'Base green color (Visual Identity Manual)'
+    '600':
+      value: '#237028' # H:121 S:52% L:29%
+      comment: 'Dark green for solid backgrounds and text'
+    '700':
+      value: '#1F5D22' # H:121 S:48% L:24%
+      comment: 'Darker green'
+    '800':
+      value: '#143A15' # H:121 S:48% L:15%
+      comment: 'Darkest green'

--- a/packages/rubin-style-dictionary/src/color/orange.yaml
+++ b/packages/rubin-style-dictionary/src/color/orange.yaml
@@ -1,4 +1,26 @@
 color:
   orange:
+    '100':
+      value: '#FCEEE0' # H:30 S:72% L:93%
+      comment: 'Lightest orange tint for soft backgrounds'
+    '200':
+      value: '#F7D5B2' # H:30 S:72% L:85%
+      comment: 'Light orange for soft variant backgrounds'
+    '300':
+      value: '#F0B976' # H:30 S:72% L:70%
+      comment: 'Medium light orange'
+    '400':
+      value: '#E8A356' # H:30 S:72% L:62%
+      comment: 'Medium orange'
     '500':
-      value: '#E08D35'
+      value: '#E08D35' # H:30 S:72% L:54%
+      comment: 'Base orange color (Visual Identity Manual)'
+    '600':
+      value: '#8F4D0A' # H:30 S:86% L:30%
+      comment: 'Dark orange for solid backgrounds and text'
+    '700':
+      value: '#8B5016' # H:30 S:72% L:31%
+      comment: 'Darker orange'
+    '800':
+      value: '#5E350F' # H:30 S:72% L:21%
+      comment: 'Darkest orange'

--- a/packages/rubin-style-dictionary/src/color/purple.yaml
+++ b/packages/rubin-style-dictionary/src/color/purple.yaml
@@ -1,4 +1,26 @@
 color:
   purple:
+    '100':
+      value: '#EFE9F4' # H:278 S:35% L:93%
+      comment: 'Lightest purple tint for soft backgrounds'
+    '200':
+      value: '#D7C7E3' # H:278 S:35% L:85%
+      comment: 'Light purple for soft variant backgrounds'
+    '300':
+      value: '#B49CC8' # H:278 S:35% L:70%
+      comment: 'Medium light purple'
+    '400':
+      value: '#8E69A5' # H:278 S:35% L:53%
+      comment: 'Medium purple'
     '500':
-      value: '#583671'
+      value: '#583671' # H:278 S:35% L:33%
+      comment: 'Base purple color (Visual Identity Manual)'
+    '600':
+      value: '#412756' # H:278 S:35% L:24%
+      comment: 'Dark purple for solid backgrounds and text'
+    '700':
+      value: '#2E1B3D' # H:278 S:35% L:17%
+      comment: 'Darker purple'
+    '800':
+      value: '#1D1126' # H:278 S:35% L:11%
+      comment: 'Darkest purple'

--- a/packages/rubin-style-dictionary/src/color/red.yaml
+++ b/packages/rubin-style-dictionary/src/color/red.yaml
@@ -1,4 +1,26 @@
 color:
   red:
+    '100':
+      value: '#FEE9E9' # H:0 S:82% L:95%
+      comment: 'Lightest red tint for soft backgrounds'
+    '200':
+      value: '#FCC7C7' # H:0 S:82% L:88%
+      comment: 'Light red for soft variant backgrounds'
+    '300':
+      value: '#F99393' # H:0 S:82% L:78%
+      comment: 'Medium light red'
+    '400':
+      value: '#F57070' # H:0 S:82% L:70%
+      comment: 'Medium red'
     '500':
-      value: '#ED4C4C'
+      value: '#ED4C4C' # H:0 S:82% L:62%
+      comment: 'Base red color (Visual Identity Manual)'
+    '600':
+      value: '#AD1919' # H:0 S:82% L:39%
+      comment: 'Dark red for solid backgrounds and text'
+    '700':
+      value: '#9D1B1B' # H:0 S:82% L:36%
+      comment: 'Darker red'
+    '800':
+      value: '#6B1212' # H:0 S:82% L:24%
+      comment: 'Darkest red'

--- a/packages/rubin-style-dictionary/src/color/yellow.yaml
+++ b/packages/rubin-style-dictionary/src/color/yellow.yaml
@@ -1,4 +1,26 @@
 color:
   yellow:
+    '100':
+      value: '#FFFAEB' # H:48 S:100% L:96%
+      comment: 'Lightest yellow tint for soft backgrounds'
+    '200':
+      value: '#FFF2C7' # H:48 S:100% L:90%
+      comment: 'Light yellow for soft variant backgrounds'
+    '300':
+      value: '#FFE999' # H:48 S:100% L:80%
+      comment: 'Medium light yellow'
+    '400':
+      value: '#FFE266' # H:48 S:100% L:70%
+      comment: 'Medium yellow. Yellow from the Visual Identity Manual.'
     '500':
-      value: '#FFE266'
+      value: '#FFDB33' # H:48 S:100% L:60%
+      comment: 'Base yellow color'
+    '600':
+      value: '#806600' # H:48 S:100% L:25%
+      comment: 'Dark yellow for solid backgrounds and text'
+    '700':
+      value: '#B39600' # H:48 S:100% L:35%
+      comment: 'Darker yellow'
+    '800':
+      value: '#806D00' # H:48 S:100% L:25%
+      comment: 'Darkest yellow'

--- a/packages/squared/src/components/Badge/Badge.module.css
+++ b/packages/squared/src/components/Badge/Badge.module.css
@@ -1,0 +1,201 @@
+/* Base badge styles */
+.badge {
+  /* Display */
+  display: inline-flex;
+  align-items: center;
+  vertical-align: baseline;
+
+  /* Typography */
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+
+  /* Spacing */
+  padding: 0.125em 0.5em;
+  gap: 0.25em;
+
+  /* Border */
+  border: 1px solid transparent;
+  border-radius: var(--sqo-border-radius-1);
+
+  /* Transition */
+  transition: var(--sqo-transition-basic);
+}
+
+/* Size variants */
+.sm {
+  font-size: 0.8em;
+}
+
+.md {
+  font-size: 1em;
+}
+
+.lg {
+  font-size: 1.2em;
+}
+
+/* Radius variants */
+.radiusNone {
+  border-radius: 0;
+}
+
+.radius1 {
+  border-radius: var(--sqo-border-radius-1);
+}
+
+.radiusFull {
+  border-radius: 9999px;
+}
+
+/* Solid variant - primary */
+.solid.primary {
+  background-color: var(--rsd-color-primary-600);
+  color: var(--rsd-color-gray-000);
+}
+
+/* Solid variant - blue */
+.solid.blue {
+  background-color: var(--rsd-color-blue-600);
+  color: var(--rsd-color-gray-000);
+}
+
+/* Solid variant - green */
+.solid.green {
+  background-color: var(--rsd-color-green-600);
+  color: var(--rsd-color-gray-000);
+}
+
+/* Solid variant - orange */
+.solid.orange {
+  background-color: var(--rsd-color-orange-600);
+  color: var(--rsd-color-gray-000);
+}
+
+/* Solid variant - purple */
+.solid.purple {
+  background-color: var(--rsd-color-purple-600);
+  color: var(--rsd-color-gray-000);
+}
+
+/* Solid variant - red */
+.solid.red {
+  background-color: var(--rsd-color-red-600);
+  color: var(--rsd-color-gray-000);
+}
+
+/* Solid variant - yellow */
+.solid.yellow {
+  background-color: var(--rsd-color-yellow-600);
+  color: var(--rsd-color-gray-000);
+}
+
+/* Solid variant - gray */
+.solid.gray {
+  background-color: var(--rsd-color-gray-500);
+  color: var(--rsd-color-gray-000);
+}
+
+/* Soft variant - primary */
+.soft.primary {
+  background-color: var(--rsd-color-primary-200);
+  color: var(--rsd-color-primary-600);
+}
+
+/* Soft variant - blue */
+.soft.blue {
+  background-color: var(--rsd-color-blue-200);
+  color: var(--rsd-color-blue-600);
+}
+
+/* Soft variant - green */
+.soft.green {
+  background-color: var(--rsd-color-green-200);
+  color: var(--rsd-color-green-600);
+}
+
+/* Soft variant - orange */
+.soft.orange {
+  background-color: var(--rsd-color-orange-200);
+  color: var(--rsd-color-orange-600);
+}
+
+/* Soft variant - purple */
+.soft.purple {
+  background-color: var(--rsd-color-purple-200);
+  color: var(--rsd-color-purple-600);
+}
+
+/* Soft variant - red */
+.soft.red {
+  background-color: var(--rsd-color-red-200);
+  color: var(--rsd-color-red-600);
+}
+
+/* Soft variant - yellow */
+.soft.yellow {
+  background-color: var(--rsd-color-yellow-200);
+  color: var(--rsd-color-yellow-600);
+}
+
+/* Soft variant - gray */
+.soft.gray {
+  background-color: var(--rsd-color-gray-100);
+  color: var(--rsd-color-gray-800);
+}
+
+/* Outline variant - primary */
+.outline.primary {
+  background-color: var(--rsd-component-page-background-color);
+  border-color: var(--rsd-color-primary-600);
+  color: var(--rsd-color-primary-600);
+}
+
+/* Outline variant - blue */
+.outline.blue {
+  background-color: var(--rsd-component-page-background-color);
+  border-color: var(--rsd-color-blue-600);
+  color: var(--rsd-color-blue-600);
+}
+
+/* Outline variant - green */
+.outline.green {
+  background-color: var(--rsd-component-page-background-color);
+  border-color: var(--rsd-color-green-600);
+  color: var(--rsd-color-green-600);
+}
+
+/* Outline variant - orange */
+.outline.orange {
+  background-color: var(--rsd-component-page-background-color);
+  border-color: var(--rsd-color-orange-600);
+  color: var(--rsd-color-orange-600);
+}
+
+/* Outline variant - purple */
+.outline.purple {
+  background-color: var(--rsd-component-page-background-color);
+  border-color: var(--rsd-color-purple-600);
+  color: var(--rsd-color-purple-600);
+}
+
+/* Outline variant - red */
+.outline.red {
+  background-color: var(--rsd-component-page-background-color);
+  border-color: var(--rsd-color-red-600);
+  color: var(--rsd-color-red-600);
+}
+
+/* Outline variant - yellow */
+.outline.yellow {
+  background-color: var(--rsd-component-page-background-color);
+  border-color: var(--rsd-color-yellow-600);
+  color: var(--rsd-color-yellow-600);
+}
+
+/* Outline variant - gray */
+.outline.gray {
+  background-color: var(--rsd-component-page-background-color);
+  border-color: var(--rsd-color-gray-500);
+  color: var(--rsd-color-gray-800);
+}

--- a/packages/squared/src/components/Badge/Badge.stories.tsx
+++ b/packages/squared/src/components/Badge/Badge.stories.tsx
@@ -1,0 +1,404 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Components/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['solid', 'soft', 'outline'],
+      description: 'Visual style of the badge',
+    },
+    color: {
+      control: 'select',
+      options: [
+        'primary',
+        'blue',
+        'green',
+        'orange',
+        'purple',
+        'red',
+        'yellow',
+        'gray',
+      ],
+      description: 'Semantic color of the badge',
+    },
+    radius: {
+      control: 'select',
+      options: ['none', '1', 'full'],
+      description: 'Corner radius style',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size of the badge',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Default badge (soft variant, primary color)
+export const Default: Story = {
+  args: {
+    children: 'New',
+  },
+};
+
+// Basic variants
+export const Solid: Story = {
+  args: {
+    children: 'Solid',
+    variant: 'solid',
+  },
+};
+
+export const Soft: Story = {
+  args: {
+    children: 'Soft',
+    variant: 'soft',
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    children: 'Outline',
+    variant: 'outline',
+  },
+};
+
+// All variants side by side
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      <Badge variant="solid">Solid</Badge>
+      <Badge variant="soft">Soft</Badge>
+      <Badge variant="outline">Outline</Badge>
+    </div>
+  ),
+};
+
+// All colors in soft variant
+export const Colors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      <Badge color="primary">Primary</Badge>
+      <Badge color="blue">Blue</Badge>
+      <Badge color="green">Green</Badge>
+      <Badge color="orange">Orange</Badge>
+      <Badge color="purple">Purple</Badge>
+      <Badge color="red">Red</Badge>
+      <Badge color="yellow">Yellow</Badge>
+      <Badge color="gray">Gray</Badge>
+    </div>
+  ),
+};
+
+// Complete color × variant matrix
+export const AllCombinations: Story = {
+  render: () => {
+    const colors = [
+      'primary',
+      'blue',
+      'green',
+      'orange',
+      'purple',
+      'red',
+      'yellow',
+      'gray',
+    ] as const;
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+        <div>
+          <h3 style={{ marginBottom: '1rem' }}>Solid Variant</h3>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            {colors.map((color) => (
+              <Badge key={color} variant="solid" color={color}>
+                {color.charAt(0).toUpperCase() + color.slice(1)}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h3 style={{ marginBottom: '1rem' }}>Soft Variant</h3>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            {colors.map((color) => (
+              <Badge key={color} variant="soft" color={color}>
+                {color.charAt(0).toUpperCase() + color.slice(1)}
+              </Badge>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h3 style={{ marginBottom: '1rem' }}>Outline Variant</h3>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            {colors.map((color) => (
+              <Badge key={color} variant="outline" color={color}>
+                {color.charAt(0).toUpperCase() + color.slice(1)}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+// Size variations
+export const Sizes: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '1rem',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      <Badge size="sm">Small</Badge>
+      <Badge size="md">Medium</Badge>
+      <Badge size="lg">Large</Badge>
+    </div>
+  ),
+};
+
+// Radius variations
+export const RadiusVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      <Badge radius="none">No Radius</Badge>
+      <Badge radius="1">Regular</Badge>
+      <Badge radius="full">Full Round</Badge>
+    </div>
+  ),
+};
+
+// Inline usage examples
+export const InlineUsage: Story = {
+  render: () => (
+    <div
+      style={{
+        maxWidth: '600px',
+        fontSize: '16px',
+        lineHeight: '1.5',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',
+      }}
+    >
+      <p>
+        The Rubin Observatory data processing pipeline is currently{' '}
+        <Badge color="green">running</Badge> normally without any issues. All
+        systems are operational and data is being processed at the expected
+        rate. The badge component integrates seamlessly within paragraph text
+        without disrupting the natural flow or line height of the content.
+      </p>
+      <p>
+        Your account has <Badge color="orange">3 pending</Badge> notifications
+        that require attention. These notifications include system updates,
+        security alerts, and administrative messages. Please review them at your
+        earliest convenience to ensure you stay informed about important changes
+        to your account and services.
+      </p>
+      <p>
+        This feature is marked as <Badge color="red">deprecated</Badge> and will
+        be removed in the next major release. We recommend migrating to the new
+        API endpoint as soon as possible. The deprecated functionality will
+        continue to work until the end of the support period, but new
+        development should use the recommended alternatives.
+      </p>
+      <p>
+        The API is{' '}
+        <Badge variant="outline" color="blue">
+          v2.0
+        </Badge>{' '}
+        and fully supported with comprehensive documentation and examples. This
+        version includes significant improvements over v1.x, including better
+        performance, enhanced security features, and a more intuitive interface
+        for developers building applications on the platform.
+      </p>
+      <p>
+        Notice how the badges with different variants maintain consistent line
+        spacing. Whether using{' '}
+        <Badge variant="solid" color="purple">
+          solid
+        </Badge>
+        ,{' '}
+        <Badge variant="soft" color="primary">
+          soft
+        </Badge>
+        , or{' '}
+        <Badge variant="outline" color="gray">
+          outline
+        </Badge>{' '}
+        variants, the text flow remains natural and readable throughout the
+        entire paragraph.
+      </p>
+    </div>
+  ),
+};
+
+// Status examples
+export const StatusBadges: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      <Badge variant="solid" color="green">
+        Active
+      </Badge>
+      <Badge variant="solid" color="orange">
+        Pending
+      </Badge>
+      <Badge variant="solid" color="red">
+        Error
+      </Badge>
+      <Badge variant="solid" color="gray">
+        Inactive
+      </Badge>
+    </div>
+  ),
+};
+
+// Soft status examples
+export const SoftStatusBadges: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+      <Badge color="green">Success</Badge>
+      <Badge color="orange">Warning</Badge>
+      <Badge color="red">Error</Badge>
+      <Badge color="blue">Info</Badge>
+      <Badge color="purple">New</Badge>
+    </div>
+  ),
+};
+
+// Different sizes with same color
+export const SizeComparison: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1.5rem',
+        alignItems: 'flex-start',
+      }}
+    >
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <Badge size="sm" color="primary">
+          Small
+        </Badge>
+        <Badge size="md" color="primary">
+          Medium
+        </Badge>
+        <Badge size="lg" color="primary">
+          Large
+        </Badge>
+      </div>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <Badge size="sm" variant="solid" color="green">
+          Small
+        </Badge>
+        <Badge size="md" variant="solid" color="green">
+          Medium
+        </Badge>
+        <Badge size="lg" variant="solid" color="green">
+          Large
+        </Badge>
+      </div>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <Badge size="sm" variant="outline" color="red">
+          Small
+        </Badge>
+        <Badge size="md" variant="outline" color="red">
+          Medium
+        </Badge>
+        <Badge size="lg" variant="outline" color="red">
+          Large
+        </Badge>
+      </div>
+    </div>
+  ),
+};
+
+// Mixed usage showcase
+export const MixedShowcase: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+      <div>
+        <h3 style={{ marginBottom: '1rem' }}>Product Features</h3>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <Badge variant="solid" color="purple">
+            New
+          </Badge>
+          <Badge variant="soft" color="blue">
+            Beta
+          </Badge>
+          <Badge variant="outline" color="orange">
+            Preview
+          </Badge>
+          <Badge variant="soft" color="green">
+            Stable
+          </Badge>
+          <Badge variant="outline" color="red">
+            Deprecated
+          </Badge>
+        </div>
+      </div>
+
+      <div>
+        <h3 style={{ marginBottom: '1rem' }}>System Status</h3>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <Badge variant="solid" color="green">
+            Operational
+          </Badge>
+          <Badge variant="solid" color="orange">
+            Degraded
+          </Badge>
+          <Badge variant="solid" color="red">
+            Outage
+          </Badge>
+          <Badge variant="outline" color="gray">
+            Maintenance
+          </Badge>
+        </div>
+      </div>
+
+      <div>
+        <h3 style={{ marginBottom: '1rem' }}>Categories</h3>
+        <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+          <Badge radius="full" color="blue">
+            Design
+          </Badge>
+          <Badge radius="full" color="purple">
+            Development
+          </Badge>
+          <Badge radius="full" color="green">
+            Marketing
+          </Badge>
+          <Badge radius="full" color="orange">
+            Sales
+          </Badge>
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+// Interactive playground
+export const Playground: Story = {
+  args: {
+    children: 'Badge',
+    variant: 'soft',
+    color: 'primary',
+    radius: '1',
+    size: 'md',
+  },
+};

--- a/packages/squared/src/components/Badge/Badge.tsx
+++ b/packages/squared/src/components/Badge/Badge.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import styles from './Badge.module.css';
+
+export type BadgeColor =
+  | 'primary'
+  | 'blue'
+  | 'green'
+  | 'orange'
+  | 'purple'
+  | 'red'
+  | 'yellow'
+  | 'gray';
+
+export type BadgeVariant = 'solid' | 'soft' | 'outline';
+
+export type BadgeRadius = 'none' | '1' | 'full';
+
+export type BadgeSize = 'sm' | 'md' | 'lg';
+
+export type BadgeProps = {
+  /**
+   * The visual variant of the badge
+   * @default 'soft'
+   */
+  variant?: BadgeVariant;
+
+  /**
+   * The semantic color of the badge
+   * @default 'primary'
+   */
+  color?: BadgeColor;
+
+  /**
+   * The corner radius style
+   * @default '1'
+   */
+  radius?: BadgeRadius;
+
+  /**
+   * The size of the badge
+   * @default 'md'
+   */
+  size?: BadgeSize;
+
+  /**
+   * The content to display in the badge
+   */
+  children: React.ReactNode;
+
+  /**
+   * Additional CSS class names
+   */
+  className?: string;
+} & React.HTMLAttributes<HTMLSpanElement>;
+
+export function Badge({
+  variant = 'soft',
+  color = 'primary',
+  radius = '1',
+  size = 'md',
+  children,
+  className,
+  ...props
+}: BadgeProps) {
+  const variantClass = styles[variant];
+  const colorClass = styles[color];
+  const radiusClass =
+    styles[`radius${radius.charAt(0).toUpperCase()}${radius.slice(1)}`];
+  const sizeClass = styles[size];
+
+  const classNames = [
+    styles.badge,
+    variantClass,
+    colorClass,
+    radiusClass,
+    sizeClass,
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <span className={classNames} {...props}>
+      {children}
+    </span>
+  );
+}

--- a/packages/squared/src/components/Badge/index.ts
+++ b/packages/squared/src/components/Badge/index.ts
@@ -1,0 +1,8 @@
+export { Badge } from './Badge';
+export type {
+  BadgeProps,
+  BadgeColor,
+  BadgeVariant,
+  BadgeRadius,
+  BadgeSize,
+} from './Badge';

--- a/packages/squared/src/index.ts
+++ b/packages/squared/src/index.ts
@@ -1,5 +1,13 @@
 /* Components */
 export {
+  Badge,
+  type BadgeProps,
+  type BadgeColor,
+  type BadgeVariant,
+  type BadgeRadius,
+  type BadgeSize,
+} from './components/Badge';
+export {
   Button,
   type ButtonProps,
   type ButtonAppearance,


### PR DESCRIPTION
Implement a new Badge component for labeling, categorizing, and highlighting status information. The component supports:

- 3 visual variants: solid, soft (default), outline
- 8 semantic colors: primary, blue, green, orange, purple, red, yellow, gray
- 3 size variants: sm, md (default), lg
- 3 border radius options: none, 1 (default), full
- CSS Modules styling with design tokens from rubin-style-dictionary
- Complete color ramps (100, 200, 600 shades) for all variants
- Inline usage that doesn't disrupt paragraph line heights