### PR TITLE
DM-53194: Create next tag for images from changesets release PR

### DIFF
--- a/.changeset/next-image-preview.md
+++ b/.changeset/next-image-preview.md
@@ -1,0 +1,15 @@
+---
+'squareone': patch
+---
+
+Enable "next" image tag for changeset release previews
+
+The CI workflow now builds and pushes Docker images with a special "next" tag when the `changeset-release/main` branch is updated. This allows developers and managers to preview the next version before merging the "Version Packages" PR.
+
+Previously, the workflow would only build images for the changeset-release branch without pushing them to the registry. Now:
+
+- Images are pushed to ghcr.io with both the branch-derived tag and the "next" tag
+- The "next" tag can be used to deploy and test the upcoming version in staging environments
+- Other changeset-release branches (non-main) remain build-only
+
+This improves the release preview workflow by making pre-release images easily accessible via a stable tag name.

--- a/.github/workflows/build-squareone.yaml
+++ b/.github/workflows/build-squareone.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         type: boolean
         default: true
+      additional-tags:
+        description: 'Comma-separated additional tags for the image (optional)'
+        required: false
+        type: string
     secrets:
       SENTRY_AUTH_TOKEN:
         required: true
@@ -31,6 +35,7 @@ jobs:
       images: ghcr.io/${{ github.repository }}
       dockerfile: apps/squareone/Dockerfile
       tag: ${{ inputs.tag }}
+      additional-tags: ${{ inputs.additional-tags }}
       push: ${{ inputs.push }}
     secrets:
       IMAGE_SECRETS: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,8 +97,9 @@ jobs:
     needs:
       - test
     with:
-      # Build-only (no push) for dependabot, changeset-release, and u/ branches; push to registry for others
-      push: ${{ !(startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'changeset-release/') || startsWith(github.head_ref, 'u/') || startsWith(github.ref, 'refs/heads/changeset-release/')) }}
+      # Build-only (no push) for dependabot and u/ branches; push with "next" tag for changeset-release/main; push normally for others
+      push: ${{ !(startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'u/') || (startsWith(github.head_ref, 'changeset-release/') && github.head_ref != 'changeset-release/main') || (startsWith(github.ref, 'refs/heads/changeset-release/') && github.ref != 'refs/heads/changeset-release/main')) }}
+      additional-tags: ${{ (github.head_ref == 'changeset-release/main' || github.ref == 'refs/heads/changeset-release/main') && 'next' || '' }}
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
This PR adds support for building and pushing Docker images with a special "next" tag when the `changeset-release/main` branch is updated by Changesets' "Version Packages" PR.

## What's Changed

- **`build-squareone.yaml`**: Added `additional-tags` input parameter that gets passed through to the `multiplatform-build-and-push` action
- **`ci.yaml`**: Modified the push conditional to allow pushing images for `changeset-release/main` (while keeping other changeset-release branches as build-only)
- **`ci.yaml`**: Added `additional-tags: 'next'` for the `changeset-release/main` branch

## Use Case

This feature is particularly useful for running a preview of the next version of Squareone before merging the release PR. This allows:

- **Testing in staging environments**: Deploy the "next" tagged image to staging to verify functionality before releasing to production
- **Validating dependency updates**: After running Dependabot updates that accumulate in a release PR, test the combined changes in a real environment
- **Release verification**: Ensure that all changes work together as expected before creating the official release

## Behavior

When the `changeset-release/main` branch is updated:
- Docker images are built AND pushed to `ghcr.io` (previously build-only)
- Images are tagged with both:
  - The branch-derived tag (e.g., `changeset-release-main`)
  - The special `next` tag for easy reference

Other `changeset-release/*` branches remain build-only (no push).

## Example Workflow

1. Changesets creates a "Version Packages" PR with the `changeset-release/main` branch
2. CI builds and pushes the image with tags: `changeset-release-main` and `next`
3. Deploy `ghcr.io/lsst-sqre/squareone:next` to a staging environment
4. Test and verify the combined changes
5. Merge the PR to create the official release