### PR TITLE
DM-53208: Filter token scopes by availability to user

### DIFF
--- a/.changeset/filter-token-scopes.md
+++ b/.changeset/filter-token-scopes.md
@@ -1,0 +1,10 @@
+---
+'squareone': patch
+---
+
+Filter available scopes in token creation form based on user's authentication token
+
+The token creation form now filters the available scopes to only show scopes that the user's current authentication token possesses. This prevents users from attempting to create tokens with scopes they don't have access to, providing a better user experience and clearer security boundaries. Changes:
+
+- Modified `/settings/tokens/new` page to filter `loginInfo.config.scopes` by `loginInfo.scopes`
+- Updated NewTokenPage Storybook story to match implementation and added a new `LimitedScopes` story demonstrating the filtering behavior

--- a/apps/squareone/src/pages/settings/tokens/new.tsx
+++ b/apps/squareone/src/pages/settings/tokens/new.tsx
@@ -163,7 +163,9 @@ const NewTokenPage: NextPageWithLayout &
         {creationError && <TokenCreationErrorDisplay error={creationError} />}
 
         <TokenForm
-          availableScopes={loginInfo.config.scopes}
+          availableScopes={loginInfo.config.scopes.filter((scope) =>
+            loginInfo.scopes.includes(scope.name)
+          )}
           initialValues={formInitialValues}
           onSubmit={handleSubmit}
           onCancel={handleCancel}


### PR DESCRIPTION
## Summary

Filters the available scopes shown in the token creation form to only include scopes that the user's current authentication token possesses. This prevents users from attempting to create tokens with scopes they don't have access to, providing better UX and clearer security boundaries.

## Changes

- Modified `/settings/tokens/new` page to filter `loginInfo.config.scopes` by `loginInfo.scopes`
- Updated NewTokenPage Storybook story to match implementation
- Added new `LimitedScopes` story demonstrating the filtering behavior

## Implementation

The filtering is done by comparing the user's current token scopes (`loginInfo.scopes`) with all available scopes in the system (`loginInfo.config.scopes`). Only scopes that the user's token has are shown as options when creating a new token.