### PR TITLE
DM-53194: Add explicit permissions blocks to GitHub workflows

### DIFF
--- a/.github/workflows/chromatic-squared.yaml
+++ b/.github/workflows/chromatic-squared.yaml
@@ -8,6 +8,9 @@ name: 'Chromatic: Squared'
     tags-ignore:
       - '*'
 
+permissions:
+  contents: read # Required by called workflow
+
 jobs:
   call:
     if: false

--- a/.github/workflows/chromatic-squareone.yaml
+++ b/.github/workflows/chromatic-squareone.yaml
@@ -8,6 +8,9 @@ name: 'Chromatic: Squareone'
     tags-ignore:
       - '*'
 
+permissions:
+  contents: read # Required by called workflow
+
 jobs:
   call:
     if: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,12 @@ name: CI
       - 'u/**'
   pull_request: {}
 
+permissions:
+  actions: write # Required by build-squareone.yaml for multiplatform-build-and-push
+  contents: read # Checkout repository and run tests
+  packages: write # Required by build-squareone.yaml to push images to ghcr.io
+  statuses: read # Required by build-squareone.yaml for multiplatform-build-and-push
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -4,6 +4,12 @@ name: Docker release
   release:
     types: [published]
 
+permissions:
+  actions: write # Required by build-squareone.yaml for multiplatform-build-and-push
+  contents: read # Read repository code and package.json
+  packages: write # Required by build-squareone.yaml to push images to ghcr.io
+  statuses: read # Required by build-squareone.yaml for multiplatform-build-and-push
+
 jobs:
   get-squareone-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,11 @@ name: Release
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write # Commit version bumps, create releases
+  pull-requests: write # Create/update release PR
+  packages: write # Publish to GitHub Packages
+
 jobs:
   release:
     name: Release packages

--- a/.github/workflows/run-chromatic.yaml
+++ b/.github/workflows/run-chromatic.yaml
@@ -18,6 +18,9 @@ name: 'Run Chromatic'
       TURBO_TOKEN:
         required: true
 
+permissions:
+  contents: read # Checkout repository with full history
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolve CodeQL security alerts by adding explicit permissions blocks to 6 workflows that were missing them. All permissions follow the principle of least privilege, granting only what each workflow needs:

- ci.yaml: contents:read for checkout and tests
- release.yaml: contents:write, pull-requests:write, packages:write for version management and publishing
- docker-release.yaml: contents:read for reading package metadata
- run-chromatic.yaml: contents:read for checkout with full history
- chromatic-squareone.yaml: contents:read (currently disabled)
- chromatic-squared.yaml: contents:read (currently disabled)

Workflows that call reusable workflows inherit permissions correctly, as the called workflows define their own explicit permissions blocks.