### PR TITLE
DM-52930: Enable Docker builds for changeset-release/main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
     # but in this case the build will fail with an error since the secret
     # won't be set.
     if: >
-      github.event_name != 'merge_group' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/') )
+      github.event_name != 'merge_group' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/') || github.ref == 'refs/heads/changeset-release/main')
 
 
   docs:


### PR DESCRIPTION
Add the changeset-release/main branch to the build-squareone job condition so that Docker images are built when changesets creates version bump commits. This ensures release commits trigger the full build and deployment pipeline.