### PR TITLE
DM-53194: Fix dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -28,6 +28,14 @@ jobs:
 
 
     steps:
+      - name: Generate GitHub App Token
+        # Associated app: https://github.com/organizations/lsst-sqre/settings/apps/squareone-ci
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          private_key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
+
       # Get PR information from the workflow run
       - name: Get PR number
         id: pr
@@ -197,7 +205,7 @@ jobs:
         if: steps.verify.outputs.is_dependabot == 'true'
         id: changeset
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.result }}
         run: |
           echo "Checking for changeset files in PR #$PR_NUMBER"
@@ -227,7 +235,7 @@ jobs:
 
 
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PR_URL: ${{ steps.verify.outputs.html_url }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
         run: |
@@ -241,7 +249,7 @@ jobs:
 
 
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.result }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
           DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}


### PR DESCRIPTION
## Summary

Fixes the auto-merge permissions issue that was preventing the workflow from enabling auto-merge on Dependabot PRs.

## Problem

After fixing the PR URL extraction in #285, the workflow was still failing at the "Enable auto-merge with squash" step with:

```
GraphQL: Resource not accessible by integration (mergePullRequest)
```

The default `GITHUB_TOKEN` lacks permissions to enable auto-merge in `workflow_run` context. This is a known limitation where the token cannot perform the `enablePullRequestAutoMerge` GraphQL mutation.

## Solution

Use the Squareone CI GitHub App to generate a token with proper permissions, following the same pattern already successfully used in:
- `dependabot-changesets.yaml`
- `release.yaml`

## Changes

- **Added token generation step**: Uses `tibdex/github-app-token@v2` to generate a token from the Squareone CI GitHub App
- **Updated "Check for changeset" step**: Uses app token instead of `GITHUB_TOKEN`
- **Updated "Enable auto-merge" step**: Uses app token instead of `GITHUB_TOKEN`
- **Updated "Comment on PR" step**: Uses app token instead of `GITHUB_TOKEN`

## Benefits

- ✅ Fixes the auto-merge permission error
- ✅ Uses existing GitHub App infrastructure
- ✅ Follows established patterns in the repository
- ✅ More secure than using a PAT

## Test plan

- [ ] Verify the workflow runs successfully on a Dependabot PR
- [ ] Confirm auto-merge is enabled without permission errors
- [ ] Ensure comments are posted to the PR