### PR TITLE
DM-53194: Fix Dependabot auto merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -234,7 +234,7 @@ jobs:
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
         run: |
           echo "Enabling auto-merge for $UPDATE_TYPE update"
-          gh pr merge --auto --squash "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL" --repo "${{ github.repository }}"
 
       # Add comment for visibility
       - name: Comment on PR


### PR DESCRIPTION
## Summary

Fixes the gh pr merge command in the dependabot-auto-merge.yaml workflow that was failing with 'fatal: not a git repository' error.

## Changes

- Added --repo flag to the gh pr merge command (line 237)

## Technical Details

The gh pr merge command was attempting to access git repository metadata even though a URL was provided. Since the workflow uses workflow_run trigger and never checks out the repository (by design for security), it failed with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The fix adds the --repo flag to explicitly specify which repository to operate on, eliminating the need for git repository detection. This matches the pattern already used successfully in other gh pr commands in the same workflow (lines 208 and 251).

## Test Plan

- Wait for next Dependabot PR to trigger the workflow
- Verify the 'Enable auto-merge with squash' step succeeds
- Confirm auto-merge is enabled on the PR