### PR TITLE
DM-53194: Fix Changesets GitHub app config for workflow triggering

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,26 @@ jobs:
     name: Release packages
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        # Associated app: https://github.com/organizations/lsst-sqre/settings/apps/squareone-ci
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          private_key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get_user_id
+        run: |
+          USER_ID=$(gh api "/users/squareone-ci[bot]" --jq .id)
+          echo "user-id=$USER_ID" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
       - name: Checkout Repo
         uses: actions/checkout@v5
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       - uses: pnpm/action-setup@v4
 
@@ -34,24 +52,17 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Generate GitHub App Token
-        # Associated app: https://github.com/organizations/lsst-sqre/settings/apps/squareone-ci
-        id: generate_token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
-          private_key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
-
       - name: Configure git identity for GitHub App
         run: |
           git config --global user.name "squareone-ci[bot]"
-          git config --global user.email "${{ secrets.SQUAREONE_CI_GH_APP_ID }}+squareone-ci[bot]@users.noreply.github.com"
+          git config --global user.email "${{ steps.get_user_id.outputs.user-id }}+squareone-ci[bot]@users.noreply.github.com"
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
           publish: pnpm run ci:publish
           version: pnpm run ci:version
+          setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Completes the fix for changesets PRs not triggering CI workflows (PR #267 was incomplete).

## Changes

**Fetch bot USER_ID from GitHub API:**
- Added step to get bot's user ID (distinct from APP_ID)
- Uses proper email format: `{USER_ID}+squareone-ci[bot]@users.noreply.github.com`

**Prevent git config overwrite:**
- Added `setupGitUser: false` to changesets action
- Without this, changesets overwrites our config with `github-actions[bot]`

**Use GitHub App token in checkout:**
- Reordered steps: token generation → checkout with token → git config
- Ensures all git operations use the app token

## Why PR #267 didn't work

1. Used `APP_ID` instead of `USER_ID` in git email (different values)
2. Missing `setupGitUser: false` - changesets overwrote the git config
3. Checkout didn't use the app token

## Research basis

Based on patterns from popular OSS projects:
- **primer/react** (GitHub's component library) - GitHub App best practices
- **chakra-ui** - `setupGitUser: false` pattern
- **changesets/action** issues - workflow triggering solutions

Next changesets PR should now trigger all workflows correctly.