### PR TITLE
DM-53194: Use GitHub App token to trigger CI on changeset commits

### DIFF
--- a/.github/workflows/dependabot-changesets.yaml
+++ b/.github/workflows/dependabot-changesets.yaml
@@ -23,11 +23,28 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Generate GitHub App Token
+        # Associated app: https://github.com/organizations/lsst-sqre/settings/apps/squareone-ci
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          private_key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
+
+      - name: Get GitHub App User ID
+        id: get_user_id
+        run: |
+          USER_ID=$(gh api "/users/squareone-ci[bot]" --jq .id)
+          echo "user-id=$USER_ID" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
       - name: Checkout PR branch
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Generate changeset
         uses: StafflinePeoplePlus/dependabot-changesets@v0.1.5
@@ -35,4 +52,6 @@ jobs:
           owner: lsst-sqre
           repo: squareone
           pr-number: ${{ github.event.pull_request.number }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
+          git-user: 'squareone-ci[bot]'
+          git-email: '${{ steps.get_user_id.outputs.user-id }}+squareone-ci[bot]@users.noreply.github.com'


### PR DESCRIPTION
Configure the dependabot-changesets workflow to use the squareone-ci GitHub App for authentication instead of GITHUB_TOKEN. This ensures that commits created by the workflow will trigger subsequent CI runs.

Changes:

- Generate GitHub App token using tibdex/github-app-token action
- Retrieve app user ID for proper commit attribution
- Pass app token to actions/checkout for git authentication
- Configure dependabot-changesets action with app token and identity
- Set git-user and git-email to squareone-ci[bot] credentials

This mirrors the pattern used in release.yaml and resolves the issue where Dependabot PRs with auto-generated changesets were not triggering CI workflow runs.