### PR TITLE
DM-53194: Dependabot dependency groupings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     open-pull-requests-limit: 15
     rebase-strategy: 'auto'
     commit-message:
-      prefix: 'chore(deps)'
+      prefix: 'chore'
       include: 'scope'
 
     # Block major version updates globally (manual review required)


### PR DESCRIPTION
## Summary

Fixes commit message scope duplication in the Dependabot configuration from the previous PR.

## Changes

Changed the commit message prefix from `chore(deps)` to `chore` to avoid duplicate scopes. Since `include: 'scope'` is set, Dependabot automatically adds `(deps)` or `(dev-deps)`, making the explicit `(deps)` in the prefix redundant.

**Before:** `chore(deps)(deps): ...` or `chore(deps)(dev-deps): ...`
**After:** `chore(deps): ...` or `chore(dev-deps): ...`