### PR TITLE
Improve dependabot groupings and add cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,22 @@ updates:
     registries:
       - npm-github
 
+    # Cooldown to mitigate supply chain attacks
+    # Security updates bypass cooldown automatically
+    cooldown:
+      default-days: 5
+      semver-patch-days: 3
+      semver-minor-days: 5
+      exclude:
+        # Core framework packages from trusted publishers
+        - 'react'
+        - 'react-dom'
+        - 'next'
+        - '@next/*'
+        - 'typescript'
+        # Type definitions (low risk, from DefinitelyTyped)
+        - '@types/*'
+
     groups:
       # Security updates - patch and minor versions (FIRST - highest priority)
       security-patch:


### PR DESCRIPTION
1. Consolidate dependabot groups and add catch-all groups to ensure that we don't have lots of PRs for individual dependencies that haven't yet been assigned to groups.
2. Add a cooldown configuration to ensure we don't update to dependencies newer than 3 days for patches or 5 days for minor updates. This helps us avoid supply chain attacks and buggy releases. The security patch updates bypass the cooldown, as do package updates from React/Next.js where the publishers are highly trusted.