### PR TITLE
DM-53194: Configure changesets committer identity to run workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,11 @@ jobs:
           app_id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
           private_key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
 
+      - name: Configure git identity for GitHub App
+        run: |
+          git config --global user.name "squareone-ci[bot]"
+          git config --global user.email "${{ secrets.SQUAREONE_CI_GH_APP_ID }}+squareone-ci[bot]@users.noreply.github.com"
+
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
Fixes changesets PRs not triggering CI and CodeQL workflows.

## Problem

Changesets PRs (like #249) weren't triggering any workflows because commits were authored by `github-actions[bot]` instead of the GitHub App identity `squareone-ci[bot]`. GitHub blocks workflow triggers when PRs are created by `GITHUB_TOKEN` as a security measure.

## Solution

Configure git identity before the changesets action runs to use the GitHub App identity for all commits.

## Expected Outcome

Future changesets PRs will:
- Have commits authored by `squareone-ci[bot]`
- Trigger ci.yaml and codeql-analysis.yaml workflows
- Show checks in `gh pr checks`