### PR TITLE
DM-52837: Ensure pnpm is setup for docker-release workflow

### DIFF
--- a/.changeset/fifty-seals-accept.md
+++ b/.changeset/fifty-seals-accept.md
@@ -1,0 +1,7 @@
+---
+'squareone': patch
+---
+
+Fix docker-release workflow for missing pnpm setup
+
+pnpm is now required to be present for the docker-release workflow because the root package.json specifies `pnpm` as the packageManager.

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -15,9 +15,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v5
 
+      - uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
+          cache: 'pnpm'
           node-version-file: '.nvmrc'
 
       - name: Get version


### PR DESCRIPTION
pnpm is now required to be present for the docker-release workflow because the root package.json specifies `pnpm` as the packageManager.