### PR TITLE
DM-53194: Fix dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -31,7 +31,7 @@ jobs:
       # Get PR information from the workflow run
       - name: Get PR number
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const pullRequests = context.payload.workflow_run.pull_requests;
@@ -47,28 +47,35 @@ jobs:
               number: pr.number,
               html_url: pr.html_url,
               head_sha: pr.head.sha,
-              head_ref: pr.head.ref,
-              user_login: pr.user.login
+              head_ref: pr.head.ref
             };
 
       # Security: Verify PR is from Dependabot
-      # We check github.event.workflow_run.pull_requests[0].user.login instead of
-      # github.actor because github.actor represents the user who triggered the
-      # workflow_run (often the repo owner), not the PR author.
+      # We fetch the full PR details using the GitHub API to access the author information,
+      # as the workflow_run payload's pull_requests array contains simplified PR objects
+      # that don't include the user property.
       - name: Verify Dependabot PR
         if: steps.pr.outputs.result != 'null'
         id: verify
-        run: |
-          USER_LOGIN=$(echo '${{ steps.pr.outputs.result }}' | jq -r '.user_login')
-          echo "PR author: $USER_LOGIN"
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = JSON.parse('${{ steps.pr.outputs.result }}').number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
 
-          if [ "$USER_LOGIN" != "dependabot[bot]" ]; then
-            echo "Not a Dependabot PR, skipping"
-            echo "is_dependabot=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+            console.log(`PR author: ${pr.user.login}`);
 
-          echo "is_dependabot=true" >> $GITHUB_OUTPUT
+            if (pr.user.login !== 'dependabot[bot]') {
+              console.log('Not a Dependabot PR, skipping');
+              core.setOutput('is_dependabot', 'false');
+              return;
+            }
+
+            core.setOutput('is_dependabot', 'true');
 
       # Fetch Dependabot metadata for semver analysis
       - name: Dependabot metadata


### PR DESCRIPTION
## Summary
Fix TypeError in the `dependabot-auto-merge.yaml` workflow that was preventing it from running successfully.

## Problem
The workflow was crashing with a TypeError when trying to access `pr.user.login` from the simplified PR objects in the `workflow_run` event payload. These simplified objects don't include the `user` property, causing the script to fail and cascading template validation errors in all downstream steps.

**Error:** `TypeError: Cannot read properties of undefined (reading 'login')` at line 51

**Workflow run with errors:** https://github.com/lsst-sqre/squareone/actions/runs/19273165035

## Changes

### Upgrade GitHub Script Action
- Bump `actions/github-script` from v7 to v8 in both steps

### Fix PR Author Extraction
- Remove `user_login: pr.user.login` from initial PR data extraction
- This property isn't available in the `workflow_run` payload structure

### Replace Author Verification Method
- Change from bash script to `actions/github-script@v8` action
- Use `github.rest.pulls.get()` to fetch complete PR details
- Access `pr.user.login` from the full API response (not simplified payload)
- Use `core.setOutput()` for proper output handling

## Result
✅ Workflow can now successfully verify PR author  
✅ No more TypeError crashes  
✅ Downstream steps receive valid PR data  
✅ Auto-merge functionality works as intended

## Related
- Follows up on PR #275 which introduced the auto-merge workflow