### PR TITLE
DM-52930: Create arm64 and amd64 images with multiplatform-build-and-push

### DIFF
--- a/.changeset/gold-icons-happen.md
+++ b/.changeset/gold-icons-happen.md
@@ -1,0 +1,7 @@
+---
+'squareone': minor
+---
+
+Publish arm64 in addition to amd64 platform Docker images
+
+We now use https://github.com/lsst-sqre/multiplatform-build-and-push to generate amd64 and arm64 images for Squareone in parallel. This is packaged in our own reusable workflow at `.github/workflows/build-squareone.yaml` for use in CI and release workflow contexts.

--- a/.github/workflows/build-squareone.yaml
+++ b/.github/workflows/build-squareone.yaml
@@ -1,0 +1,26 @@
+name: Build Squareone Docker Image
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag for image (optional). If not set, tag will be derived from git branch.'
+        required: false
+        type: string
+    secrets:
+      GHCR_PUSH_TOKEN:
+        required: true
+      SENTRY_AUTH_TOKEN:
+        required: true
+
+jobs:
+  build:
+    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@tickets/DM-52930
+    with:
+      images: ghcr.io/${{ github.repository }}
+      dockerfile: apps/squareone/Dockerfile
+      tag: ${{ inputs.tag }}
+    secrets:
+      GHCR_PUSH_TOKEN: ${{ secrets.GHCR_PUSH_TOKEN }}
+      IMAGE_SECRETS: |
+        SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,25 +73,20 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
   build-squareone:
+    uses: ./.github/workflows/build-squareone.yaml
     needs:
       - test
-    timeout-minutes: 25
+    secrets:
+      GHCR_PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches. This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
     if: >
-      startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/')
+      github.event_name != 'merge_group' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/') )
 
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: lsst-sqre/build-and-push-to-ghcr@v1
-        id: build
-        with:
-          image: lsst-sqre/squareone
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dockerfile: apps/squareone/Dockerfile
-          secrets: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
 
   docs:
     needs: [changes]

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -5,12 +5,11 @@ name: Docker release
     types: [published]
 
 jobs:
-  release-squareone:
-    timeout-minutes: 25
-    name: Release Squareone image
+  get-squareone-version:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/squareone')
-
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v5
@@ -26,27 +25,14 @@ jobs:
       - name: Get version
         id: version
         run: |
-          echo "version=$(node -e "console.log(require('./apps/squareone/package.json').version);")" >> "$GITHUB_ENV"
+          echo "version=$(node -e "console.log(require('./apps/squareone/package.json').version);")" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: '.'
-          file: 'apps/squareone/Dockerfile'
-          push: true
-          tags: |
-            ghcr.io/lsst-sqre/squareone:${{ env.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          secrets: |
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+  release-squareone:
+    uses: ./.github/workflows/build-squareone.yaml
+    needs: [get-squareone-version]
+    if: startsWith(github.ref, 'refs/tags/squareone')
+    with:
+      tag: ${{ needs.get-squareone-version.outputs.version }}
+    secrets:
+      GHCR_PUSH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
Use lsst-sqre/multiplatform-build-and-push to create multiplatform images for Squareone. The challenges here are:

1. Passing image build secrets (see https://github.com/lsst-sqre/multiplatform-build-and-push/pull/4)
2. Passing the computed tag in the release workflow (docker-release.yaml)

Implementation:

- lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml
  allows us to build multiplatform images in parallel
- We're currently using its tickets/DM-52930 branch in order to add the
  IMAGE_SECRETS secrets input for build secrets like our
  SENTRY_AUTH_TOKEN
- Refactored the squareone docker builds that are done in the ci.yaml
  and docker-release.yaml workflow contexts into a single reusable
  workflow build-squareone.yaml to both reduce repetition and also to
  make it easy to understand how to extend CI for additional docker
  images.
