### PR TITLE
DM-53194: Restore appearance of secondary buttons

### DIFF
--- a/apps/squareone/src/components/TokenForm/TokenForm.tsx
+++ b/apps/squareone/src/components/TokenForm/TokenForm.tsx
@@ -143,7 +143,12 @@ export default function TokenForm({
         >
           Create token
         </Button>
-        <Button type="button" onClick={onCancel} disabled={isSubmitting}>
+        <Button
+          type="button"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          variant="secondary"
+        >
           Cancel
         </Button>
       </div>

--- a/apps/squareone/src/components/TokenSuccessModal/TokenSuccessModal.tsx
+++ b/apps/squareone/src/components/TokenSuccessModal/TokenSuccessModal.tsx
@@ -81,6 +81,7 @@ export default function TokenSuccessModal({
               size="md"
               ariaLabel="Copy token to clipboard"
               className={styles.tokenCopyButton}
+              variant="secondary"
             />
           </div>
         </div>
@@ -100,6 +101,7 @@ export default function TokenSuccessModal({
             size="md"
             ariaLabel="Copy token template to clipboard"
             className={styles.templateCopyButton}
+            variant="secondary"
           />
         </div>
       </div>


### PR DESCRIPTION
These buttons likely used a role prop to declare them as "secondary" but when we renamed "role" to "variant" we likely dropped this prop. This should restore the appearance of these buttons.