### PR TITLE
DM-52930: Update to multiplatform-build-and-push v1

### DIFF
--- a/.github/workflows/build-squareone.yaml
+++ b/.github/workflows/build-squareone.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build:
-    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@tickets/DM-52930
+    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v1
     with:
       images: ghcr.io/${{ github.repository }}
       dockerfile: apps/squareone/Dockerfile


### PR DESCRIPTION
We've merged https://github.com/lsst-sqre/multiplatform-build-and-push/pull/4 and released as v1.2.0, so we can use the mainstream version of the reusable workflow now with support for IMAGE_SECRETS.