### PR TITLE
DM-53194: Migrate to official GitHub App token action

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -31,10 +31,10 @@ jobs:
       - name: Generate GitHub App Token
         # Associated app: https://github.com/organizations/lsst-sqre/settings/apps/squareone-ci
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
-          private_key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          private-key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
 
       # Get PR information from the workflow run
       - name: Get PR number

--- a/.github/workflows/dependabot-changesets.yaml
+++ b/.github/workflows/dependabot-changesets.yaml
@@ -33,10 +33,10 @@ jobs:
       - name: Generate GitHub App Token
         # Associated app: https://github.com/organizations/lsst-sqre/settings/apps/squareone-ci
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
-          private_key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          private-key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID
         id: get_user_id

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Generate GitHub App Token
         # Associated app: https://github.com/organizations/lsst-sqre/settings/apps/squareone-ci
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
-          private_key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          private-key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID
         id: get_user_id


### PR DESCRIPTION
Replace tibdex/github-app-token@v2 with the official actions/create-github-app-token@v2 action across all workflows. The tibdex action has been archived and is no longer maintained.

Changes:

- Update action reference in all three workflows
- Convert parameter names from snake_case to kebab-case (app_id → app-id, private_key → private-key)
- All functionality remains identical (same token output)

Affected workflows:

- dependabot-auto-merge.yaml
- dependabot-changesets.yaml
- release.yaml