### PR TITLE
DM-53122: Increase tab label contrast

### DIFF
--- a/.changeset/tabs-dark-mode-contrast.md
+++ b/.changeset/tabs-dark-mode-contrast.md
@@ -1,0 +1,7 @@
+---
+'@lsst-sqre/squared': patch
+---
+
+Improve Tabs component contrast in dark mode
+
+Enhanced the visibility of unselected tab labels in dark mode by implementing proper color overrides. Unselected tabs now use light gray text (`--rsd-component-text-reverse-color`) instead of dark gray, significantly improving readability on dark backgrounds. Selected tabs and hover states use lighter teal colors that maintain the visual hierarchy while providing better contrast.

--- a/packages/squared/src/components/Tabs/Tabs.module.css
+++ b/packages/squared/src/components/Tabs/Tabs.module.css
@@ -112,4 +112,28 @@
   display: none;
 }
 
-/* Dark mode support - handled automatically by design tokens */
+/* Dark mode support */
+[data-theme='dark'] .trigger {
+  color: var(
+    --rsd-component-text-reverse-color
+  ); /* Light gray for better contrast */
+}
+
+[data-theme='dark'] .trigger:hover:not([data-disabled]) {
+  color: var(--rsd-color-primary-400); /* Lighter teal on hover */
+  background: rgba(255, 255, 255, 0.05); /* Subtle light background */
+}
+
+[data-theme='dark'] .trigger[data-state='active'] {
+  color: var(--rsd-color-primary-400); /* Lighter teal for selected tab */
+  border-bottom-color: var(--rsd-color-primary-400);
+}
+
+[data-theme='dark'] .trigger[data-state='active']:hover {
+  color: var(--rsd-color-primary-300); /* Even lighter on hover */
+  border-bottom-color: var(--rsd-color-primary-300);
+}
+
+[data-theme='dark'] .trigger[data-disabled] {
+  color: var(--rsd-color-gray-500); /* Slightly lighter disabled state */
+}


### PR DESCRIPTION
## Summary

Improved the visibility of unselected tab labels in dark mode by implementing proper color overrides.

## Changes

- Unselected tabs now use light gray text (`--rsd-component-text-reverse-color`) instead of dark gray, significantly improving readability on dark backgrounds
- Selected tabs and hover states use lighter teal colors (`--rsd-color-primary-400`) that maintain visual hierarchy while providing better contrast
- Follows established dark mode patterns in the design system using `[data-theme='dark']` selectors

## Test Plan

- [x] View Tabs component in Storybook with dark mode enabled
- [ ] Verify unselected tab labels are clearly visible
- [x] Verify selected tabs still use teal color to indicate selection
- [x] Check hover states work correctly in both light and dark modes