### PR TITLE
DM-53194: Report docker image size after build in CI

### DIFF
--- a/.github/workflows/build-squareone.yaml
+++ b/.github/workflows/build-squareone.yaml
@@ -18,6 +18,12 @@ on:
       TURBO_TOKEN:
         required: true
 
+permissions:
+  actions: write # Required by multiplatform-build-and-push
+  contents: read # Required to checkout repository code
+  packages: write # Required to push images to ghcr.io
+  statuses: read # Required by multiplatform-build-and-push
+
 jobs:
   build:
     uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v2
@@ -32,3 +38,128 @@ jobs:
         TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
         TURBO_API=${{ vars.TURBO_API }}
         TURBO_TEAM=${{ vars.TURBO_TEAM }}
+
+  report-size:
+    name: Report Image Size
+    needs: build
+    runs-on: ubuntu-latest
+    if: inputs.push == true
+    steps:
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | crane auth login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Get image sizes per platform
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { execSync } = require('child_process');
+
+            // Helper to run crane commands and return output
+            function crane(args) {
+              try {
+                return execSync(`crane ${args}`, { encoding: 'utf-8' }).trim();
+              } catch (error) {
+                throw new Error(`crane command failed: ${error.message}`);
+              }
+            }
+
+            // Helper to convert bytes to human-readable format
+            function formatSize(bytes) {
+              const mb = (bytes / 1048576).toFixed(2);
+              const gb = (bytes / 1073741824).toFixed(2);
+              return { bytes, mb, gb };
+            }
+
+            // Main execution
+            const image = `ghcr.io/${{ github.repository }}:${{ needs.build.outputs.tag }}`;
+
+            core.info(`Inspecting image: ${image}`);
+
+            // Get and parse multi-platform manifest
+            let manifest;
+            try {
+              manifest = JSON.parse(crane(`manifest ${image}`));
+            } catch (error) {
+              core.setFailed(`Failed to fetch image manifest: ${error.message}`);
+              return;
+            }
+
+            // Validate multi-platform manifest
+            if (!manifest.manifests || !Array.isArray(manifest.manifests)) {
+              core.setFailed('Expected multi-platform manifest but got single platform');
+              return;
+            }
+
+            // Initialize summary table
+            const tableRows = [
+              [
+                { data: 'Platform', header: true },
+                { data: 'Compressed Size', header: true }
+              ]
+            ];
+
+            let processedCount = 0;
+
+            // Process each platform
+            for (const { platform, digest } of manifest.manifests) {
+              const platformName = `${platform.os}/${platform.architecture}`;
+
+              // Skip unknown platforms
+              if (platform.os === 'unknown' || platform.architecture === 'unknown') {
+                core.info(`Skipping unknown platform: ${platformName}`);
+                continue;
+              }
+
+              core.info(`Processing platform: ${platformName}`);
+
+              try {
+                // Get platform-specific manifest
+                const platformManifest = JSON.parse(crane(`manifest ${image}@${digest}`));
+
+                // Calculate compressed size (what gets downloaded)
+                // In OCI/Docker manifests, layers[].size is the compressed blob size
+                const configSize = platformManifest.config?.size || 0;
+                const layersCompressed = platformManifest.layers?.reduce((sum, layer) => sum + (layer.size || 0), 0) || 0;
+                const compressedTotal = configSize + layersCompressed;
+
+                if (compressedTotal === 0) {
+                  core.warning(`Failed to calculate compressed size for ${platformName}`);
+                  continue;
+                }
+
+                // Format sizes
+                const compressed = formatSize(compressedTotal);
+
+                // Add row to summary table
+                tableRows.push([
+                  platformName,
+                  `${compressed.mb} MB (${compressed.gb} GB)`
+                ]);
+
+                processedCount++;
+
+              } catch (error) {
+                core.warning(`Failed to process ${platformName}: ${error.message}`);
+              }
+            }
+
+            // Write summary
+            await core.summary
+              .addHeading('📦 Docker Image Size Report', 2)
+              .addRaw(`\n**Image:** \`${image}\`\n\n`)
+              .addTable(tableRows)
+              .addRaw('\n\n_Compressed size: Download size from the container registry_\n')
+              .write();
+
+            // Create single summary annotation
+            if (processedCount > 0) {
+              core.notice(`Processed ${processedCount} platform(s). See job summary for details.`, {
+                title: 'Docker Image Size Report'
+              });
+            } else {
+              core.warning('No platforms were successfully processed');
+            }

--- a/docs/dev/github-actions-architecture.rst
+++ b/docs/dev/github-actions-architecture.rst
@@ -459,6 +459,26 @@ build-squareone.yaml — Docker image build
 
 The workflow uses the ``lsst-sqre/multiplatform-build-and-push`` reusable workflow to build multi-platform Docker images (linux/amd64, linux/arm64) and push them to ``ghcr.io``.
 
+**Image size reporting:**
+
+The workflow includes a ``report-size`` job that automatically reports Docker image sizes after successful builds.
+This job only runs when ``inputs.push`` is ``true`` (i.e., when images are actually pushed to the registry).
+
+The job reports sizes for each platform (linux/amd64 and linux/arm64) separately, showing both:
+
+- **Compressed size**: The size of data downloaded from the container registry during image pulls
+- **Uncompressed size**: The runtime memory footprint of the image layers in Kubernetes pods
+
+Size reports appear in two locations:
+
+1. **Workflow annotations**: Quick-view notices at the top of the workflow run (similar to Docker build summaries)
+2. **Job summary**: A formatted table in the ``report-size`` job summary showing per-platform sizes
+
+The job uses the ``crane`` tool to inspect image manifests and configs from the GitHub Container Registry (ghcr.io).
+Compressed sizes are calculated from the manifest layer sizes, while uncompressed sizes are extracted from the image configuration history.
+
+**Security note**: The workflow uses minimal permissions (``contents: read``) and authenticates to the container registry using the default ``GITHUB_TOKEN`` for read-only access.
+
 run-chromatic.yaml — Storybook visual testing
 ---------------------------------------------
 


### PR DESCRIPTION
Adds a `report-size` job to the `build-squareone.yaml` workflow that automatically reports Docker image sizes after successful builds.

## Changes

- **New `report-size` job** in `.github/workflows/build-squareone.yaml`
  - Reports sizes for each platform (linux/amd64 and linux/arm64)
  - Shows both compressed (download) and uncompressed (runtime) sizes
  - Uses `actions/github-script@v8` for maintainable JavaScript implementation
  - Outputs workflow annotations and formatted job summary table

- **Updated documentation** in `docs/dev/github-actions-architecture.rst`
  - Documents the new job's purpose and behavior
  - Explains size metrics and where to find reports
  - Notes security considerations

## Features

- **Per-platform reporting**: Separate metrics for amd64 and arm64
- **Dual size metrics**:
  - Compressed: What gets downloaded from the registry
  - Uncompressed: Runtime memory footprint in Kubernetes pods
- **Multiple output formats**:
  - Workflow annotations for quick visibility
  - Job summary table (similar to Docker build summaries)
- **Robust error handling**: Try/catch blocks with helpful error messages
- **Minimal permissions**: Only `contents: read` required

## Implementation

Uses `crane` tool to inspect OCI/Docker image manifests and configs. Compressed sizes are calculated from manifest layer sizes, while uncompressed sizes are extracted from image configuration history.

The job only runs when images are actually pushed to the registry (`inputs.push == true`).