### PR TITLE
Build file factory CLI for component scaffolding

### DIFF
--- a/.changeset/file-factory-initial.md
+++ b/.changeset/file-factory-initial.md
@@ -1,0 +1,20 @@
+---
+"@lsst-sqre/file-factory": minor
+---
+
+Add file-factory CLI tool for scaffolding React components, hooks, contexts, and pages
+
+This new package provides:
+- `file-factory component` - Create React components with optional CSS Modules, tests, and Storybook stories
+- `file-factory hook` - Create React hooks with optional directory structure
+- `file-factory context` - Create global React context providers
+- `file-factory page` - Create Next.js pages (both Pages Router and App Router)
+
+Features:
+- Directory-as-template pattern (like cookiecutter)
+- Component-scoped contexts with `--with-context` flag
+- Automatic barrel file updates
+- Package-specific configuration via `.file-factory/config.ts`
+- Custom template overrides
+- TypeScript throughout with Zod validation
+- Interactive mode when no arguments provided

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -21,7 +21,8 @@ This directory contains configuration for Claude Code, including specialized ski
 │   ├── data-fetching-patterns/ # SWR data fetching patterns
 │   ├── migrate-styled-components-to-css-modules/ # Migration guide
 │   ├── platform-api-integration/ # RSP API discovery & integration
-│   └── docker-version-validation/ # Dockerfile version synchronization
+│   ├── docker-version-validation/ # Dockerfile version synchronization
+│   └── file-factory/          # CLI scaffolding for components, hooks, contexts, pages
 ├── tasks/                      # Gitignored task-specific docs
 ├── projects/                   # Project-specific configurations
 ├── settings.local.json         # Local settings & permissions
@@ -253,6 +254,26 @@ Skills are modular capabilities that extend Claude's expertise with domain-speci
 
 - None (references validation script at `scripts/validate-docker-versions.js`)
 
+#### file-factory
+
+**When to use**: Creating new React components, hooks, context providers, or Next.js pages. Scaffolding new code with consistent file structure.
+
+**Covers**:
+
+- CLI tool for scaffolding (`pnpm file-factory <type> <name>`)
+- Component generation with CSS Modules, tests, stories
+- Hook generation (directory or flat file patterns)
+- Global context provider generation
+- Next.js page generation (Pages or App Router)
+- Package-specific configurations
+- Automatic barrel file updates
+
+**Supporting files**:
+
+- Feature-specific guides (components.md, hooks.md, contexts.md, pages.md)
+- Package conventions (squared.md, squareone.md)
+- Configuration reference (configuration.md)
+
 ## Agents
 
 ### test-suite-runner
@@ -293,6 +314,7 @@ Skills activate automatically when relevant. Simply describe what you want:
 
 - "Set up configuration loading for a new page" → `appconfig-system`
 - "Create a new component with CSS Modules" → `component-creation`
+- "Scaffold a new React hook" → `file-factory`
 - "What CSS variables are available for colors?" → `design-system`
 - "Why is my build slow?" → `turborepo-workflow`
 - "Write tests for my component" → `testing-infrastructure`

--- a/.claude/skills/component-creation/SKILL.md
+++ b/.claude/skills/component-creation/SKILL.md
@@ -5,6 +5,8 @@ description: Comprehensive guide for creating React components in the squared pa
 
 # Component Creation Guide
 
+> **Tip**: Use the **file-factory** CLI to scaffold new components: `pnpm file-factory component <name> --package <package>`. This creates the correct directory structure with all files (component, styles, tests, stories, index). Then follow the patterns in this guide for implementation.
+
 ## Component Structure
 
 ```
@@ -377,6 +379,7 @@ export default function MyComponent({ showExtra, data }: Props) {
 
 ## Related Skills
 
+- **file-factory** - Use `pnpm file-factory component <name>` to scaffold new components with the correct structure before implementing
 - **design-system** - Complete CSS variable and design token reference
 - **squared-package** - Understanding NO BUILD STEP architecture for squared components
 - **testing-infrastructure** - Writing tests for components

--- a/.claude/skills/file-factory/SKILL.md
+++ b/.claude/skills/file-factory/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: file-factory
+description: How to use the file-factory CLI to create new React components, hooks, context providers, Next.js pages along with associated tests and storybook stories. ALWAYS use this tool instead of manually creating new components/hooks/contexts/pages to ensure consistent file structure and conventions.
+---
+
+# File Factory Skill
+
+This skill describes how to create new React components, hooks, context providers, and Next.js pages in the Squareone monorepo using the `@lsst-sqre/file-factory` CLI tool. **ALWAYS use this tool instead of manually creating new components/hooks/context providers/pages.** It ensures consistent file structure, barrel files, CSS modules, and automatic barrel file updates.
+
+## Tool Calling
+
+Call from the monorepo root:
+
+```bash
+pnpm file-factory <type> <name> --package <package-name>
+```
+
+Package resolution supports multiple formats:
+- **Short names**: `squared`, `squareone` (recommended)
+- **Full names**: `@lsst-sqre/squared`
+- **Directory paths**: `apps/squareone`, `packages/squared`
+
+If there's a conflict between an app and package with the same short name, apps take priority.
+
+## Documentation for specific project types
+
+Reference these pages for CLI command documentation:
+
+- React components: [components.md](components.md)
+- React hooks: [hooks.md](hooks.md)
+- Global context providers: [contexts.md](contexts.md)
+- Next.js pages: [pages.md](pages.md)
+
+## Package-Specific Conventions
+
+- For apps/squareone: [squareone.md](squareone.md)
+- For packages/squared: [squared.md](squared.md)
+
+## Important Notes
+
+1. **Always use the tool** - Never manually create component directories
+2. **Component-scoped contexts** - Use `--with-context`, not the `context` command
+3. **Global contexts** - Use the `context` command for app-wide state
+4. **Barrel updates** - For squared package, exports are automatically added to `src/index.ts`
+5. **Naming conventions**:
+   - Components: PascalCase (Button, DataTable)
+   - Hooks: camelCase with `use` prefix (useDebounce)
+   - Contexts: Input "Theme" → generates ThemeContext, ThemeProvider, useTheme
+
+## Example Workflows
+
+### Adding a component to squared (component library):
+
+```bash
+pnpm file-factory component Alert --package squared --with-story
+# Creates: packages/squared/src/components/Alert/
+# Auto-updates: src/components/index.ts and src/index.ts with exports
+```
+
+### Adding a complex component with state to squareone:
+
+```bash
+pnpm file-factory component Wizard --with-context --package squareone
+# Creates: apps/squareone/src/components/Wizard/
+# Includes: Wizard.tsx, WizardContext.tsx (with WizardProvider + useWizard)
+```
+
+### Adding a global theme context to squareone:
+
+```bash
+pnpm file-factory context Theme --package squareone
+# Creates: apps/squareone/src/contexts/ThemeContext/
+# Use ThemeProvider in _app.tsx, useTheme() in components
+```
+
+## Related Skills
+
+After scaffolding files with file-factory, use these skills for implementation guidance:
+
+- **component-creation** - TypeScript patterns, CSS Modules conventions, and implementation details for components
+- **squared-package** - Architecture constraints for squared components (NO BUILD STEP, CSS Modules only)
+- **design-system** - Complete CSS variable and design token reference for styling
+- **testing-infrastructure** - Testing patterns for generated test files

--- a/.claude/skills/file-factory/components.md
+++ b/.claude/skills/file-factory/components.md
@@ -1,0 +1,58 @@
+# Creating a new component
+
+```bash
+# Basic component (CSS Modules by default)
+pnpm file-factory component Button --package squareone
+
+# Component with its own scoped context
+pnpm file-factory component DataTable --with-context --package squareone
+
+# With Storybook story
+pnpm file-factory component Card --with-story --package squared
+
+# Without test file
+pnpm file-factory component Modal --no-test --package squareone
+
+# Override style system
+pnpm file-factory component Modal --style styled-components --package squared
+```
+
+## Command reference
+
+| Option                 | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| `--with-context`       | Include a component-scoped context                            |
+| `--with-test`          | Include test file (default from config)                       |
+| `--no-test`            | Exclude test file                                             |
+| `--with-story`         | Include Storybook story                                       |
+| `--no-story`           | Exclude Storybook story                                       |
+| `--style <system>`     | Style system: `css-modules`, `styled-components`, `tailwind`, `none` |
+| `-p, --package <name>` | Target package (e.g., `squared`, `squareone`)                 |
+| `--dry-run`            | Show what would be created without writing files              |
+| `-v, --verbose`        | Verbose output                                                |
+
+## File structures
+
+**Basic component structure:**
+
+```
+src/components/Button/
+├── Button.tsx           # Main component
+├── Button.module.css    # CSS Module styles (when using css-modules)
+├── Button.test.tsx      # Test file (when withTest is true)
+├── Button.stories.tsx   # Storybook story (when withStory is true)
+└── index.ts             # Barrel file
+```
+
+**Component with context structure (`--with-context`):**
+
+```
+src/components/DataTable/
+├── DataTable.tsx            # Main component
+├── DataTableContext.tsx     # Scoped context (Provider + useDataTable hook)
+├── DataTable.module.css     # CSS Module styles
+├── DataTable.test.tsx       # Test file
+└── index.ts                 # Exports component, provider, and hook
+```
+
+For details on coding conventions for components, see the [component-creation](../component-creation/SKILL.md) Claude Skill.

--- a/.claude/skills/file-factory/configuration.md
+++ b/.claude/skills/file-factory/configuration.md
@@ -1,0 +1,57 @@
+# Configuring file-factory for specific apps and packages
+
+The .file-factory directory in each project/app provides customizations and configurations for file creation.
+
+## Template Customization
+
+Each package can override templates in `.file-factory/templates/`. The directory structure mirrors the output:
+
+```
+.file-factory/
+├── config.mts          # Use .mts for Next.js apps
+└── templates/
+    └── component/
+        └── {{ComponentName}}/
+            ├── {{ComponentName}}.tsx.ejs    # Custom component template
+            └── index.ts.ejs
+```
+
+## Configuration File
+
+Create `.file-factory/config.mts` (or `config.ts`) in your package.
+
+**Recommended**: Use `.mts` extension for packages without `"type": "module"` in package.json (like Next.js apps). The `.mts` extension explicitly marks the file as an ES module.
+
+**Note**: The `defineConfig` import is optional - you can export a plain object. The CLI validates configs with Zod after loading. Use `defineConfig` only when you need TypeScript type hints during authoring in packages with `@lsst-sqre/file-factory` installed as a dependency.
+
+```typescript
+// Plain object export (recommended for apps like squareone)
+export default {
+  component: {
+    directory: "src/components",
+    styleSystem: "css-modules",
+    withTest: true,
+    withStory: true,
+    appRouterBarrel: false,
+    updateBarrels: [
+      {
+        file: "src/index.ts",
+        template: "export * from './components/{{ComponentName}}';\n",
+        position: "alphabetical",
+      },
+    ],
+  },
+  hook: {
+    directory: "src/hooks",
+    withTest: true,
+    useDirectory: true,
+  },
+  context: {
+    directory: "src/contexts",
+  },
+  page: {
+    directory: "src/pages",
+    router: "pages",
+  },
+};
+```

--- a/.claude/skills/file-factory/contexts.md
+++ b/.claude/skills/file-factory/contexts.md
@@ -1,0 +1,33 @@
+# Create a Global Context
+
+Use this for **app-wide contexts** like Theme, Auth, or Config. For component-scoped contexts, use `--with-context` on the component command instead (see components.md).
+
+```bash
+pnpm file-factory context Theme --package squareone
+pnpm file-factory context RSPConfig --package squareone
+```
+
+## Command Options
+
+| Option                 | Description                                       |
+| ---------------------- | ------------------------------------------------- |
+| `-p, --package <name>` | Target package (e.g., `squared`, `squareone`)     |
+| `--dry-run`            | Show what would be created without writing files  |
+| `-v, --verbose`        | Verbose output                                    |
+
+## File structures
+
+**Generated structure:**
+
+```
+src/contexts/ThemeContext/
+├── ThemeContext.tsx     # ThemeProvider + useTheme hook
+└── index.ts             # Exports provider, hook, and types
+```
+
+**What's exported:**
+
+- `ThemeProvider` - The provider component
+- `useTheme` - The consumer hook
+- `ThemeContextValue` - TypeScript type
+- **NOT** the raw `ThemeContext` (encapsulated)

--- a/.claude/skills/file-factory/hooks.md
+++ b/.claude/skills/file-factory/hooks.md
@@ -1,0 +1,39 @@
+# Creating a new React hook
+
+```bash
+# Hook with directory (default)
+pnpm file-factory hook useDebounce --package squareone
+
+# Hook as a flat file (no directory)
+pnpm file-factory hook useLocalStorage --flat-file --package squared
+```
+
+## Command reference
+
+| Option                 | Description                                           |
+| ---------------------- | ----------------------------------------------------- |
+| `--flat-file`          | Create hook as a flat file instead of a directory     |
+| `--with-test`          | Include test file (default from config)               |
+| `--no-test`            | Exclude test file                                     |
+| `-p, --package <name>` | Target package (e.g., `squared`, `squareone`)         |
+| `--dry-run`            | Show what would be created without writing files      |
+| `-v, --verbose`        | Verbose output                                        |
+
+## File structures
+
+**Directory structure (default):**
+
+```
+src/hooks/useDebounce/
+├── useDebounce.ts
+├── useDebounce.test.ts
+└── index.ts
+```
+
+**Flat structure (`--flat-file`):**
+
+```
+src/hooks/
+├── useLocalStorage.ts
+└── useLocalStorage.test.ts
+```

--- a/.claude/skills/file-factory/pages.md
+++ b/.claude/skills/file-factory/pages.md
@@ -1,0 +1,33 @@
+# Create Next.js pages
+
+```bash
+# Pages Router (current squareone setup)
+pnpm file-factory page dashboard --package squareone
+pnpm file-factory page dashboard/settings --package squareone
+
+# App Router (for future migration)
+pnpm file-factory page dashboard --router app --package squareone
+```
+
+## Command options
+
+| Option                 | Description                                       |
+| ---------------------- | ------------------------------------------------- |
+| `--router <type>`      | Router type: `app` or `pages`                     |
+| `-p, --package <name>` | Target package (e.g., `squared`, `squareone`)     |
+| `--dry-run`            | Show what would be created without writing files  |
+| `-v, --verbose`        | Verbose output                                    |
+
+## File structures
+
+**Pages Router structure:**
+
+```
+src/pages/dashboard/settings.tsx
+```
+
+**App Router structure:**
+
+```
+src/app/dashboard/settings/page.tsx
+```

--- a/.claude/skills/file-factory/squared.md
+++ b/.claude/skills/file-factory/squared.md
@@ -1,0 +1,7 @@
+### @lsst-sqre/squared file factory conventions
+
+- **CSS Modules** (required - NO styled-components in squared)
+- Generates **Storybook stories** by default
+- **Automatic barrel updates** - adds exports to `src/index.ts`
+- Full test coverage
+- **Config file**: Uses `.mts` extension (`.file-factory/config.mts`) for ESM compatibility

--- a/.claude/skills/file-factory/squareone.md
+++ b/.claude/skills/file-factory/squareone.md
@@ -1,0 +1,8 @@
+### apps/squareone file factory conventions
+
+- **CSS Modules** (default)
+- **Pages Router** (currently)
+- Components at `src/components/`
+- Global contexts at `src/contexts/`
+- No automatic barrel updates
+- **Config file**: Uses `.mts` extension (`.file-factory/config.mts`) for ESM compatibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ For detailed guidance on specific topics, Claude has access to specialized skill
 - **platform-api-integration** - OpenAPI specs, API discovery, hook patterns, authentication
 - **migrate-styled-components-to-css-modules** - Converting styled-components to CSS Modules
 - **docker-version-validation** - Dockerfile version synchronization, validation rules, troubleshooting
+- **file-factory** - CLI scaffolding for components, hooks, contexts, pages with consistent structure
 
 These skills automatically activate when relevant or can be referenced explicitly. See `.claude/README.md` for complete skill documentation.
 

--- a/apps/squareone/.file-factory/config.mts
+++ b/apps/squareone/.file-factory/config.mts
@@ -1,0 +1,23 @@
+// Export plain object - defineConfig import not needed, loader validates config
+export default {
+  component: {
+    directory: 'src/components',
+    styleSystem: 'css-modules',
+    withTest: true,
+    withStory: false,
+    appRouterBarrel: false, // Still on Pages Router
+  },
+  hook: {
+    directory: 'src/hooks',
+    withTest: true,
+    useDirectory: false,
+  },
+  context: {
+    directory: 'src/contexts',
+    withTest: true,
+  },
+  page: {
+    directory: 'src/pages',
+    router: 'pages', // Currently using Pages Router
+  },
+};

--- a/apps/squareone/.file-factory/templates/component/{{ComponentName}}/_when_withCssModules_{{ComponentName}}.module.css.ejs
+++ b/apps/squareone/.file-factory/templates/component/{{ComponentName}}/_when_withCssModules_{{ComponentName}}.module.css.ejs
@@ -1,0 +1,7 @@
+/**
+ * <%= ComponentName %> styles
+ */
+
+.root {
+  /* Add styles here */
+}

--- a/apps/squareone/.file-factory/templates/component/{{ComponentName}}/_when_withTest_{{ComponentName}}.test.tsx.ejs
+++ b/apps/squareone/.file-factory/templates/component/{{ComponentName}}/_when_withTest_{{ComponentName}}.test.tsx.ejs
@@ -1,0 +1,12 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import <%= ComponentName %> from './<%= ComponentName %>';
+
+describe('<%= ComponentName %>', () => {
+  it('renders', () => {
+    render(<<%= ComponentName %> />);
+    // Add assertions based on component behavior
+  });
+});

--- a/apps/squareone/.file-factory/templates/component/{{ComponentName}}/index.ts.ejs
+++ b/apps/squareone/.file-factory/templates/component/{{ComponentName}}/index.ts.ejs
@@ -1,0 +1,8 @@
+<% if (appRouterBarrel) { -%>
+// App Router compatible barrel (no wildcard exports)
+export { default } from './<%= ComponentName %>';
+export type { <%= ComponentName %>Props } from './<%= ComponentName %>';
+<% } else { -%>
+export * from './<%= ComponentName %>';
+export { default } from './<%= ComponentName %>';
+<% } -%>

--- a/apps/squareone/.file-factory/templates/component/{{ComponentName}}/{{ComponentName}}.tsx.ejs
+++ b/apps/squareone/.file-factory/templates/component/{{ComponentName}}/{{ComponentName}}.tsx.ejs
@@ -1,0 +1,56 @@
+<% if (styleSystem === 'css-modules') { -%>
+import styles from './<%= ComponentName %>.module.css';
+<% } else if (styleSystem === 'styled-components') { -%>
+import styled from 'styled-components';
+<% } -%>
+
+export type <%= ComponentName %>Props = {
+  /** Optional className for styling overrides */
+  className?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * <%= ComponentName %> component
+ *
+ * @example
+ * ```tsx
+ * <<%= ComponentName %>>Content</<%= ComponentName %>>
+ * ```
+ */
+export function <%= ComponentName %>({
+  className,
+  children,
+}: <%= ComponentName %>Props) {
+<% if (styleSystem === 'css-modules') { -%>
+  const rootClassName = className
+    ? `${styles.root} ${className}`
+    : styles.root;
+
+  return (
+    <div className={rootClassName}>
+      {children}
+    </div>
+  );
+<% } else if (styleSystem === 'styled-components') { -%>
+  return (
+    <Root className={className}>
+      {children}
+    </Root>
+  );
+<% } else { -%>
+  return (
+    <div className={className}>
+      {children}
+    </div>
+  );
+<% } -%>
+}
+<% if (styleSystem === 'styled-components') { -%>
+
+const Root = styled.div`
+  /* Add styles here */
+`;
+<% } -%>
+
+export default <%= ComponentName %>;

--- a/apps/squareone/.file-factory/templates/context/{{ContextName}}/_when_withTest_{{ContextName}}.test.tsx.ejs
+++ b/apps/squareone/.file-factory/templates/context/{{ContextName}}/_when_withTest_{{ContextName}}.test.tsx.ejs
@@ -1,0 +1,20 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { <%= ProviderName %>, <%= consumerHookName %> } from './<%= ContextName %>';
+
+function TestConsumer() {
+  const value = <%= consumerHookName %>();
+  return <div data-testid="value">{JSON.stringify(value)}</div>;
+}
+
+describe('<%= ContextName %>', () => {
+  it('provides value to consumers', () => {
+    render(
+      <<%= ProviderName %>>
+        <TestConsumer />
+      </<%= ProviderName %>>
+    );
+    expect(screen.getByTestId('value')).toBeInTheDocument();
+  });
+});

--- a/apps/squareone/.file-factory/templates/context/{{ContextName}}/index.ts.ejs
+++ b/apps/squareone/.file-factory/templates/context/{{ContextName}}/index.ts.ejs
@@ -1,0 +1,6 @@
+// Export Provider, hook, and types - NOT the raw context
+export { <%= ProviderName %>, <%= consumerHookName %> } from './<%= ContextName %>';
+export type {
+  <%= ContextName %>Value,
+  <%= ProviderName %>Props,
+} from './<%= ContextName %>';

--- a/apps/squareone/.file-factory/templates/context/{{ContextName}}/{{ContextName}}.tsx.ejs
+++ b/apps/squareone/.file-factory/templates/context/{{ContextName}}/{{ContextName}}.tsx.ejs
@@ -1,0 +1,103 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  type ReactNode,
+} from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type <%= ContextName %>State = {
+  // Add state properties here
+};
+
+type <%= ContextName %>Actions = {
+  // Add action methods here
+};
+
+export type <%= ContextName %>Value = <%= ContextName %>State & <%= ContextName %>Actions;
+
+export type <%= ProviderName %>Props = {
+  children: ReactNode;
+  /** Optional initial state override */
+  initialState?: Partial<<%= ContextName %>State>;
+};
+
+// ============================================================================
+// Context (internal - use the hook instead)
+// ============================================================================
+
+const <%= ContextName %> = createContext<<%= ContextName %>Value | null>(null);
+<%= ContextName %>.displayName = '<%= ContextName %>';
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+/**
+ * <%= ProviderName %> - Provides <%= contextDisplayName %> state to the app
+ *
+ * @example
+ * ```tsx
+ * // In your app root
+ * <<%= ProviderName %>>
+ *   <App />
+ * </<%= ProviderName %>>
+ * ```
+ */
+export function <%= ProviderName %>({
+  children,
+  initialState = {},
+}: <%= ProviderName %>Props) {
+  const [state, setState] = useState<<%= ContextName %>State>({
+    // Default state
+    ...initialState,
+  });
+
+  const value = useMemo<<%= ContextName %>Value>(
+    () => ({
+      ...state,
+      // Add actions here
+    }),
+    [state]
+  );
+
+  return (
+    <<%= ContextName %>.Provider value={value}>
+      {children}
+    </<%= ContextName %>.Provider>
+  );
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * <%= consumerHookName %> - Access <%= contextDisplayName %> state
+ *
+ * Must be used within a <%= ProviderName %>
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { someValue } = <%= consumerHookName %>();
+ *   // ...
+ * }
+ * ```
+ */
+export function <%= consumerHookName %>(): <%= ContextName %>Value {
+  const context = useContext(<%= ContextName %>);
+
+  if (context === null) {
+    throw new Error(
+      '<%= consumerHookName %> must be used within a <%= ProviderName %>. ' +
+      'Wrap your component tree with <<%= ProviderName %>> to fix this error.'
+    );
+  }
+
+  return context;
+}

--- a/apps/squareone/.file-factory/templates/hook/_when_withTest_{{hookName}}.test.ts.ejs
+++ b/apps/squareone/.file-factory/templates/hook/_when_withTest_{{hookName}}.test.ts.ejs
@@ -1,0 +1,10 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { <%= hookName %> } from './<%= hookName %>';
+
+describe('<%= hookName %>', () => {
+  it('returns expected value', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+    expect(result.current).toBeDefined();
+  });
+});

--- a/apps/squareone/.file-factory/templates/hook/{{hookName}}.ts.ejs
+++ b/apps/squareone/.file-factory/templates/hook/{{hookName}}.ts.ejs
@@ -1,0 +1,28 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * <%= hookName %> hook
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { value, setValue, reset } = <%= hookName %>();
+ *   // ...
+ * }
+ * ```
+ */
+export function <%= hookName %>() {
+  const [value, setValue] = useState<unknown>(null);
+
+  const reset = useCallback(() => {
+    setValue(null);
+  }, []);
+
+  return {
+    value,
+    setValue,
+    reset,
+  } as const;
+}
+
+export default <%= hookName %>;

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,7 @@
     "defaultBranch": "main"
   },
   "files": {
-    "includes": ["**", "!!**/package.json"]
+    "includes": ["**", "!!**/package.json", "!**/*.ejs"]
   },
   "formatter": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "localci": "node scripts/validate-docker-versions.js && node scripts/turbo-wrapper.js run biome:format:check prettier:yaml lint type-check test build && pnpm run biome:lint",
     "build": "node scripts/turbo-wrapper.js run build",
+    "file-factory": "node packages/file-factory/dist/cli.js",
     "dev": "node scripts/turbo-wrapper.js run dev",
     "test": "node scripts/turbo-wrapper.js run test",
     "storybook": "node scripts/turbo-wrapper.js run storybook",

--- a/packages/file-factory/README.md
+++ b/packages/file-factory/README.md
@@ -1,0 +1,264 @@
+# @lsst-sqre/file-factory
+
+CLI tool to scaffold React components, hooks, context providers, and Next.js pages in the Squareone monorepo.
+
+## Features
+
+- **Directory-as-template pattern** - Templates mirror the output structure (like cookiecutter)
+- **Component directory pattern** - `ComponentName/ComponentName.tsx` + `index.ts` barrel
+- **Component-scoped contexts** - Create components with their own context using `--with-context`
+- **Automatic barrel updates** - Keeps index files in sync with new exports
+- **App Router support** - Handles barrel file quirks (`export { default }` only)
+- **CSS Modules by default** - Modern styling approach with design tokens
+- **TypeScript throughout** - Full type safety with Zod configuration validation
+- **Package-specific configuration** - Each package can define its own templates and settings
+
+## Installation
+
+The package is installed as part of the monorepo workspace:
+
+```bash
+pnpm install
+```
+
+## Quick Start
+
+```bash
+# Create a component
+pnpm file-factory component Button --package apps/squareone
+
+# Create a component with context
+pnpm file-factory component DataTable --with-context --package apps/squareone
+
+# Create a hook
+pnpm file-factory hook useDebounce --package apps/squareone
+
+# Create a global context
+pnpm file-factory context Theme --package apps/squareone
+
+# Create a page
+pnpm file-factory page dashboard/settings --package apps/squareone
+```
+
+## CLI Commands
+
+### `file-factory component [name]`
+
+Create a new React component.
+
+```bash
+Options:
+  -p, --package <package>  Target package
+  --with-context          Include component-scoped context
+  --with-test             Include test file
+  --no-test               Exclude test file
+  --with-story            Include Storybook story
+  --style <system>        Style system (css-modules, styled-components, tailwind, none)
+  --dry-run               Preview without creating files
+  -v, --verbose           Verbose output
+```
+
+### `file-factory hook [name]`
+
+Create a new React hook. By default, hooks are created in their own directory with a barrel file for cleaner imports and co-located tests.
+
+```bash
+Options:
+  -p, --package <package>  Target package
+  --flat-file             Create hook as flat file (no directory)
+  --with-test             Include test file
+  --no-test               Exclude test file
+  --dry-run               Preview without creating files
+```
+
+### `file-factory context [name]`
+
+Create a new global React context.
+
+```bash
+Options:
+  -p, --package <package>  Target package
+  --with-test             Include test file
+  --dry-run               Preview without creating files
+```
+
+### `file-factory page [path]`
+
+Create a new Next.js page.
+
+```bash
+Options:
+  -p, --package <package>  Target package
+  --router <type>         Router type (app, pages)
+  --dry-run               Preview without creating files
+```
+
+## Configuration
+
+Create `.file-factory/config.ts` in your package:
+
+```typescript
+import { defineConfig } from '@lsst-sqre/file-factory';
+
+export default defineConfig({
+  component: {
+    directory: 'src/components',
+    styleSystem: 'css-modules',
+    withTest: true,
+    withStory: false,
+    appRouterBarrel: true,
+    updateBarrels: [],
+  },
+  hook: {
+    directory: 'src/hooks',
+    withTest: true,
+    useDirectory: true,
+    updateBarrels: [],
+  },
+  context: {
+    directory: 'src/contexts',
+    withTest: false,
+    updateBarrels: [],
+  },
+  page: {
+    directory: 'src/pages',
+    router: 'pages',
+  },
+});
+```
+
+### Configuration Options
+
+#### Component Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `directory` | `string` | `'src/components'` | Components directory |
+| `styleSystem` | `'css-modules' \| 'styled-components' \| 'tailwind' \| 'none'` | `'css-modules'` | Style system |
+| `withTest` | `boolean` | `true` | Generate test files |
+| `withStory` | `boolean` | `false` | Generate Storybook stories |
+| `appRouterBarrel` | `boolean` | `true` | Use App Router barrel pattern |
+| `updateBarrels` | `BarrelUpdate[]` | `[]` | Barrel files to update |
+
+#### Hook Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `directory` | `string` | `'src/hooks'` | Hooks directory |
+| `withTest` | `boolean` | `true` | Generate test files |
+| `useDirectory` | `boolean` | `true` | Create hooks in their own directory |
+| `updateBarrels` | `BarrelUpdate[]` | `[]` | Barrel files to update |
+
+#### Context Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `directory` | `string` | `'src/contexts'` | Contexts directory |
+| `withTest` | `boolean` | `false` | Generate test files |
+| `updateBarrels` | `BarrelUpdate[]` | `[]` | Barrel files to update |
+
+#### Page Configuration
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `directory` | `string` | `'src/pages'` | Pages directory |
+| `router` | `'app' \| 'pages'` | `'pages'` | Next.js router type |
+
+### Barrel Updates
+
+Automatically update index files when creating new artifacts:
+
+```typescript
+updateBarrels: [
+  {
+    file: 'src/index.ts',
+    template: "export * from './components/{{ComponentName}}';\n",
+    position: 'alphabetical', // 'append' | 'prepend' | 'alphabetical'
+    skipIfExists: true,
+  },
+],
+```
+
+## Custom Templates
+
+Override default templates by creating `.file-factory/templates/<type>/` in your package.
+
+### Template Resolution Order
+
+1. Package's `.file-factory/templates/<type>/`
+2. Monorepo root's `.file-factory/templates/<type>/`
+3. Built-in default templates
+
+### Template Variables
+
+| Variable | Example Input | Example Output |
+|----------|---------------|----------------|
+| `{{ComponentName}}` | "DataTable" | "DataTable" |
+| `{{componentName}}` | "DataTable" | "dataTable" |
+| `{{component-name}}` | "DataTable" | "data-table" |
+| `{{hookName}}` | "useLocalStorage" | "useLocalStorage" |
+| `{{ContextName}}` | "Theme" | "ThemeContext" |
+| `{{ProviderName}}` | "Theme" | "ThemeProvider" |
+| `{{consumerHookName}}` | "Theme" | "useTheme" |
+
+### Conditional Files
+
+Use `_when_<condition>_` prefix for conditional files:
+
+```
+component/
+└── {{ComponentName}}/
+    ├── {{ComponentName}}.tsx.ejs                    # Always included
+    ├── _when_withTest_{{ComponentName}}.test.tsx.ejs   # Only with --with-test
+    ├── _when_withStory_{{ComponentName}}.stories.tsx.ejs # Only with --with-story
+    └── index.ts.ejs
+```
+
+## Programmatic API
+
+```typescript
+import {
+  generateComponent,
+  generateHook,
+  generateContext,
+  generatePage,
+  loadConfig,
+  createGeneratorOptions,
+} from '@lsst-sqre/file-factory';
+
+// Load configuration
+const configResult = await loadConfig({
+  packageRoot: '/path/to/package',
+});
+
+// Create generator options
+const options = createGeneratorOptions('Button', configResult, {
+  verbose: true,
+});
+
+// Generate component
+const result = await generateComponent({
+  ...options,
+  withContext: true,
+  withStory: true,
+});
+
+console.log(result.files); // Created files
+```
+
+## Development
+
+```bash
+# Build the package
+pnpm build --filter @lsst-sqre/file-factory
+
+# Run tests
+pnpm test --filter @lsst-sqre/file-factory
+
+# Watch mode
+pnpm dev --filter @lsst-sqre/file-factory
+```
+
+## License
+
+MIT

--- a/packages/file-factory/package.json
+++ b/packages/file-factory/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@lsst-sqre/file-factory",
+  "version": "0.1.0",
+  "description": "CLI tool to scaffold React components, hooks, contexts, and pages in the Squareone monorepo",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "bin": {
+    "file-factory": "./dist/cli.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./config": {
+      "types": "./dist/config/index.d.ts",
+      "import": "./dist/config/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "templates"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "keywords": [
+    "cli",
+    "scaffold",
+    "react",
+    "component",
+    "generator",
+    "squareone",
+    "rubin"
+  ],
+  "author": "Association of Universities for Research in Astronomy (AURA), Inc.",
+  "license": "MIT",
+  "dependencies": {
+    "@inquirer/prompts": "^7.2.1",
+    "chalk": "^5.4.1",
+    "commander": "^13.0.0",
+    "ejs": "^3.1.10",
+    "fast-glob": "^3.3.3",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "@lsst-sqre/tsconfig": "workspace:*",
+    "@types/ejs": "^3.1.5",
+    "@types/node": "^22.10.1",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/file-factory/src/cli.ts
+++ b/packages/file-factory/src/cli.ts
@@ -1,0 +1,306 @@
+import { confirm, input, select } from '@inquirer/prompts';
+import chalk from 'chalk';
+import { Command } from 'commander';
+import {
+  findMonorepoRoot,
+  loadConfig,
+  resolvePackageDir,
+} from './config/index.js';
+import type { Router, StyleSystem } from './config/schema.js';
+import {
+  createGeneratorOptions,
+  generateComponent,
+  generateContext,
+  generateHook,
+  generatePage,
+} from './generators/index.js';
+
+const program = new Command();
+
+// Package version - will be replaced during build
+const VERSION = '0.1.0';
+
+program
+  .name('file-factory')
+  .description(
+    'CLI tool to scaffold React components, hooks, contexts, and pages'
+  )
+  .version(VERSION);
+
+/**
+ * Resolve package root from CLI options
+ */
+async function resolvePackageRoot(packageOption?: string): Promise<string> {
+  const cwd = process.cwd();
+  const monorepoRoot = findMonorepoRoot(cwd);
+
+  if (packageOption && monorepoRoot) {
+    const resolved = resolvePackageDir(packageOption, monorepoRoot);
+    if (!resolved) {
+      console.error(chalk.red(`Could not find package: ${packageOption}`));
+      process.exit(1);
+    }
+    return resolved;
+  }
+
+  // Use current directory's package
+  return cwd;
+}
+
+/**
+ * Print generation results
+ */
+function printResults(
+  type: string,
+  name: string,
+  result: { success: boolean; files: string[]; error?: string }
+): void {
+  if (result.success) {
+    console.log(chalk.green(`\n✓ Created ${type}: ${name}`));
+    console.log(chalk.dim('\nFiles created:'));
+    for (const file of result.files) {
+      console.log(chalk.dim(`  ${file}`));
+    }
+  } else {
+    console.error(chalk.red(`\n✗ Failed to create ${type}: ${name}`));
+    if (result.error) {
+      console.error(chalk.red(`  ${result.error}`));
+    }
+    process.exit(1);
+  }
+}
+
+// ============================================================================
+// Component Command
+// ============================================================================
+
+program
+  .command('component [name]')
+  .description('Create a new React component')
+  .option(
+    '-p, --package <package>',
+    'Target package (e.g., @lsst-sqre/squared)'
+  )
+  .option('--with-context', 'Include a component-scoped context')
+  .option('--with-test', 'Include test file (default from config)')
+  .option('--no-test', 'Exclude test file')
+  .option('--with-story', 'Include Storybook story')
+  .option('--no-story', 'Exclude Storybook story')
+  .option(
+    '--style <system>',
+    'Style system (css-modules, styled-components, tailwind, none)'
+  )
+  .option('--dry-run', 'Show what would be created without writing files')
+  .option('-v, --verbose', 'Verbose output')
+  .action(async (name: string | undefined, options) => {
+    // Interactive mode if no name provided
+    if (!name) {
+      name = await input({
+        message: 'Component name (PascalCase):',
+        validate: (value) =>
+          value.length > 0 ? true : 'Component name is required',
+      });
+
+      const withContext = await confirm({
+        message: 'Include a component-scoped context?',
+        default: false,
+      });
+
+      options.withContext = withContext;
+    }
+
+    const packageRoot = await resolvePackageRoot(options.package);
+    const configResult = await loadConfig({ packageRoot });
+
+    const generatorOptions = createGeneratorOptions(name, configResult, {
+      dryRun: options.dryRun,
+      verbose: options.verbose,
+    });
+
+    const result = await generateComponent({
+      ...generatorOptions,
+      withContext: options.withContext,
+      withTest: options.test,
+      withStory: options.story ?? options.withStory,
+      styleSystem: options.style as StyleSystem | undefined,
+    });
+
+    printResults('component', name, result);
+  });
+
+// ============================================================================
+// Hook Command
+// ============================================================================
+
+program
+  .command('hook [name]')
+  .description('Create a new React hook')
+  .option(
+    '-p, --package <package>',
+    'Target package (e.g., @lsst-sqre/squared)'
+  )
+  .option('--flat-file', 'Create hook as a flat file instead of a directory')
+  .option('--with-test', 'Include test file (default from config)')
+  .option('--no-test', 'Exclude test file')
+  .option('--dry-run', 'Show what would be created without writing files')
+  .option('-v, --verbose', 'Verbose output')
+  .action(async (name: string | undefined, options) => {
+    // Interactive mode if no name provided
+    if (!name) {
+      name = await input({
+        message: 'Hook name (useXxx):',
+        validate: (value) =>
+          value.length > 0 ? true : 'Hook name is required',
+      });
+    }
+
+    const packageRoot = await resolvePackageRoot(options.package);
+    const configResult = await loadConfig({ packageRoot });
+
+    const generatorOptions = createGeneratorOptions(name, configResult, {
+      dryRun: options.dryRun,
+      verbose: options.verbose,
+    });
+
+    const result = await generateHook({
+      ...generatorOptions,
+      flatFile: options.flatFile,
+      withTest: options.test,
+    });
+
+    printResults('hook', name, result);
+  });
+
+// ============================================================================
+// Context Command
+// ============================================================================
+
+program
+  .command('context [name]')
+  .description('Create a new global React context')
+  .option(
+    '-p, --package <package>',
+    'Target package (e.g., @lsst-sqre/squared)'
+  )
+  .option('--with-test', 'Include test file')
+  .option('--no-test', 'Exclude test file')
+  .option('--dry-run', 'Show what would be created without writing files')
+  .option('-v, --verbose', 'Verbose output')
+  .action(async (name: string | undefined, options) => {
+    // Interactive mode if no name provided
+    if (!name) {
+      name = await input({
+        message: 'Context name (e.g., Theme, Auth):',
+        validate: (value) =>
+          value.length > 0 ? true : 'Context name is required',
+      });
+    }
+
+    const packageRoot = await resolvePackageRoot(options.package);
+    const configResult = await loadConfig({ packageRoot });
+
+    const generatorOptions = createGeneratorOptions(name, configResult, {
+      dryRun: options.dryRun,
+      verbose: options.verbose,
+    });
+
+    const result = await generateContext({
+      ...generatorOptions,
+      withTest: options.test,
+    });
+
+    printResults('context', name, result);
+  });
+
+// ============================================================================
+// Page Command
+// ============================================================================
+
+program
+  .command('page [path]')
+  .description('Create a new Next.js page')
+  .option('-p, --package <package>', 'Target package (e.g., apps/squareone)')
+  .option('--router <type>', 'Router type (app, pages)')
+  .option('--dry-run', 'Show what would be created without writing files')
+  .option('-v, --verbose', 'Verbose output')
+  .action(async (pagePath: string | undefined, options) => {
+    // Interactive mode if no path provided
+    if (!pagePath) {
+      pagePath = await input({
+        message: 'Page path (e.g., dashboard/settings):',
+        validate: (value) =>
+          value.length > 0 ? true : 'Page path is required',
+      });
+
+      if (!options.router) {
+        options.router = await select({
+          message: 'Router type:',
+          choices: [
+            { name: 'Pages Router', value: 'pages' },
+            { name: 'App Router', value: 'app' },
+          ],
+        });
+      }
+    }
+
+    const packageRoot = await resolvePackageRoot(options.package);
+    const configResult = await loadConfig({ packageRoot });
+
+    const generatorOptions = createGeneratorOptions(pagePath, configResult, {
+      dryRun: options.dryRun,
+      verbose: options.verbose,
+    });
+
+    const result = await generatePage({
+      ...generatorOptions,
+      router: options.router as Router | undefined,
+    });
+
+    printResults('page', pagePath, result);
+  });
+
+// ============================================================================
+// Interactive Mode (default)
+// ============================================================================
+
+program
+  .command('create', { isDefault: true })
+  .description('Interactive mode to create any artifact')
+  .option('-p, --package <package>', 'Target package')
+  .action(async (options) => {
+    const artifactType = await select({
+      message: 'What would you like to create?',
+      choices: [
+        { name: 'Component', value: 'component' },
+        { name: 'Hook', value: 'hook' },
+        { name: 'Context (global)', value: 'context' },
+        { name: 'Page', value: 'page' },
+      ],
+    });
+
+    // Delegate to the appropriate command
+    const args = options.package ? ['-p', options.package] : [];
+
+    switch (artifactType) {
+      case 'component':
+        await program.parseAsync([
+          'node',
+          'file-factory',
+          'component',
+          ...args,
+        ]);
+        break;
+      case 'hook':
+        await program.parseAsync(['node', 'file-factory', 'hook', ...args]);
+        break;
+      case 'context':
+        await program.parseAsync(['node', 'file-factory', 'context', ...args]);
+        break;
+      case 'page':
+        await program.parseAsync(['node', 'file-factory', 'page', ...args]);
+        break;
+    }
+  });
+
+// Parse CLI arguments
+program.parse();

--- a/packages/file-factory/src/config/defaults.ts
+++ b/packages/file-factory/src/config/defaults.ts
@@ -1,0 +1,34 @@
+import type { FileFactoryConfig } from './schema.js';
+
+/**
+ * Default configuration for file-factory
+ *
+ * These defaults are used when no configuration file is found
+ * or for any values not specified in the configuration.
+ */
+export const defaultConfig: FileFactoryConfig = {
+  component: {
+    directory: 'src/components',
+    styleSystem: 'css-modules',
+    withTest: true,
+    withStory: false,
+    appRouterBarrel: true,
+    updateBarrels: [],
+  },
+  hook: {
+    directory: 'src/hooks',
+    withTest: true,
+    useDirectory: false,
+    updateBarrels: [],
+  },
+  context: {
+    directory: 'src/contexts',
+    withTest: false,
+    updateBarrels: [],
+  },
+  page: {
+    directory: 'src/pages',
+    router: 'pages',
+  },
+  hooks: {},
+};

--- a/packages/file-factory/src/config/index.ts
+++ b/packages/file-factory/src/config/index.ts
@@ -1,0 +1,40 @@
+// Schema and types
+
+// Defaults
+export { defaultConfig } from './defaults.js';
+export type { LoadConfigOptions, LoadConfigResult } from './loader.js';
+// Loader
+export {
+  findMonorepoRoot,
+  findPackageRoot,
+  findTemplatesDir,
+  loadConfig,
+  resolvePackageDir,
+} from './loader.js';
+export type {
+  ArtifactCreationResult,
+  BarrelUpdate,
+  ComponentConfig,
+  ContextConfig,
+  FileFactoryConfig,
+  HookConfig,
+  HooksConfig,
+  PageConfig,
+  Router,
+  StyleSystem,
+} from './schema.js';
+export {
+  ArtifactCreationResultSchema,
+  BarrelUpdateSchema,
+  ComponentConfigSchema,
+  ContextConfigSchema,
+  defineConfig,
+  FileFactoryConfigSchema,
+  HookConfigSchema,
+  HooksConfigSchema,
+  PageConfigSchema,
+  parseConfig,
+  RouterSchema,
+  StyleSystemSchema,
+  safeParseConfig,
+} from './schema.js';

--- a/packages/file-factory/src/config/loader.ts
+++ b/packages/file-factory/src/config/loader.ts
@@ -1,0 +1,317 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { defaultConfig } from './defaults.js';
+import { type FileFactoryConfig, FileFactoryConfigSchema } from './schema.js';
+
+/**
+ * Configuration file names to search for
+ */
+const CONFIG_FILE_NAMES = [
+  'config.mts',
+  'config.ts',
+  'config.js',
+  'config.mjs',
+] as const;
+
+/**
+ * Find the monorepo root by looking for pnpm-workspace.yaml
+ */
+export function findMonorepoRoot(startDir: string): string | null {
+  let currentDir = path.resolve(startDir);
+  const root = path.parse(currentDir).root;
+
+  while (currentDir !== root) {
+    const workspaceFile = path.join(currentDir, 'pnpm-workspace.yaml');
+    if (fs.existsSync(workspaceFile)) {
+      return currentDir;
+    }
+    currentDir = path.dirname(currentDir);
+  }
+
+  return null;
+}
+
+/**
+ * Find the package root by looking for package.json
+ */
+export function findPackageRoot(startDir: string): string | null {
+  let currentDir = path.resolve(startDir);
+  const root = path.parse(currentDir).root;
+
+  while (currentDir !== root) {
+    const packageFile = path.join(currentDir, 'package.json');
+    if (fs.existsSync(packageFile)) {
+      return currentDir;
+    }
+    currentDir = path.dirname(currentDir);
+  }
+
+  return null;
+}
+
+/**
+ * Find a configuration file in a directory
+ */
+function findConfigFile(dir: string): string | null {
+  const fileFactoryDir = path.join(dir, '.file-factory');
+
+  if (!fs.existsSync(fileFactoryDir)) {
+    return null;
+  }
+
+  for (const fileName of CONFIG_FILE_NAMES) {
+    const filePath = path.join(fileFactoryDir, fileName);
+    if (fs.existsSync(filePath)) {
+      return filePath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Load a configuration file dynamically
+ */
+async function loadConfigFile(
+  filePath: string
+): Promise<Partial<FileFactoryConfig>> {
+  try {
+    // Use dynamic import for ES modules
+    const fileUrl = pathToFileURL(filePath).href;
+    const module = await import(fileUrl);
+
+    // Support both default export and named defineConfig export
+    const config = module.default || module;
+
+    // Validate with Zod (partial validation)
+    const result = FileFactoryConfigSchema.partial().safeParse(config);
+
+    if (!result.success) {
+      console.warn(
+        `Warning: Invalid configuration in ${filePath}:`,
+        result.error.message
+      );
+      return {};
+    }
+
+    return result.data;
+  } catch (error) {
+    console.warn(
+      `Warning: Failed to load configuration from ${filePath}:`,
+      error
+    );
+    return {};
+  }
+}
+
+/**
+ * Deep merge two configuration objects
+ */
+function mergeConfigs(
+  base: FileFactoryConfig,
+  override: Partial<FileFactoryConfig>
+): FileFactoryConfig {
+  return {
+    component: { ...base.component, ...override.component },
+    hook: { ...base.hook, ...override.hook },
+    context: { ...base.context, ...override.context },
+    page: { ...base.page, ...override.page },
+    hooks: { ...base.hooks, ...override.hooks },
+  };
+}
+
+export interface LoadConfigOptions {
+  /** Package root directory (defaults to current working directory) */
+  packageRoot?: string;
+  /** Monorepo root directory (auto-detected if not provided) */
+  monorepoRoot?: string;
+}
+
+export interface LoadConfigResult {
+  /** The merged configuration */
+  config: FileFactoryConfig;
+  /** Path to the package configuration file (if found) */
+  packageConfigPath: string | null;
+  /** Path to the monorepo configuration file (if found) */
+  monorepoConfigPath: string | null;
+  /** The package root directory */
+  packageRoot: string;
+  /** The monorepo root directory (if found) */
+  monorepoRoot: string | null;
+}
+
+/**
+ * Load and merge configuration from package and monorepo
+ *
+ * Resolution order (later overrides earlier):
+ * 1. Default configuration
+ * 2. Monorepo root .file-factory/config.ts
+ * 3. Package .file-factory/config.ts
+ */
+export async function loadConfig(
+  options: LoadConfigOptions = {}
+): Promise<LoadConfigResult> {
+  const packageRoot = options.packageRoot
+    ? path.resolve(options.packageRoot)
+    : findPackageRoot(process.cwd()) || process.cwd();
+
+  const monorepoRoot = options.monorepoRoot
+    ? path.resolve(options.monorepoRoot)
+    : findMonorepoRoot(packageRoot);
+
+  let config = { ...defaultConfig };
+  let monorepoConfigPath: string | null = null;
+  let packageConfigPath: string | null = null;
+
+  // Load monorepo configuration first
+  if (monorepoRoot) {
+    monorepoConfigPath = findConfigFile(monorepoRoot);
+    if (monorepoConfigPath) {
+      const monorepoConfig = await loadConfigFile(monorepoConfigPath);
+      config = mergeConfigs(config, monorepoConfig);
+    }
+  }
+
+  // Load package configuration (overrides monorepo config)
+  packageConfigPath = findConfigFile(packageRoot);
+  if (packageConfigPath) {
+    const packageConfig = await loadConfigFile(packageConfigPath);
+    config = mergeConfigs(config, packageConfig);
+  }
+
+  return {
+    config,
+    packageConfigPath,
+    monorepoConfigPath,
+    packageRoot,
+    monorepoRoot,
+  };
+}
+
+/**
+ * Find templates directory, checking package first, then monorepo, then built-in
+ */
+export function findTemplatesDir(
+  templateType: string,
+  packageRoot: string,
+  monorepoRoot: string | null,
+  builtInTemplatesDir: string
+): string {
+  // Check package templates first
+  const packageTemplates = path.join(
+    packageRoot,
+    '.file-factory',
+    'templates',
+    templateType
+  );
+  if (fs.existsSync(packageTemplates)) {
+    return packageTemplates;
+  }
+
+  // Check monorepo templates
+  if (monorepoRoot) {
+    const monorepoTemplates = path.join(
+      monorepoRoot,
+      '.file-factory',
+      'templates',
+      templateType
+    );
+    if (fs.existsSync(monorepoTemplates)) {
+      return monorepoTemplates;
+    }
+  }
+
+  // Fall back to built-in templates
+  const builtInTemplates = path.join(builtInTemplatesDir, templateType);
+  if (fs.existsSync(builtInTemplates)) {
+    return builtInTemplates;
+  }
+
+  throw new Error(`No templates found for type: ${templateType}`);
+}
+
+/**
+ * Build a map from package name to directory path.
+ * Processes packages first, then apps - apps override for short name conflicts.
+ */
+function buildPackageMap(monorepoRoot: string): Map<string, string> {
+  const map = new Map<string, string>();
+  // Process packages first, then apps - apps override for short name conflicts
+  const dirs = ['packages', 'apps'];
+
+  for (const dir of dirs) {
+    const fullDir = path.join(monorepoRoot, dir);
+    if (!fs.existsSync(fullDir)) continue;
+
+    for (const entry of fs.readdirSync(fullDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const pkgJsonPath = path.join(fullDir, entry.name, 'package.json');
+      if (!fs.existsSync(pkgJsonPath)) continue;
+
+      try {
+        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+        const name = pkgJson.name;
+        if (name) {
+          const pkgDir = path.join(fullDir, entry.name);
+          // Map full name (always set, even if duplicate - apps override packages)
+          map.set(name, pkgDir);
+          // Also map short name (without scope) - apps override packages
+          if (name.startsWith('@') && name.includes('/')) {
+            const shortName = name.split('/')[1];
+            map.set(shortName, pkgDir);
+          }
+        }
+      } catch {
+        // Skip packages with invalid package.json
+      }
+    }
+  }
+
+  return map;
+}
+
+/**
+ * Resolve a package specifier to a directory path
+ *
+ * Supports:
+ * - Package names (e.g., "@lsst-sqre/squared", "squared", "squareone")
+ * - Directory paths (e.g., "apps/squareone", "packages/squared")
+ * - Relative paths (e.g., "./packages/squared")
+ * - Absolute paths
+ */
+export function resolvePackageDir(
+  packageSpecifier: string,
+  monorepoRoot: string
+): string | null {
+  // Handle absolute paths
+  if (path.isAbsolute(packageSpecifier)) {
+    return fs.existsSync(packageSpecifier) ? packageSpecifier : null;
+  }
+
+  // Handle relative paths (starting with ./ or ../)
+  if (packageSpecifier.startsWith('./') || packageSpecifier.startsWith('../')) {
+    const resolved = path.resolve(process.cwd(), packageSpecifier);
+    return fs.existsSync(resolved) ? resolved : null;
+  }
+
+  // Handle paths like "apps/squareone" or "packages/squared"
+  if (
+    packageSpecifier.startsWith('apps/') ||
+    packageSpecifier.startsWith('packages/')
+  ) {
+    const resolved = path.join(monorepoRoot, packageSpecifier);
+    return fs.existsSync(resolved) ? resolved : null;
+  }
+
+  // Build package map and look up by name
+  // This handles scoped names (@lsst-sqre/squared), short names (squared), and app names (squareone)
+  const packageMap = buildPackageMap(monorepoRoot);
+  const resolvedPath = packageMap.get(packageSpecifier);
+  if (resolvedPath) {
+    return resolvedPath;
+  }
+
+  return null;
+}

--- a/packages/file-factory/src/config/schema.test.ts
+++ b/packages/file-factory/src/config/schema.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BarrelUpdateSchema,
+  ComponentConfigSchema,
+  ContextConfigSchema,
+  defineConfig,
+  FileFactoryConfigSchema,
+  HookConfigSchema,
+  PageConfigSchema,
+  parseConfig,
+  RouterSchema,
+  StyleSystemSchema,
+  safeParseConfig,
+} from './schema.js';
+
+describe('StyleSystemSchema', () => {
+  it('accepts valid style systems', () => {
+    expect(StyleSystemSchema.parse('css-modules')).toBe('css-modules');
+    expect(StyleSystemSchema.parse('styled-components')).toBe(
+      'styled-components'
+    );
+    expect(StyleSystemSchema.parse('tailwind')).toBe('tailwind');
+    expect(StyleSystemSchema.parse('none')).toBe('none');
+  });
+
+  it('rejects invalid style systems', () => {
+    expect(() => StyleSystemSchema.parse('sass')).toThrow();
+    expect(() => StyleSystemSchema.parse('')).toThrow();
+  });
+});
+
+describe('RouterSchema', () => {
+  it('accepts valid routers', () => {
+    expect(RouterSchema.parse('app')).toBe('app');
+    expect(RouterSchema.parse('pages')).toBe('pages');
+  });
+
+  it('rejects invalid routers', () => {
+    expect(() => RouterSchema.parse('hybrid')).toThrow();
+  });
+});
+
+describe('BarrelUpdateSchema', () => {
+  it('parses minimal barrel update config', () => {
+    const result = BarrelUpdateSchema.parse({
+      file: 'src/index.ts',
+      template: "export * from './{{ComponentName}}';",
+    });
+
+    expect(result.file).toBe('src/index.ts');
+    expect(result.template).toBe("export * from './{{ComponentName}}';");
+    expect(result.position).toBe('append');
+    expect(result.skipIfExists).toBe(true);
+  });
+
+  it('parses full barrel update config', () => {
+    const result = BarrelUpdateSchema.parse({
+      file: 'src/components/index.ts',
+      template: "export { {{ComponentName}} } from './{{ComponentName}}';",
+      position: 'alphabetical',
+      skipIfExists: false,
+    });
+
+    expect(result.position).toBe('alphabetical');
+    expect(result.skipIfExists).toBe(false);
+  });
+});
+
+describe('ComponentConfigSchema', () => {
+  it('applies default values', () => {
+    const result = ComponentConfigSchema.parse({});
+
+    expect(result.directory).toBe('src/components');
+    expect(result.styleSystem).toBe('css-modules');
+    expect(result.withTest).toBe(true);
+    expect(result.withStory).toBe(false);
+    expect(result.appRouterBarrel).toBe(true);
+    expect(result.updateBarrels).toEqual([]);
+  });
+
+  it('accepts custom values', () => {
+    const result = ComponentConfigSchema.parse({
+      directory: 'src/ui',
+      styleSystem: 'styled-components',
+      withTest: false,
+      withStory: true,
+      appRouterBarrel: false,
+    });
+
+    expect(result.directory).toBe('src/ui');
+    expect(result.styleSystem).toBe('styled-components');
+    expect(result.withTest).toBe(false);
+    expect(result.withStory).toBe(true);
+    expect(result.appRouterBarrel).toBe(false);
+  });
+});
+
+describe('HookConfigSchema', () => {
+  it('applies default values', () => {
+    const result = HookConfigSchema.parse({});
+
+    expect(result.directory).toBe('src/hooks');
+    expect(result.withTest).toBe(true);
+    expect(result.useDirectory).toBe(true);
+  });
+});
+
+describe('ContextConfigSchema', () => {
+  it('applies default values', () => {
+    const result = ContextConfigSchema.parse({});
+
+    expect(result.directory).toBe('src/contexts');
+    expect(result.withTest).toBe(false);
+  });
+});
+
+describe('PageConfigSchema', () => {
+  it('applies default values', () => {
+    const result = PageConfigSchema.parse({});
+
+    expect(result.directory).toBe('src/pages');
+    expect(result.router).toBe('pages');
+  });
+
+  it('accepts app router', () => {
+    const result = PageConfigSchema.parse({
+      directory: 'src/app',
+      router: 'app',
+    });
+
+    expect(result.directory).toBe('src/app');
+    expect(result.router).toBe('app');
+  });
+});
+
+describe('FileFactoryConfigSchema', () => {
+  it('applies all default values for empty object', () => {
+    const result = FileFactoryConfigSchema.parse({});
+
+    expect(result.component.directory).toBe('src/components');
+    expect(result.hook.directory).toBe('src/hooks');
+    expect(result.context.directory).toBe('src/contexts');
+    expect(result.page.directory).toBe('src/pages');
+    expect(result.hooks).toEqual({});
+  });
+
+  it('merges partial configuration', () => {
+    const result = FileFactoryConfigSchema.parse({
+      component: {
+        styleSystem: 'styled-components',
+      },
+    });
+
+    expect(result.component.styleSystem).toBe('styled-components');
+    expect(result.component.directory).toBe('src/components');
+  });
+});
+
+describe('defineConfig', () => {
+  it('returns validated configuration', () => {
+    const config = defineConfig({
+      component: {
+        styleSystem: 'tailwind',
+      },
+    });
+
+    expect(config.component.styleSystem).toBe('tailwind');
+    expect(config.component.directory).toBe('src/components');
+  });
+
+  it('throws on invalid configuration', () => {
+    expect(() =>
+      defineConfig({
+        component: {
+          // @ts-expect-error - testing invalid input
+          styleSystem: 'invalid',
+        },
+      })
+    ).toThrow();
+  });
+});
+
+describe('parseConfig', () => {
+  it('parses and validates configuration', () => {
+    const config = parseConfig({
+      hook: {
+        useDirectory: true,
+      },
+    });
+
+    expect(config.hook.useDirectory).toBe(true);
+  });
+});
+
+describe('safeParseConfig', () => {
+  it('returns success result for valid config', () => {
+    const result = safeParseConfig({});
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.component.directory).toBe('src/components');
+    }
+  });
+
+  it('returns error result for invalid config', () => {
+    const result = safeParseConfig({
+      component: {
+        styleSystem: 'invalid',
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBeDefined();
+    }
+  });
+});

--- a/packages/file-factory/src/config/schema.ts
+++ b/packages/file-factory/src/config/schema.ts
@@ -1,0 +1,193 @@
+import { z } from 'zod';
+
+/**
+ * Supported style systems for components
+ */
+export const StyleSystemSchema = z.enum([
+  'css-modules',
+  'styled-components',
+  'tailwind',
+  'none',
+]);
+export type StyleSystem = z.infer<typeof StyleSystemSchema>;
+
+/**
+ * Supported Next.js routers
+ */
+export const RouterSchema = z.enum(['app', 'pages']);
+export type Router = z.infer<typeof RouterSchema>;
+
+/**
+ * Configuration for updating barrel/index files after generation
+ */
+export const BarrelUpdateSchema = z.object({
+  /** Path to the barrel file relative to package root */
+  file: z.string(),
+  /** Template string for the export line. Variables: {{ComponentName}}, {{hookName}}, etc. */
+  template: z.string(),
+  /** Insert position: 'append' (default), 'prepend', or 'alphabetical' */
+  position: z.enum(['append', 'prepend', 'alphabetical']).default('append'),
+  /** Skip if this export already exists */
+  skipIfExists: z.boolean().default(true),
+});
+export type BarrelUpdate = z.infer<typeof BarrelUpdateSchema>;
+
+/**
+ * Component generation configuration
+ */
+export const ComponentConfigSchema = z.object({
+  /** Directory for components relative to package root */
+  directory: z.string().default('src/components'),
+  /** Style system to use */
+  styleSystem: StyleSystemSchema.default('css-modules'),
+  /** Generate test file */
+  withTest: z.boolean().default(true),
+  /** Generate Storybook story */
+  withStory: z.boolean().default(false),
+  /** Use App Router barrel pattern (export { default } only, no export *) */
+  appRouterBarrel: z.boolean().default(true),
+  /** Files to update after generation */
+  updateBarrels: z.array(BarrelUpdateSchema).default([]),
+});
+export type ComponentConfig = z.infer<typeof ComponentConfigSchema>;
+
+/**
+ * Hook generation configuration
+ */
+export const HookConfigSchema = z.object({
+  /** Directory for hooks relative to package root */
+  directory: z.string().default('src/hooks'),
+  /** Generate test file */
+  withTest: z.boolean().default(true),
+  /** Whether hooks get their own directory (default: true) */
+  useDirectory: z.boolean().default(true),
+  /** Files to update after generation */
+  updateBarrels: z.array(BarrelUpdateSchema).default([]),
+});
+export type HookConfig = z.infer<typeof HookConfigSchema>;
+
+/**
+ * Context generation configuration (for global contexts)
+ */
+export const ContextConfigSchema = z.object({
+  /** Directory for global contexts relative to package root */
+  directory: z.string().default('src/contexts'),
+  /** Generate test file */
+  withTest: z.boolean().default(false),
+  /** Files to update after generation */
+  updateBarrels: z.array(BarrelUpdateSchema).default([]),
+});
+export type ContextConfig = z.infer<typeof ContextConfigSchema>;
+
+/**
+ * Page generation configuration
+ */
+export const PageConfigSchema = z.object({
+  /** Directory for pages relative to package root */
+  directory: z.string().default('src/pages'),
+  /** Next.js router type */
+  router: RouterSchema.default('pages'),
+});
+export type PageConfig = z.infer<typeof PageConfigSchema>;
+
+/**
+ * Artifact creation result passed to hooks
+ */
+export const ArtifactCreationResultSchema = z.object({
+  /** Type of artifact created */
+  type: z.enum(['component', 'hook', 'context', 'page']),
+  /** Name of the artifact */
+  name: z.string(),
+  /** List of created file paths (absolute) */
+  files: z.array(z.string()),
+  /** Package root directory */
+  packageRoot: z.string(),
+});
+export type ArtifactCreationResult = z.infer<
+  typeof ArtifactCreationResultSchema
+>;
+
+/**
+ * Lifecycle hooks configuration
+ * Note: Functions cannot be validated by Zod at runtime, so we use z.any() for functions
+ */
+export const HooksConfigSchema = z
+  .object({
+    /** Runs after any artifact is created */
+    afterCreate: z
+      .function()
+      .args(ArtifactCreationResultSchema)
+      .returns(z.promise(z.void()))
+      .optional(),
+    /** Runs after a component is created */
+    afterComponent: z
+      .function()
+      .args(ArtifactCreationResultSchema)
+      .returns(z.promise(z.void()))
+      .optional(),
+    /** Runs after a hook is created */
+    afterHook: z
+      .function()
+      .args(ArtifactCreationResultSchema)
+      .returns(z.promise(z.void()))
+      .optional(),
+    /** Runs after a context is created */
+    afterContext: z
+      .function()
+      .args(ArtifactCreationResultSchema)
+      .returns(z.promise(z.void()))
+      .optional(),
+    /** Runs after a page is created */
+    afterPage: z
+      .function()
+      .args(ArtifactCreationResultSchema)
+      .returns(z.promise(z.void()))
+      .optional(),
+  })
+  .default({});
+export type HooksConfig = z.infer<typeof HooksConfigSchema>;
+
+/**
+ * Complete file-factory configuration schema
+ */
+export const FileFactoryConfigSchema = z.object({
+  /** Component generation configuration */
+  component: ComponentConfigSchema.default({}),
+  /** Hook generation configuration */
+  hook: HookConfigSchema.default({}),
+  /** Context generation configuration */
+  context: ContextConfigSchema.default({}),
+  /** Page generation configuration */
+  page: PageConfigSchema.default({}),
+  /** Lifecycle hooks */
+  hooks: HooksConfigSchema,
+});
+export type FileFactoryConfig = z.infer<typeof FileFactoryConfigSchema>;
+
+/**
+ * Helper function to define configuration with type safety
+ */
+export function defineConfig(
+  config: Partial<z.input<typeof FileFactoryConfigSchema>>
+): FileFactoryConfig {
+  return FileFactoryConfigSchema.parse(config);
+}
+
+/**
+ * Parse and validate a configuration object
+ */
+export function parseConfig(config: unknown): FileFactoryConfig {
+  return FileFactoryConfigSchema.parse(config);
+}
+
+/**
+ * Safely parse configuration, returning default config on error
+ */
+export function safeParseConfig(
+  config: unknown
+):
+  | { success: true; data: FileFactoryConfig }
+  | { success: false; error: z.ZodError } {
+  const result = FileFactoryConfigSchema.safeParse(config);
+  return result;
+}

--- a/packages/file-factory/src/generators/base.ts
+++ b/packages/file-factory/src/generators/base.ts
@@ -1,0 +1,280 @@
+import * as path from 'node:path';
+import chalk from 'chalk';
+import { findTemplatesDir, type LoadConfigResult } from '../config/loader.js';
+import type {
+  ArtifactCreationResult,
+  BarrelUpdate,
+  FileFactoryConfig,
+} from '../config/schema.js';
+import { updateBarrels } from '../hooks/barrel-updater.js';
+import { runHooks } from '../hooks/runner.js';
+import { getBuiltInTemplatesDir, pathExists } from '../utils/paths.js';
+import { processTemplates } from '../utils/templates.js';
+
+/**
+ * Base options for all generators
+ */
+export interface GeneratorOptions {
+  /** Name of the artifact to create */
+  name: string;
+  /** Package root directory */
+  packageRoot: string;
+  /** Monorepo root directory (if applicable) */
+  monorepoRoot: string | null;
+  /** Configuration */
+  config: FileFactoryConfig;
+  /** Dry run mode - don't write files */
+  dryRun?: boolean;
+  /** Verbose output */
+  verbose?: boolean;
+}
+
+/**
+ * Result of a generator run
+ */
+export interface GeneratorResult {
+  /** Whether the generation was successful */
+  success: boolean;
+  /** Created files (absolute paths) */
+  files: string[];
+  /** Created directories (absolute paths) */
+  directories: string[];
+  /** Error message if generation failed */
+  error?: string;
+}
+
+/**
+ * Base generator class
+ *
+ * Provides common functionality for all artifact generators:
+ * - Template discovery and resolution
+ * - File generation from templates
+ * - Barrel file updates
+ * - Lifecycle hook execution
+ */
+export abstract class BaseGenerator {
+  protected options: GeneratorOptions;
+  protected builtInTemplatesDir: string;
+
+  constructor(options: GeneratorOptions) {
+    this.options = options;
+    this.builtInTemplatesDir = getBuiltInTemplatesDir();
+  }
+
+  /**
+   * Get the artifact type identifier
+   */
+  abstract get artifactType(): 'component' | 'hook' | 'context' | 'page';
+
+  /**
+   * Get the template type to use
+   */
+  abstract get templateType(): string;
+
+  /**
+   * Get the target directory for generated files
+   */
+  abstract get targetDirectory(): string;
+
+  /**
+   * Get variables for filename interpolation
+   */
+  abstract getFilenameVariables(): Record<string, string>;
+
+  /**
+   * Get data for template rendering
+   */
+  abstract getTemplateData(): Record<string, unknown>;
+
+  /**
+   * Get flags for conditional file inclusion
+   */
+  abstract getConditionalFlags(): Record<string, boolean>;
+
+  /**
+   * Get barrel updates configuration
+   */
+  abstract getBarrelUpdates(): BarrelUpdate[];
+
+  /**
+   * Get variables for barrel update template interpolation
+   */
+  getBarrelVariables(): Record<string, string> {
+    return this.getFilenameVariables();
+  }
+
+  /**
+   * Resolve the templates directory
+   */
+  protected resolveTemplatesDir(): string {
+    return findTemplatesDir(
+      this.templateType,
+      this.options.packageRoot,
+      this.options.monorepoRoot,
+      this.builtInTemplatesDir
+    );
+  }
+
+  /**
+   * Log a message if verbose mode is enabled
+   */
+  protected log(message: string): void {
+    if (this.options.verbose) {
+      console.log(message);
+    }
+  }
+
+  /**
+   * Log an error message
+   */
+  protected logError(message: string): void {
+    console.error(chalk.red(message));
+  }
+
+  /**
+   * Log a success message
+   */
+  protected logSuccess(message: string): void {
+    console.log(chalk.green(message));
+  }
+
+  /**
+   * Log a warning message
+   */
+  protected logWarning(message: string): void {
+    console.log(chalk.yellow(message));
+  }
+
+  /**
+   * Validate the generator options
+   *
+   * Override in subclasses to add type-specific validation
+   */
+  protected async validate(): Promise<string | null> {
+    // Check if target already exists
+    const targetPath = path.join(
+      this.options.packageRoot,
+      this.targetDirectory
+    );
+
+    const filenameVars = this.getFilenameVariables();
+    const primaryName = Object.values(filenameVars)[0];
+
+    if (!primaryName) {
+      return 'No name provided';
+    }
+
+    // For directory-based artifacts, check if directory exists
+    const artifactPath = path.join(targetPath, primaryName);
+    if (await pathExists(artifactPath)) {
+      return `${this.artifactType} already exists at: ${artifactPath}`;
+    }
+
+    return null;
+  }
+
+  /**
+   * Run the generator
+   */
+  async run(): Promise<GeneratorResult> {
+    const result: GeneratorResult = {
+      success: false,
+      files: [],
+      directories: [],
+    };
+
+    try {
+      // Validate
+      const validationError = await this.validate();
+      if (validationError) {
+        result.error = validationError;
+        return result;
+      }
+
+      // Resolve templates directory
+      const templatesDir = this.resolveTemplatesDir();
+      this.log(`Using templates from: ${templatesDir}`);
+
+      // Calculate target directory
+      const targetDir = path.join(
+        this.options.packageRoot,
+        this.targetDirectory
+      );
+
+      // Process templates
+      const processResult = await processTemplates({
+        templatesDir,
+        targetDir,
+        filenameVariables: this.getFilenameVariables(),
+        templateData: this.getTemplateData(),
+        conditionalFlags: this.getConditionalFlags(),
+        dryRun: this.options.dryRun,
+      });
+
+      result.files = processResult.createdFiles;
+      result.directories = processResult.createdDirectories;
+
+      // Update barrel files
+      const barrelUpdates = this.getBarrelUpdates();
+      if (barrelUpdates.length > 0) {
+        this.log('Updating barrel files...');
+        const barrelResults = await updateBarrels(
+          barrelUpdates,
+          this.getBarrelVariables(),
+          this.options.packageRoot,
+          this.options.dryRun
+        );
+
+        for (const barrelResult of barrelResults) {
+          if (barrelResult.created) {
+            this.log(`  Created: ${barrelResult.filePath}`);
+            result.files.push(barrelResult.filePath);
+          } else if (barrelResult.updated) {
+            this.log(`  Updated: ${barrelResult.filePath}`);
+          } else if (barrelResult.skipped) {
+            this.log(
+              `  Skipped: ${barrelResult.filePath} (export already exists)`
+            );
+          }
+        }
+      }
+
+      // Run lifecycle hooks
+      const hookResult: ArtifactCreationResult = {
+        type: this.artifactType,
+        name: this.options.name,
+        files: result.files,
+        packageRoot: this.options.packageRoot,
+      };
+
+      await runHooks(this.options.config.hooks, hookResult);
+
+      result.success = true;
+    } catch (error) {
+      result.error =
+        error instanceof Error ? error.message : 'Unknown error occurred';
+      this.logError(result.error);
+    }
+
+    return result;
+  }
+}
+
+/**
+ * Helper to create a generator from configuration result
+ */
+export function createGeneratorOptions(
+  name: string,
+  configResult: LoadConfigResult,
+  overrides: Partial<GeneratorOptions> = {}
+): GeneratorOptions {
+  return {
+    name,
+    packageRoot: configResult.packageRoot,
+    monorepoRoot: configResult.monorepoRoot,
+    config: configResult.config,
+    dryRun: false,
+    verbose: false,
+    ...overrides,
+  };
+}

--- a/packages/file-factory/src/generators/component.ts
+++ b/packages/file-factory/src/generators/component.ts
@@ -1,0 +1,145 @@
+import type { BarrelUpdate, StyleSystem } from '../config/schema.js';
+import { getComponentNames, getContextNames } from '../utils/naming.js';
+import { BaseGenerator, type GeneratorOptions } from './base.js';
+
+/**
+ * Component-specific options
+ */
+export interface ComponentGeneratorOptions extends GeneratorOptions {
+  /** Include a component-scoped context */
+  withContext?: boolean;
+  /** Generate test file */
+  withTest?: boolean;
+  /** Generate Storybook story */
+  withStory?: boolean;
+  /** Override the style system */
+  styleSystem?: StyleSystem;
+}
+
+/**
+ * Component generator
+ *
+ * Creates React components with optional:
+ * - CSS Module styles
+ * - styled-components styles
+ * - Tailwind styles
+ * - Test files
+ * - Storybook stories
+ * - Component-scoped contexts
+ */
+export class ComponentGenerator extends BaseGenerator {
+  protected override options: ComponentGeneratorOptions;
+
+  constructor(options: ComponentGeneratorOptions) {
+    super(options);
+    this.options = options;
+  }
+
+  get artifactType(): 'component' {
+    return 'component';
+  }
+
+  get templateType(): string {
+    return this.options.withContext ? 'component-with-context' : 'component';
+  }
+
+  get targetDirectory(): string {
+    return this.options.config.component.directory;
+  }
+
+  /**
+   * Get the effective style system (from options or config)
+   */
+  private get styleSystem(): StyleSystem {
+    return (
+      this.options.styleSystem ?? this.options.config.component.styleSystem
+    );
+  }
+
+  /**
+   * Get whether to include test files
+   */
+  private get withTest(): boolean {
+    return this.options.withTest ?? this.options.config.component.withTest;
+  }
+
+  /**
+   * Get whether to include story files
+   */
+  private get withStory(): boolean {
+    return this.options.withStory ?? this.options.config.component.withStory;
+  }
+
+  getFilenameVariables(): Record<string, string> {
+    const componentNames = getComponentNames(this.options.name);
+
+    // For component-with-context, we also need context naming
+    if (this.options.withContext) {
+      const contextNames = getContextNames(this.options.name);
+      return {
+        ...componentNames,
+        ContextName: contextNames.ContextName,
+        ProviderName: contextNames.ProviderName,
+      };
+    }
+
+    return componentNames;
+  }
+
+  getTemplateData(): Record<string, unknown> {
+    const componentNames = getComponentNames(this.options.name);
+    const contextNames = getContextNames(this.options.name);
+
+    return {
+      // Component names
+      ...componentNames,
+      // Context names (for component-with-context)
+      ...contextNames,
+      // Style system
+      styleSystem: this.styleSystem,
+      // Flags
+      withContext: this.options.withContext ?? false,
+      withTest: this.withTest,
+      withStory: this.withStory,
+      // Barrel pattern
+      appRouterBarrel: this.options.config.component.appRouterBarrel,
+    };
+  }
+
+  getConditionalFlags(): Record<string, boolean> {
+    return {
+      withTest: this.withTest,
+      withStory: this.withStory,
+      withCssModules: this.styleSystem === 'css-modules',
+      withStyledComponents: this.styleSystem === 'styled-components',
+      withTailwind: this.styleSystem === 'tailwind',
+      withStyles: this.styleSystem !== 'none',
+    };
+  }
+
+  getBarrelUpdates(): BarrelUpdate[] {
+    return this.options.config.component.updateBarrels;
+  }
+
+  override getBarrelVariables(): Record<string, string> {
+    const componentNames = getComponentNames(this.options.name);
+    const contextNames = getContextNames(this.options.name);
+
+    return {
+      ...componentNames,
+      ContextName: contextNames.ContextName,
+      ProviderName: contextNames.ProviderName,
+      consumerHookName: contextNames.consumerHookName,
+    };
+  }
+}
+
+/**
+ * Create and run a component generator
+ */
+export async function generateComponent(
+  options: ComponentGeneratorOptions
+): Promise<ReturnType<ComponentGenerator['run']>> {
+  const generator = new ComponentGenerator(options);
+  return generator.run();
+}

--- a/packages/file-factory/src/generators/context.ts
+++ b/packages/file-factory/src/generators/context.ts
@@ -1,0 +1,99 @@
+import type { BarrelUpdate } from '../config/schema.js';
+import { getContextNames } from '../utils/naming.js';
+import { BaseGenerator, type GeneratorOptions } from './base.js';
+
+/**
+ * Context-specific options
+ */
+export interface ContextGeneratorOptions extends GeneratorOptions {
+  /** Generate test file */
+  withTest?: boolean;
+}
+
+/**
+ * Context generator
+ *
+ * Creates global React context providers with:
+ * - Context definition
+ * - Provider component
+ * - Consumer hook
+ * - TypeScript types
+ * - Optional test file
+ *
+ * Note: For component-scoped contexts, use the ComponentGenerator
+ * with the `withContext` option instead.
+ */
+export class ContextGenerator extends BaseGenerator {
+  protected override options: ContextGeneratorOptions;
+  private contextNames: ReturnType<typeof getContextNames>;
+
+  constructor(options: ContextGeneratorOptions) {
+    super(options);
+    this.options = options;
+    this.contextNames = getContextNames(options.name);
+  }
+
+  get artifactType(): 'context' {
+    return 'context';
+  }
+
+  get templateType(): string {
+    return 'context';
+  }
+
+  get targetDirectory(): string {
+    return this.options.config.context.directory;
+  }
+
+  /**
+   * Get whether to include test files
+   */
+  private get withTest(): boolean {
+    return this.options.withTest ?? this.options.config.context.withTest;
+  }
+
+  getFilenameVariables(): Record<string, string> {
+    return {
+      ContextName: this.contextNames.ContextName,
+      ProviderName: this.contextNames.ProviderName,
+      consumerHookName: this.contextNames.consumerHookName,
+      contextDisplayName: this.contextNames.contextDisplayName,
+      baseName: this.contextNames.baseName,
+    };
+  }
+
+  getTemplateData(): Record<string, unknown> {
+    return {
+      ...this.contextNames,
+      withTest: this.withTest,
+    };
+  }
+
+  getConditionalFlags(): Record<string, boolean> {
+    return {
+      withTest: this.withTest,
+    };
+  }
+
+  getBarrelUpdates(): BarrelUpdate[] {
+    return this.options.config.context.updateBarrels;
+  }
+
+  override getBarrelVariables(): Record<string, string> {
+    return {
+      ContextName: this.contextNames.ContextName,
+      ProviderName: this.contextNames.ProviderName,
+      consumerHookName: this.contextNames.consumerHookName,
+    };
+  }
+}
+
+/**
+ * Create and run a context generator
+ */
+export async function generateContext(
+  options: ContextGeneratorOptions
+): Promise<ReturnType<ContextGenerator['run']>> {
+  const generator = new ContextGenerator(options);
+  return generator.run();
+}

--- a/packages/file-factory/src/generators/hook.ts
+++ b/packages/file-factory/src/generators/hook.ts
@@ -1,0 +1,132 @@
+import * as path from 'node:path';
+import type { BarrelUpdate } from '../config/schema.js';
+import { normalizeHookName, toKebabCase } from '../utils/naming.js';
+import { pathExists } from '../utils/paths.js';
+import { BaseGenerator, type GeneratorOptions } from './base.js';
+
+/**
+ * Hook-specific options
+ */
+export interface HookGeneratorOptions extends GeneratorOptions {
+  /** Generate test file */
+  withTest?: boolean;
+  /** Create hook as a flat file (no directory) */
+  flatFile?: boolean;
+}
+
+/**
+ * Hook generator
+ *
+ * Creates React hooks with optional:
+ * - Test files
+ * - Directory structure (for complex hooks)
+ */
+export class HookGenerator extends BaseGenerator {
+  protected override options: HookGeneratorOptions;
+  private normalizedName: string;
+
+  constructor(options: HookGeneratorOptions) {
+    super(options);
+    this.options = options;
+    this.normalizedName = normalizeHookName(options.name);
+  }
+
+  get artifactType(): 'hook' {
+    return 'hook';
+  }
+
+  get templateType(): string {
+    return this.useDirectory ? 'hook-with-directory' : 'hook';
+  }
+
+  get targetDirectory(): string {
+    // For directory-based hooks, the template creates the directory
+    // For flat hooks, files go directly into the hooks directory
+    return this.options.config.hook.directory;
+  }
+
+  /**
+   * Get whether to use directory structure
+   * Default is true (directory), unless flatFile option is set
+   */
+  private get useDirectory(): boolean {
+    // If flatFile is explicitly set, invert it
+    if (this.options.flatFile !== undefined) {
+      return !this.options.flatFile;
+    }
+    // Otherwise use config default (now true)
+    return this.options.config.hook.useDirectory;
+  }
+
+  /**
+   * Get whether to include test files
+   */
+  private get withTest(): boolean {
+    return this.options.withTest ?? this.options.config.hook.withTest;
+  }
+
+  getFilenameVariables(): Record<string, string> {
+    return {
+      hookName: this.normalizedName,
+      'hook-name': toKebabCase(this.normalizedName),
+    };
+  }
+
+  getTemplateData(): Record<string, unknown> {
+    return {
+      hookName: this.normalizedName,
+      withTest: this.withTest,
+      useDirectory: this.useDirectory,
+    };
+  }
+
+  getConditionalFlags(): Record<string, boolean> {
+    return {
+      withTest: this.withTest,
+    };
+  }
+
+  getBarrelUpdates(): BarrelUpdate[] {
+    return this.options.config.hook.updateBarrels;
+  }
+
+  override getBarrelVariables(): Record<string, string> {
+    return {
+      hookName: this.normalizedName,
+      'hook-name': toKebabCase(this.normalizedName),
+    };
+  }
+
+  /**
+   * Override validation for hooks
+   */
+  protected override async validate(): Promise<string | null> {
+    const targetDir = path.join(this.options.packageRoot, this.targetDirectory);
+
+    if (this.useDirectory) {
+      // Check if hook directory exists
+      const hookDir = path.join(targetDir, this.normalizedName);
+      if (await pathExists(hookDir)) {
+        return `Hook already exists at: ${hookDir}`;
+      }
+    } else {
+      // Check if hook file exists
+      const hookFile = path.join(targetDir, `${this.normalizedName}.ts`);
+      if (await pathExists(hookFile)) {
+        return `Hook already exists at: ${hookFile}`;
+      }
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Create and run a hook generator
+ */
+export async function generateHook(
+  options: HookGeneratorOptions
+): Promise<ReturnType<HookGenerator['run']>> {
+  const generator = new HookGenerator(options);
+  return generator.run();
+}

--- a/packages/file-factory/src/generators/index.ts
+++ b/packages/file-factory/src/generators/index.ts
@@ -1,0 +1,16 @@
+// Base generator
+
+export type { GeneratorOptions, GeneratorResult } from './base.js';
+export { BaseGenerator, createGeneratorOptions } from './base.js';
+export type { ComponentGeneratorOptions } from './component.js';
+// Component generator
+export { ComponentGenerator, generateComponent } from './component.js';
+export type { ContextGeneratorOptions } from './context.js';
+// Context generator
+export { ContextGenerator, generateContext } from './context.js';
+export type { HookGeneratorOptions } from './hook.js';
+// Hook generator
+export { generateHook, HookGenerator } from './hook.js';
+export type { PageGeneratorOptions } from './page.js';
+// Page generator
+export { generatePage, PageGenerator } from './page.js';

--- a/packages/file-factory/src/generators/page.ts
+++ b/packages/file-factory/src/generators/page.ts
@@ -1,0 +1,132 @@
+import * as path from 'node:path';
+import type { Router } from '../config/schema.js';
+import { getPageNames } from '../utils/naming.js';
+import { pathExists } from '../utils/paths.js';
+import { BaseGenerator, type GeneratorOptions } from './base.js';
+
+/**
+ * Page-specific options
+ */
+export interface PageGeneratorOptions extends GeneratorOptions {
+  /** Override the router type */
+  router?: Router;
+}
+
+/**
+ * Page generator
+ *
+ * Creates Next.js pages for either:
+ * - Pages Router (src/pages/path/page.tsx)
+ * - App Router (src/app/path/page.tsx)
+ */
+export class PageGenerator extends BaseGenerator {
+  protected override options: PageGeneratorOptions;
+  private pageNames: ReturnType<typeof getPageNames>;
+
+  constructor(options: PageGeneratorOptions) {
+    super(options);
+    this.options = options;
+    this.pageNames = getPageNames(options.name);
+  }
+
+  get artifactType(): 'page' {
+    return 'page';
+  }
+
+  get templateType(): string {
+    return this.router === 'app' ? 'page-app' : 'page-pages';
+  }
+
+  /**
+   * Get the effective router type
+   */
+  private get router(): Router {
+    return this.options.router ?? this.options.config.page.router;
+  }
+
+  get targetDirectory(): string {
+    const baseDir = this.options.config.page.directory;
+
+    if (this.router === 'app') {
+      // App Router: src/app/path/
+      const pagePath = this.options.name;
+      return path.join(baseDir, pagePath);
+    } else {
+      // Pages Router: src/pages/path/
+      // For nested paths, we need the parent directory
+      const segments = this.options.name.split('/');
+      if (segments.length > 1) {
+        return path.join(baseDir, ...segments.slice(0, -1));
+      }
+      return baseDir;
+    }
+  }
+
+  getFilenameVariables(): Record<string, string> {
+    return {
+      pageName: this.pageNames.pageName,
+      PageName: this.pageNames.PageName,
+      pagePath: this.pageNames.pagePath,
+    };
+  }
+
+  getTemplateData(): Record<string, unknown> {
+    return {
+      ...this.pageNames,
+      router: this.router,
+    };
+  }
+
+  getConditionalFlags(): Record<string, boolean> {
+    return {
+      isAppRouter: this.router === 'app',
+      isPagesRouter: this.router === 'pages',
+    };
+  }
+
+  getBarrelUpdates(): never[] {
+    // Pages don't have barrel updates
+    return [];
+  }
+
+  /**
+   * Override validation for pages
+   */
+  protected override async validate(): Promise<string | null> {
+    const baseDir = this.options.config.page.directory;
+    let pagePath: string;
+
+    if (this.router === 'app') {
+      // App Router: check for page.tsx in the directory
+      pagePath = path.join(
+        this.options.packageRoot,
+        baseDir,
+        this.options.name,
+        'page.tsx'
+      );
+    } else {
+      // Pages Router: check for the page file
+      pagePath = path.join(
+        this.options.packageRoot,
+        baseDir,
+        `${this.options.name}.tsx`
+      );
+    }
+
+    if (await pathExists(pagePath)) {
+      return `Page already exists at: ${pagePath}`;
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Create and run a page generator
+ */
+export async function generatePage(
+  options: PageGeneratorOptions
+): Promise<ReturnType<PageGenerator['run']>> {
+  const generator = new PageGenerator(options);
+  return generator.run();
+}

--- a/packages/file-factory/src/hooks/barrel-updater.test.ts
+++ b/packages/file-factory/src/hooks/barrel-updater.test.ts
@@ -1,0 +1,205 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateBarrel, updateBarrels } from './barrel-updater.js';
+
+// Mock the file system operations
+vi.mock('node:fs', () => ({
+  promises: {
+    access: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    mkdir: vi.fn(),
+  },
+  existsSync: vi.fn(),
+}));
+
+describe('updateBarrel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('creates new barrel file when it does not exist', async () => {
+    const mockAccess = vi.mocked(fs.promises.access);
+    const mockWriteFile = vi.mocked(fs.promises.writeFile);
+    const mockMkdir = vi.mocked(fs.promises.mkdir);
+
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const result = await updateBarrel({
+      barrelUpdate: {
+        file: 'src/index.ts',
+        template: "export * from './{{ComponentName}}';\n",
+        position: 'append',
+        skipIfExists: true,
+      },
+      variables: { ComponentName: 'Button' },
+      packageRoot: '/project',
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.updated).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(result.exportLine).toBe("export * from './Button';\n");
+  });
+
+  it('updates existing barrel file with append position', async () => {
+    const mockAccess = vi.mocked(fs.promises.access);
+    const mockReadFile = vi.mocked(fs.promises.readFile);
+    const mockWriteFile = vi.mocked(fs.promises.writeFile);
+    const mockMkdir = vi.mocked(fs.promises.mkdir);
+
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue("export * from './Alert';\n");
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const result = await updateBarrel({
+      barrelUpdate: {
+        file: 'src/index.ts',
+        template: "export * from './{{ComponentName}}';\n",
+        position: 'append',
+        skipIfExists: true,
+      },
+      variables: { ComponentName: 'Button' },
+      packageRoot: '/project',
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.updated).toBe(true);
+
+    // Verify the write call contains both exports
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      path.join('/project', 'src/index.ts'),
+      expect.stringContaining("export * from './Alert'"),
+      'utf-8'
+    );
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      path.join('/project', 'src/index.ts'),
+      expect.stringContaining("export * from './Button'"),
+      'utf-8'
+    );
+  });
+
+  it('skips update when export already exists', async () => {
+    const mockAccess = vi.mocked(fs.promises.access);
+    const mockReadFile = vi.mocked(fs.promises.readFile);
+    const mockWriteFile = vi.mocked(fs.promises.writeFile);
+
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue("export * from './Button';\n");
+
+    const result = await updateBarrel({
+      barrelUpdate: {
+        file: 'src/index.ts',
+        template: "export * from './{{ComponentName}}';\n",
+        position: 'append',
+        skipIfExists: true,
+      },
+      variables: { ComponentName: 'Button' },
+      packageRoot: '/project',
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.updated).toBe(false);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('does not skip when skipIfExists is false', async () => {
+    const mockAccess = vi.mocked(fs.promises.access);
+    const mockReadFile = vi.mocked(fs.promises.readFile);
+    const mockWriteFile = vi.mocked(fs.promises.writeFile);
+    const mockMkdir = vi.mocked(fs.promises.mkdir);
+
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue("export * from './Button';\n");
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const result = await updateBarrel({
+      barrelUpdate: {
+        file: 'src/index.ts',
+        template: "export * from './{{ComponentName}}';\n",
+        position: 'append',
+        skipIfExists: false,
+      },
+      variables: { ComponentName: 'Button' },
+      packageRoot: '/project',
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.updated).toBe(true);
+    expect(mockWriteFile).toHaveBeenCalled();
+  });
+
+  it('respects dry run mode', async () => {
+    const mockAccess = vi.mocked(fs.promises.access);
+    const mockWriteFile = vi.mocked(fs.promises.writeFile);
+
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+
+    const result = await updateBarrel({
+      barrelUpdate: {
+        file: 'src/index.ts',
+        template: "export * from './{{ComponentName}}';\n",
+        position: 'append',
+        skipIfExists: true,
+      },
+      variables: { ComponentName: 'Button' },
+      packageRoot: '/project',
+      dryRun: true,
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.updated).toBe(true);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateBarrels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updates multiple barrel files', async () => {
+    const mockAccess = vi.mocked(fs.promises.access);
+    const mockReadFile = vi.mocked(fs.promises.readFile);
+    const mockWriteFile = vi.mocked(fs.promises.writeFile);
+    const mockMkdir = vi.mocked(fs.promises.mkdir);
+
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue('// existing content\n');
+    mockMkdir.mockResolvedValue(undefined);
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const results = await updateBarrels(
+      [
+        {
+          file: 'src/index.ts',
+          template: "export * from './{{ComponentName}}';\n",
+          position: 'append',
+          skipIfExists: true,
+        },
+        {
+          file: 'src/components/index.ts',
+          template:
+            "export { {{ComponentName}} } from './{{ComponentName}}';\n",
+          position: 'append',
+          skipIfExists: true,
+        },
+      ],
+      { ComponentName: 'Button' },
+      '/project'
+    );
+
+    expect(results).toHaveLength(2);
+    expect(results[0].updated).toBe(true);
+    expect(results[1].updated).toBe(true);
+  });
+});

--- a/packages/file-factory/src/hooks/barrel-updater.ts
+++ b/packages/file-factory/src/hooks/barrel-updater.ts
@@ -1,0 +1,242 @@
+import * as path from 'node:path';
+import type { BarrelUpdate } from '../config/schema.js';
+import { interpolate } from '../utils/interpolate.js';
+import { pathExists, readFile, writeFile } from '../utils/paths.js';
+
+/**
+ * Default header comment for auto-generated barrel files
+ */
+const DEFAULT_BARREL_HEADER = '// Auto-generated barrel file\n\n';
+
+/**
+ * Options for updating a barrel file
+ */
+export interface UpdateBarrelOptions {
+  /** Barrel update configuration */
+  barrelUpdate: BarrelUpdate;
+  /** Variables for template interpolation */
+  variables: Record<string, string>;
+  /** Package root directory */
+  packageRoot: string;
+  /** Dry run mode - don't write files */
+  dryRun?: boolean;
+}
+
+/**
+ * Result of a barrel update operation
+ */
+export interface UpdateBarrelResult {
+  /** Path to the barrel file */
+  filePath: string;
+  /** Whether the file was created */
+  created: boolean;
+  /** Whether the file was updated */
+  updated: boolean;
+  /** Whether the update was skipped (export already exists) */
+  skipped: boolean;
+  /** The export line that was added (or would have been added) */
+  exportLine: string;
+}
+
+/**
+ * Parse exports from a barrel file content
+ *
+ * Extracts all export statements to check for duplicates
+ */
+function parseExports(content: string): string[] {
+  const exports: string[] = [];
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('export ')) {
+      exports.push(trimmed);
+    }
+  }
+
+  return exports;
+}
+
+/**
+ * Check if an export already exists in the content
+ *
+ * Compares normalized versions of the export statements
+ */
+function exportExists(content: string, exportLine: string): boolean {
+  const normalizedExport = exportLine.trim().replace(/\s+/g, ' ');
+  const existingExports = parseExports(content);
+
+  return existingExports.some((existing) => {
+    const normalized = existing.replace(/\s+/g, ' ');
+    return normalized === normalizedExport;
+  });
+}
+
+/**
+ * Insert an export line alphabetically into the content
+ *
+ * Sorts export statements alphabetically while preserving non-export content
+ */
+function insertAlphabetically(content: string, exportLine: string): string {
+  const lines = content.split('\n');
+  const exportLines: string[] = [];
+  const otherLines: string[] = [];
+  const headerLines: string[] = [];
+
+  // Separate exports from other content
+  let inHeader = true;
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Detect header (comments at the start)
+    if (inHeader && (trimmed.startsWith('//') || trimmed === '')) {
+      headerLines.push(line);
+      continue;
+    }
+    inHeader = false;
+
+    if (trimmed.startsWith('export ')) {
+      exportLines.push(trimmed);
+    } else if (trimmed !== '') {
+      otherLines.push(line);
+    }
+  }
+
+  // Add new export and sort
+  exportLines.push(exportLine.trim());
+  exportLines.sort((a, b) => {
+    // Extract the path or name being exported for comparison
+    const extractSortKey = (exp: string): string => {
+      // Match export { X } from './path' or export * from './path'
+      const fromMatch = exp.match(/from\s+['"]([^'"]+)['"]/);
+      if (fromMatch) return fromMatch[1];
+      // Match export { X }
+      const namedMatch = exp.match(/export\s*\{\s*([^}]+)\s*\}/);
+      if (namedMatch) return namedMatch[1].trim();
+      return exp;
+    };
+    return extractSortKey(a).localeCompare(extractSortKey(b));
+  });
+
+  // Reconstruct content
+  const parts: string[] = [];
+
+  if (headerLines.length > 0) {
+    parts.push(headerLines.join('\n'));
+  }
+
+  if (exportLines.length > 0) {
+    parts.push(exportLines.join('\n'));
+  }
+
+  if (otherLines.length > 0) {
+    parts.push(otherLines.join('\n'));
+  }
+
+  return `${parts.join('\n')}\n`;
+}
+
+/**
+ * Update a barrel file with a new export
+ *
+ * Handles:
+ * - Creating the file if it doesn't exist
+ * - Checking for duplicate exports
+ * - Inserting at the specified position (append, prepend, alphabetical)
+ */
+export async function updateBarrel(
+  options: UpdateBarrelOptions
+): Promise<UpdateBarrelResult> {
+  const { barrelUpdate, variables, packageRoot, dryRun = false } = options;
+  const { file, template, position, skipIfExists } = barrelUpdate;
+
+  const filePath = path.join(packageRoot, file);
+  const exportLine = interpolate(template, variables);
+
+  const result: UpdateBarrelResult = {
+    filePath,
+    created: false,
+    updated: false,
+    skipped: false,
+    exportLine,
+  };
+
+  // Check if file exists
+  const fileExists = await pathExists(filePath);
+
+  let content: string;
+  if (fileExists) {
+    content = await readFile(filePath);
+
+    // Check if export already exists
+    if (skipIfExists && exportExists(content, exportLine)) {
+      result.skipped = true;
+      return result;
+    }
+  } else {
+    content = DEFAULT_BARREL_HEADER;
+    result.created = true;
+  }
+
+  // Insert export at specified position
+  let newContent: string;
+  switch (position) {
+    case 'prepend': {
+      // Find the first non-comment, non-empty line
+      const lines = content.split('\n');
+      let insertIndex = 0;
+      for (let i = 0; i < lines.length; i++) {
+        const trimmed = lines[i].trim();
+        if (trimmed !== '' && !trimmed.startsWith('//')) {
+          insertIndex = i;
+          break;
+        }
+        insertIndex = i + 1;
+      }
+      lines.splice(insertIndex, 0, exportLine.trim());
+      newContent = lines.join('\n');
+      break;
+    }
+
+    case 'alphabetical':
+      newContent = insertAlphabetically(content, exportLine);
+      break;
+
+    default:
+      // Ensure content ends with newline, then add export
+      newContent = `${content.trimEnd()}\n${exportLine.trim()}\n`;
+      break;
+  }
+
+  // Write the file
+  if (!dryRun) {
+    await writeFile(filePath, newContent);
+  }
+
+  result.updated = true;
+  return result;
+}
+
+/**
+ * Update multiple barrel files
+ */
+export async function updateBarrels(
+  barrelUpdates: BarrelUpdate[],
+  variables: Record<string, string>,
+  packageRoot: string,
+  dryRun = false
+): Promise<UpdateBarrelResult[]> {
+  const results: UpdateBarrelResult[] = [];
+
+  for (const barrelUpdate of barrelUpdates) {
+    const result = await updateBarrel({
+      barrelUpdate,
+      variables,
+      packageRoot,
+      dryRun,
+    });
+    results.push(result);
+  }
+
+  return results;
+}

--- a/packages/file-factory/src/hooks/index.ts
+++ b/packages/file-factory/src/hooks/index.ts
@@ -1,0 +1,7 @@
+export type {
+  UpdateBarrelOptions,
+  UpdateBarrelResult,
+} from './barrel-updater.js';
+export { updateBarrel, updateBarrels } from './barrel-updater.js';
+
+export { runHooks } from './runner.js';

--- a/packages/file-factory/src/hooks/runner.ts
+++ b/packages/file-factory/src/hooks/runner.ts
@@ -1,0 +1,45 @@
+import type { ArtifactCreationResult, HooksConfig } from '../config/schema.js';
+
+/**
+ * Run lifecycle hooks after artifact creation
+ *
+ * Executes hooks in order:
+ * 1. Type-specific hook (afterComponent, afterHook, afterContext, afterPage)
+ * 2. Generic afterCreate hook
+ */
+export async function runHooks(
+  hooksConfig: HooksConfig,
+  result: ArtifactCreationResult
+): Promise<void> {
+  const { type } = result;
+
+  // Run type-specific hook first
+  const typeHookName =
+    `after${type.charAt(0).toUpperCase()}${type.slice(1)}` as keyof HooksConfig;
+  const typeHook = hooksConfig[typeHookName] as
+    | ((result: ArtifactCreationResult) => Promise<void>)
+    | undefined;
+
+  if (typeHook) {
+    try {
+      await typeHook(result);
+    } catch (error) {
+      console.warn(
+        `Warning: ${typeHookName} hook failed:`,
+        error instanceof Error ? error.message : error
+      );
+    }
+  }
+
+  // Run generic afterCreate hook
+  if (hooksConfig.afterCreate) {
+    try {
+      await hooksConfig.afterCreate(result);
+    } catch (error) {
+      console.warn(
+        'Warning: afterCreate hook failed:',
+        error instanceof Error ? error.message : error
+      );
+    }
+  }
+}

--- a/packages/file-factory/src/index.ts
+++ b/packages/file-factory/src/index.ts
@@ -1,0 +1,99 @@
+/**
+ * @lsst-sqre/file-factory
+ *
+ * CLI tool and programmatic API for scaffolding React components,
+ * hooks, contexts, and pages in the Squareone monorepo.
+ */
+
+export { defaultConfig } from './config/defaults.js';
+export type {
+  ArtifactCreationResult,
+  BarrelUpdate,
+  ComponentConfig,
+  ContextConfig,
+  FileFactoryConfig,
+  HookConfig,
+  HooksConfig,
+  LoadConfigOptions,
+  LoadConfigResult,
+  PageConfig,
+  Router,
+  StyleSystem,
+} from './config/index.js';
+export {
+  findMonorepoRoot,
+  findPackageRoot,
+  findTemplatesDir,
+  loadConfig,
+  resolvePackageDir,
+} from './config/loader.js';
+// Configuration
+export { defineConfig, parseConfig, safeParseConfig } from './config/schema.js';
+export type {
+  ComponentGeneratorOptions,
+  ContextGeneratorOptions,
+  GeneratorOptions,
+  GeneratorResult,
+  HookGeneratorOptions,
+  PageGeneratorOptions,
+} from './generators/index.js';
+// Generators
+export {
+  BaseGenerator,
+  ComponentGenerator,
+  ContextGenerator,
+  createGeneratorOptions,
+  generateComponent,
+  generateContext,
+  generateHook,
+  generatePage,
+  HookGenerator,
+  PageGenerator,
+} from './generators/index.js';
+export type { UpdateBarrelOptions, UpdateBarrelResult } from './hooks/index.js';
+// Hooks
+export { runHooks, updateBarrel, updateBarrels } from './hooks/index.js';
+export type {
+  ProcessTemplatesOptions,
+  ProcessTemplatesResult,
+  TemplateFile,
+} from './utils/index.js';
+// Utilities
+export {
+  // Templates
+  discoverTemplateFiles,
+  ensureDir,
+  extractVariables,
+  getActualFilename,
+  getAvailableTemplateTypes,
+  getBasename,
+  // Paths
+  getBuiltInTemplatesDir,
+  getComponentNames,
+  getContextNames,
+  getDirname,
+  getExtension,
+  getPageNames,
+  getRelativePath,
+  // Interpolation
+  interpolate,
+  interpolateFilename,
+  joinPaths,
+  normalizeHookName,
+  parseConditionalFilename,
+  pathExists,
+  pathExistsSync,
+  processTemplates,
+  readFile,
+  renderTemplate,
+  renderTemplateFile,
+  resolvePath,
+  shouldIncludeConditionalFile,
+  templateExists,
+  toCamelCase,
+  toKebabCase,
+  // Naming
+  toPascalCase,
+  toSnakeCase,
+  writeFile,
+} from './utils/index.js';

--- a/packages/file-factory/src/utils/index.ts
+++ b/packages/file-factory/src/utils/index.ts
@@ -1,0 +1,50 @@
+// Naming utilities
+
+// Interpolation utilities
+export {
+  extractVariables,
+  getActualFilename,
+  interpolate,
+  interpolateFilename,
+  parseConditionalFilename,
+  shouldIncludeConditionalFile,
+} from './interpolate.js';
+export {
+  getComponentNames,
+  getContextNames,
+  getPageNames,
+  normalizeHookName,
+  toCamelCase,
+  toKebabCase,
+  toPascalCase,
+  toSnakeCase,
+} from './naming.js';
+// Path utilities
+export {
+  ensureDir,
+  getBasename,
+  getBuiltInTemplatesDir,
+  getDirname,
+  getExtension,
+  getRelativePath,
+  joinPaths,
+  pathExists,
+  pathExistsSync,
+  readFile,
+  resolvePath,
+  writeFile,
+} from './paths.js';
+export type {
+  ProcessTemplatesOptions,
+  ProcessTemplatesResult,
+  TemplateFile,
+} from './templates.js';
+// Template utilities
+export {
+  discoverTemplateFiles,
+  getAvailableTemplateTypes,
+  processTemplates,
+  renderTemplate,
+  renderTemplateFile,
+  templateExists,
+} from './templates.js';

--- a/packages/file-factory/src/utils/interpolate.test.ts
+++ b/packages/file-factory/src/utils/interpolate.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractVariables,
+  getActualFilename,
+  interpolate,
+  interpolateFilename,
+  parseConditionalFilename,
+  shouldIncludeConditionalFile,
+} from './interpolate.js';
+
+describe('interpolate', () => {
+  it('replaces single variable', () => {
+    const result = interpolate('{{ComponentName}}.tsx', {
+      ComponentName: 'Button',
+    });
+    expect(result).toBe('Button.tsx');
+  });
+
+  it('replaces multiple variables', () => {
+    const result = interpolate('{{ComponentName}}/{{ComponentName}}.tsx', {
+      ComponentName: 'Button',
+    });
+    expect(result).toBe('Button/Button.tsx');
+  });
+
+  it('replaces different variables', () => {
+    const result = interpolate('{{hookName}}/{{hookName}}.ts', {
+      hookName: 'useDebounce',
+    });
+    expect(result).toBe('useDebounce/useDebounce.ts');
+  });
+
+  it('handles kebab-case variables', () => {
+    const result = interpolate('{{component-name}}/index.ts', {
+      'component-name': 'data-table',
+    });
+    expect(result).toBe('data-table/index.ts');
+  });
+
+  it('leaves unmatched variables as-is', () => {
+    const result = interpolate('{{ComponentName}}/{{unknown}}.tsx', {
+      ComponentName: 'Button',
+    });
+    expect(result).toBe('Button/{{unknown}}.tsx');
+  });
+
+  it('handles empty variables object', () => {
+    const result = interpolate('{{ComponentName}}.tsx', {});
+    expect(result).toBe('{{ComponentName}}.tsx');
+  });
+});
+
+describe('interpolateFilename', () => {
+  it('interpolates and removes .ejs extension', () => {
+    const result = interpolateFilename('{{ComponentName}}.tsx.ejs', {
+      ComponentName: 'Button',
+    });
+    expect(result).toBe('Button.tsx');
+  });
+
+  it('handles filenames without .ejs extension', () => {
+    const result = interpolateFilename('{{ComponentName}}.tsx', {
+      ComponentName: 'Button',
+    });
+    expect(result).toBe('Button.tsx');
+  });
+
+  it('handles CSS module filenames', () => {
+    const result = interpolateFilename('{{ComponentName}}.module.css.ejs', {
+      ComponentName: 'Button',
+    });
+    expect(result).toBe('Button.module.css');
+  });
+});
+
+describe('extractVariables', () => {
+  it('extracts single variable', () => {
+    const result = extractVariables('{{ComponentName}}.tsx');
+    expect(result).toEqual(['ComponentName']);
+  });
+
+  it('extracts multiple unique variables', () => {
+    const result = extractVariables('{{ComponentName}}/{{componentName}}.tsx');
+    expect(result).toContain('ComponentName');
+    expect(result).toContain('componentName');
+  });
+
+  it('deduplicates repeated variables', () => {
+    const result = extractVariables('{{ComponentName}}/{{ComponentName}}.tsx');
+    expect(result).toEqual(['ComponentName']);
+  });
+
+  it('extracts kebab-case variables', () => {
+    const result = extractVariables('{{component-name}}/index.ts');
+    expect(result).toEqual(['component-name']);
+  });
+
+  it('returns empty array for no variables', () => {
+    const result = extractVariables('index.ts');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('parseConditionalFilename', () => {
+  it('parses conditional filename with _when_ prefix', () => {
+    const result = parseConditionalFilename(
+      '_when_withTest_Button.test.tsx.ejs'
+    );
+    expect(result).toEqual({
+      condition: 'withTest',
+      filename: 'Button.test.tsx.ejs',
+    });
+  });
+
+  it('returns null for non-conditional filename', () => {
+    const result = parseConditionalFilename('Button.tsx.ejs');
+    expect(result).toBeNull();
+  });
+
+  it('handles complex filenames', () => {
+    const result = parseConditionalFilename(
+      '_when_withStory_{{ComponentName}}.stories.tsx.ejs'
+    );
+    expect(result).toEqual({
+      condition: 'withStory',
+      filename: '{{ComponentName}}.stories.tsx.ejs',
+    });
+  });
+});
+
+describe('shouldIncludeConditionalFile', () => {
+  it('includes file when condition is true', () => {
+    const result = shouldIncludeConditionalFile(
+      '_when_withTest_Button.test.tsx.ejs',
+      { withTest: true }
+    );
+    expect(result).toBe(true);
+  });
+
+  it('excludes file when condition is false', () => {
+    const result = shouldIncludeConditionalFile(
+      '_when_withTest_Button.test.tsx.ejs',
+      { withTest: false }
+    );
+    expect(result).toBe(false);
+  });
+
+  it('excludes file when condition is not in flags', () => {
+    const result = shouldIncludeConditionalFile(
+      '_when_withTest_Button.test.tsx.ejs',
+      { withStory: true }
+    );
+    expect(result).toBe(false);
+  });
+
+  it('always includes non-conditional files', () => {
+    const result = shouldIncludeConditionalFile('Button.tsx.ejs', {
+      withTest: false,
+    });
+    expect(result).toBe(true);
+  });
+});
+
+describe('getActualFilename', () => {
+  it('removes _when_ prefix from conditional filename', () => {
+    const result = getActualFilename('_when_withTest_Button.test.tsx.ejs');
+    expect(result).toBe('Button.test.tsx.ejs');
+  });
+
+  it('returns non-conditional filename as-is', () => {
+    const result = getActualFilename('Button.tsx.ejs');
+    expect(result).toBe('Button.tsx.ejs');
+  });
+
+  it('handles interpolation variables', () => {
+    const result = getActualFilename(
+      '_when_withStory_{{ComponentName}}.stories.tsx.ejs'
+    );
+    expect(result).toBe('{{ComponentName}}.stories.tsx.ejs');
+  });
+});

--- a/packages/file-factory/src/utils/interpolate.ts
+++ b/packages/file-factory/src/utils/interpolate.ts
@@ -1,0 +1,147 @@
+/**
+ * Interpolation utilities for handling {{VariableName}} patterns in filenames and templates
+ */
+
+/**
+ * Pattern to match interpolation variables: {{VariableName}}
+ * Supports PascalCase, camelCase, and kebab-case variable names
+ */
+const INTERPOLATION_PATTERN = /\{\{([a-zA-Z][a-zA-Z0-9-]*)\}\}/g;
+
+/**
+ * Interpolate variables in a string
+ *
+ * Replaces {{VariableName}} patterns with values from the variables object.
+ *
+ * @example
+ * interpolate('{{ComponentName}}.tsx', { ComponentName: 'Button' })
+ * // 'Button.tsx'
+ *
+ * interpolate('src/{{component-name}}/index.ts', { 'component-name': 'data-table' })
+ * // 'src/data-table/index.ts'
+ */
+export function interpolate(
+  template: string,
+  variables: Record<string, string>
+): string {
+  return template.replace(INTERPOLATION_PATTERN, (match, variableName) => {
+    if (variableName in variables) {
+      return variables[variableName];
+    }
+    // Leave unmatched variables as-is
+    return match;
+  });
+}
+
+/**
+ * Interpolate a filename, also removing the .ejs extension if present
+ *
+ * @example
+ * interpolateFilename('{{ComponentName}}.tsx.ejs', { ComponentName: 'Button' })
+ * // 'Button.tsx'
+ */
+export function interpolateFilename(
+  filename: string,
+  variables: Record<string, string>
+): string {
+  let result = interpolate(filename, variables);
+
+  // Remove .ejs extension
+  if (result.endsWith('.ejs')) {
+    result = result.slice(0, -4);
+  }
+
+  return result;
+}
+
+/**
+ * Extract variable names from a template string
+ *
+ * @example
+ * extractVariables('{{ComponentName}}/{{ComponentName}}.tsx')
+ * // ['ComponentName']
+ */
+export function extractVariables(template: string): string[] {
+  const variables = new Set<string>();
+
+  // Reset lastIndex to ensure we start from the beginning
+  const pattern = new RegExp(INTERPOLATION_PATTERN.source, 'g');
+
+  let match = pattern.exec(template);
+  while (match !== null) {
+    variables.add(match[1]);
+    match = pattern.exec(template);
+  }
+
+  return Array.from(variables);
+}
+
+/**
+ * Check if a filename is a conditional file based on the _when_ prefix
+ *
+ * Convention: _when_<condition>_filename.ext
+ *
+ * @example
+ * parseConditionalFilename('_when_withTest_Button.test.tsx.ejs')
+ * // { condition: 'withTest', filename: 'Button.test.tsx.ejs' }
+ *
+ * parseConditionalFilename('Button.tsx.ejs')
+ * // null (not conditional)
+ */
+export function parseConditionalFilename(
+  filename: string
+): { condition: string; filename: string } | null {
+  const match = filename.match(/^_when_([a-zA-Z]+)_(.+)$/);
+
+  if (!match) {
+    return null;
+  }
+
+  return {
+    condition: match[1],
+    filename: match[2],
+  };
+}
+
+/**
+ * Check if a conditional file should be included based on the provided flags
+ *
+ * @example
+ * shouldIncludeConditionalFile('_when_withTest_Button.test.tsx.ejs', { withTest: true })
+ * // true
+ *
+ * shouldIncludeConditionalFile('_when_withStory_Button.stories.tsx.ejs', { withStory: false })
+ * // false
+ *
+ * shouldIncludeConditionalFile('Button.tsx.ejs', { withTest: true })
+ * // true (non-conditional files are always included)
+ */
+export function shouldIncludeConditionalFile(
+  filename: string,
+  flags: Record<string, boolean>
+): boolean {
+  const parsed = parseConditionalFilename(filename);
+
+  if (!parsed) {
+    // Not a conditional file, always include
+    return true;
+  }
+
+  // Check if the condition is true
+  return flags[parsed.condition] === true;
+}
+
+/**
+ * Get the actual filename from a potentially conditional filename
+ *
+ * @example
+ * getActualFilename('_when_withTest_{{ComponentName}}.test.tsx.ejs')
+ * // '{{ComponentName}}.test.tsx.ejs'
+ *
+ * getActualFilename('{{ComponentName}}.tsx.ejs')
+ * // '{{ComponentName}}.tsx.ejs'
+ */
+export function getActualFilename(filename: string): string {
+  const parsed = parseConditionalFilename(filename);
+  return parsed ? parsed.filename : filename;
+}

--- a/packages/file-factory/src/utils/naming.test.ts
+++ b/packages/file-factory/src/utils/naming.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getComponentNames,
+  getContextNames,
+  getPageNames,
+  normalizeHookName,
+  toCamelCase,
+  toKebabCase,
+  toPascalCase,
+  toSnakeCase,
+} from './naming.js';
+
+describe('toPascalCase', () => {
+  it('converts kebab-case to PascalCase', () => {
+    expect(toPascalCase('my-component')).toBe('MyComponent');
+    expect(toPascalCase('data-table-row')).toBe('DataTableRow');
+  });
+
+  it('converts camelCase to PascalCase', () => {
+    expect(toPascalCase('myComponent')).toBe('MyComponent');
+    expect(toPascalCase('dataTableRow')).toBe('DataTableRow');
+  });
+
+  it('converts snake_case to PascalCase', () => {
+    expect(toPascalCase('my_component')).toBe('MyComponent');
+    expect(toPascalCase('data_table_row')).toBe('DataTableRow');
+  });
+
+  it('preserves existing PascalCase', () => {
+    expect(toPascalCase('MyComponent')).toBe('MyComponent');
+    expect(toPascalCase('DataTable')).toBe('DataTable');
+  });
+});
+
+describe('toCamelCase', () => {
+  it('converts PascalCase to camelCase', () => {
+    expect(toCamelCase('MyComponent')).toBe('myComponent');
+    expect(toCamelCase('DataTableRow')).toBe('dataTableRow');
+  });
+
+  it('converts kebab-case to camelCase', () => {
+    expect(toCamelCase('my-component')).toBe('myComponent');
+    expect(toCamelCase('data-table-row')).toBe('dataTableRow');
+  });
+
+  it('converts snake_case to camelCase', () => {
+    expect(toCamelCase('my_component')).toBe('myComponent');
+    expect(toCamelCase('data_table_row')).toBe('dataTableRow');
+  });
+});
+
+describe('toKebabCase', () => {
+  it('converts PascalCase to kebab-case', () => {
+    expect(toKebabCase('MyComponent')).toBe('my-component');
+    expect(toKebabCase('DataTableRow')).toBe('data-table-row');
+  });
+
+  it('converts camelCase to kebab-case', () => {
+    expect(toKebabCase('myComponent')).toBe('my-component');
+    expect(toKebabCase('dataTableRow')).toBe('data-table-row');
+  });
+
+  it('converts snake_case to kebab-case', () => {
+    expect(toKebabCase('my_component')).toBe('my-component');
+    expect(toKebabCase('data_table_row')).toBe('data-table-row');
+  });
+});
+
+describe('toSnakeCase', () => {
+  it('converts PascalCase to snake_case', () => {
+    expect(toSnakeCase('MyComponent')).toBe('my_component');
+    expect(toSnakeCase('DataTableRow')).toBe('data_table_row');
+  });
+
+  it('converts camelCase to snake_case', () => {
+    expect(toSnakeCase('myComponent')).toBe('my_component');
+    expect(toSnakeCase('dataTableRow')).toBe('data_table_row');
+  });
+
+  it('converts kebab-case to snake_case', () => {
+    expect(toSnakeCase('my-component')).toBe('my_component');
+    expect(toSnakeCase('data-table-row')).toBe('data_table_row');
+  });
+});
+
+describe('normalizeHookName', () => {
+  it('adds use prefix to base name', () => {
+    expect(normalizeHookName('Debounce')).toBe('useDebounce');
+    expect(normalizeHookName('LocalStorage')).toBe('useLocalStorage');
+  });
+
+  it('preserves use prefix if already present', () => {
+    expect(normalizeHookName('useDebounce')).toBe('useDebounce');
+    expect(normalizeHookName('useLocalStorage')).toBe('useLocalStorage');
+  });
+
+  it('normalizes case-insensitive use prefix', () => {
+    expect(normalizeHookName('UseDebounce')).toBe('useDebounce');
+    expect(normalizeHookName('USEDebounce')).toBe('useDebounce');
+  });
+});
+
+describe('getContextNames', () => {
+  it('generates all context naming variants', () => {
+    const result = getContextNames('Theme');
+
+    expect(result).toEqual({
+      ContextName: 'ThemeContext',
+      ProviderName: 'ThemeProvider',
+      consumerHookName: 'useTheme',
+      contextDisplayName: 'Theme',
+      baseName: 'Theme',
+    });
+  });
+
+  it('handles input with Context suffix', () => {
+    const result = getContextNames('ThemeContext');
+
+    expect(result.ContextName).toBe('ThemeContext');
+    expect(result.ProviderName).toBe('ThemeProvider');
+    expect(result.baseName).toBe('Theme');
+  });
+
+  it('handles input with Provider suffix', () => {
+    const result = getContextNames('ThemeProvider');
+
+    expect(result.ContextName).toBe('ThemeContext');
+    expect(result.ProviderName).toBe('ThemeProvider');
+    expect(result.baseName).toBe('Theme');
+  });
+});
+
+describe('getComponentNames', () => {
+  it('generates all component naming variants', () => {
+    const result = getComponentNames('DataTable');
+
+    expect(result).toEqual({
+      ComponentName: 'DataTable',
+      componentName: 'dataTable',
+      'component-name': 'data-table',
+    });
+  });
+
+  it('handles kebab-case input', () => {
+    const result = getComponentNames('data-table');
+
+    expect(result.ComponentName).toBe('DataTable');
+    expect(result.componentName).toBe('dataTable');
+    expect(result['component-name']).toBe('data-table');
+  });
+});
+
+describe('getPageNames', () => {
+  it('generates page names from simple path', () => {
+    const result = getPageNames('dashboard');
+
+    expect(result).toEqual({
+      pageName: 'dashboard',
+      PageName: 'Dashboard',
+      pageTitle: 'Dashboard',
+      pageDescription: 'Dashboard page',
+      pagePath: 'dashboard',
+    });
+  });
+
+  it('generates page names from nested path', () => {
+    const result = getPageNames('dashboard/settings');
+
+    expect(result.pageName).toBe('settings');
+    expect(result.PageName).toBe('Settings');
+    expect(result.pagePath).toBe('dashboard/settings');
+  });
+
+  it('handles multi-word page names', () => {
+    const result = getPageNames('user-profile');
+
+    expect(result.PageName).toBe('UserProfile');
+    expect(result.pageTitle).toBe('User Profile');
+  });
+});

--- a/packages/file-factory/src/utils/naming.ts
+++ b/packages/file-factory/src/utils/naming.ts
@@ -1,0 +1,198 @@
+/**
+ * Naming utilities for converting between different case styles
+ */
+
+/**
+ * Convert a string to PascalCase
+ *
+ * @example
+ * toPascalCase('my-component') // 'MyComponent'
+ * toPascalCase('myComponent') // 'MyComponent'
+ * toPascalCase('my_component') // 'MyComponent'
+ */
+export function toPascalCase(str: string): string {
+  // Handle already PascalCase strings
+  if (/^[A-Z][a-zA-Z0-9]*$/.test(str)) {
+    return str;
+  }
+
+  return (
+    str
+      // Split on hyphens, underscores, or camelCase boundaries
+      .split(/[-_]|(?=[A-Z])/)
+      .filter(Boolean)
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join('')
+  );
+}
+
+/**
+ * Convert a string to camelCase
+ *
+ * @example
+ * toCamelCase('MyComponent') // 'myComponent'
+ * toCamelCase('my-component') // 'myComponent'
+ * toCamelCase('my_component') // 'myComponent'
+ */
+export function toCamelCase(str: string): string {
+  const pascal = toPascalCase(str);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}
+
+/**
+ * Convert a string to kebab-case
+ *
+ * @example
+ * toKebabCase('MyComponent') // 'my-component'
+ * toKebabCase('myComponent') // 'my-component'
+ * toKebabCase('my_component') // 'my-component'
+ */
+export function toKebabCase(str: string): string {
+  return (
+    str
+      // Insert hyphen before uppercase letters (for PascalCase/camelCase)
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      // Replace underscores with hyphens
+      .replace(/_/g, '-')
+      // Convert to lowercase
+      .toLowerCase()
+  );
+}
+
+/**
+ * Convert a string to snake_case
+ *
+ * @example
+ * toSnakeCase('MyComponent') // 'my_component'
+ * toSnakeCase('myComponent') // 'my_component'
+ * toSnakeCase('my-component') // 'my_component'
+ */
+export function toSnakeCase(str: string): string {
+  return (
+    str
+      // Insert underscore before uppercase letters
+      .replace(/([a-z])([A-Z])/g, '$1_$2')
+      // Replace hyphens with underscores
+      .replace(/-/g, '_')
+      // Convert to lowercase
+      .toLowerCase()
+  );
+}
+
+/**
+ * Ensure a hook name starts with "use"
+ *
+ * @example
+ * normalizeHookName('Debounce') // 'useDebounce'
+ * normalizeHookName('useDebounce') // 'useDebounce'
+ * normalizeHookName('UseDebounce') // 'useDebounce'
+ */
+export function normalizeHookName(name: string): string {
+  // Remove existing 'use' prefix (case-insensitive)
+  const baseName = name.replace(/^use/i, '');
+  // Ensure proper casing
+  const pascalBase = toPascalCase(baseName);
+  return `use${pascalBase}`;
+}
+
+/**
+ * Get context-related names from a base context name
+ *
+ * @example
+ * getContextNames('Theme')
+ * // {
+ * //   ContextName: 'ThemeContext',
+ * //   ProviderName: 'ThemeProvider',
+ * //   consumerHookName: 'useTheme',
+ * //   contextDisplayName: 'Theme',
+ * //   baseName: 'Theme'
+ * // }
+ *
+ * getContextNames('ThemeContext')
+ * // Same as above - removes 'Context' suffix before processing
+ */
+export function getContextNames(name: string): {
+  ContextName: string;
+  ProviderName: string;
+  consumerHookName: string;
+  contextDisplayName: string;
+  baseName: string;
+} {
+  // Remove 'Context' or 'Provider' suffix if present
+  let baseName = name.replace(/Context$/i, '').replace(/Provider$/i, '');
+
+  baseName = toPascalCase(baseName);
+
+  return {
+    ContextName: `${baseName}Context`,
+    ProviderName: `${baseName}Provider`,
+    consumerHookName: `use${baseName}`,
+    contextDisplayName: baseName,
+    baseName,
+  };
+}
+
+/**
+ * Get component-related names
+ *
+ * @example
+ * getComponentNames('data-table')
+ * // {
+ * //   ComponentName: 'DataTable',
+ * //   componentName: 'dataTable',
+ * //   'component-name': 'data-table'
+ * // }
+ */
+export function getComponentNames(name: string): {
+  ComponentName: string;
+  componentName: string;
+  'component-name': string;
+} {
+  const ComponentName = toPascalCase(name);
+  const componentName = toCamelCase(name);
+  const kebabName = toKebabCase(name);
+
+  return {
+    ComponentName,
+    componentName,
+    'component-name': kebabName,
+  };
+}
+
+/**
+ * Get page-related names from a page path
+ *
+ * @example
+ * getPageNames('dashboard/settings')
+ * // {
+ * //   pageName: 'settings',
+ * //   PageName: 'Settings',
+ * //   pageTitle: 'Settings',
+ * //   pageDescription: 'Settings page',
+ * //   pagePath: 'dashboard/settings'
+ * // }
+ */
+export function getPageNames(pagePath: string): {
+  pageName: string;
+  PageName: string;
+  pageTitle: string;
+  pageDescription: string;
+  pagePath: string;
+} {
+  // Get the last segment of the path
+  const segments = pagePath.split('/').filter(Boolean);
+  const pageName = segments[segments.length - 1] || 'index';
+  const PageName = toPascalCase(pageName);
+  const pageTitle = PageName
+    // Add spaces before capital letters
+    .replace(/([A-Z])/g, ' $1')
+    .trim();
+
+  return {
+    pageName,
+    PageName,
+    pageTitle,
+    pageDescription: `${pageTitle} page`,
+    pagePath,
+  };
+}

--- a/packages/file-factory/src/utils/paths.ts
+++ b/packages/file-factory/src/utils/paths.ts
@@ -1,0 +1,128 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Get the directory containing the built-in templates
+ *
+ * Templates are located at: packages/file-factory/templates/
+ */
+export function getBuiltInTemplatesDir(): string {
+  // In ESM, we need to use import.meta.url to get the current file path
+  // This file is at src/utils/paths.ts, templates are at ../../../templates
+  const currentDir = path.dirname(fileURLToPath(import.meta.url));
+
+  // When running from source (development)
+  const devTemplatesDir = path.resolve(currentDir, '..', 'templates');
+  if (fs.existsSync(devTemplatesDir)) {
+    return devTemplatesDir;
+  }
+
+  // When running from dist (production)
+  // dist/utils/paths.js -> templates/
+  const distTemplatesDir = path.resolve(currentDir, '..', '..', 'templates');
+  if (fs.existsSync(distTemplatesDir)) {
+    return distTemplatesDir;
+  }
+
+  throw new Error(
+    'Could not locate built-in templates directory. ' +
+      `Checked: ${devTemplatesDir}, ${distTemplatesDir}`
+  );
+}
+
+/**
+ * Ensure a directory exists, creating it recursively if needed
+ */
+export async function ensureDir(dirPath: string): Promise<void> {
+  await fs.promises.mkdir(dirPath, { recursive: true });
+}
+
+/**
+ * Check if a path exists
+ */
+export async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a path exists (synchronous)
+ */
+export function pathExistsSync(targetPath: string): boolean {
+  try {
+    fs.accessSync(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read a file as a string
+ */
+export async function readFile(filePath: string): Promise<string> {
+  return fs.promises.readFile(filePath, 'utf-8');
+}
+
+/**
+ * Write a string to a file, creating directories as needed
+ */
+export async function writeFile(
+  filePath: string,
+  content: string
+): Promise<void> {
+  await ensureDir(path.dirname(filePath));
+  await fs.promises.writeFile(filePath, content, 'utf-8');
+}
+
+/**
+ * Get relative path from one file to another
+ */
+export function getRelativePath(from: string, to: string): string {
+  const relativePath = path.relative(path.dirname(from), to);
+  // Ensure it starts with ./ for relative imports
+  if (!relativePath.startsWith('.') && !relativePath.startsWith('/')) {
+    return `./${relativePath}`;
+  }
+  return relativePath;
+}
+
+/**
+ * Join paths and normalize
+ */
+export function joinPaths(...segments: string[]): string {
+  return path.join(...segments);
+}
+
+/**
+ * Resolve a path to absolute
+ */
+export function resolvePath(...segments: string[]): string {
+  return path.resolve(...segments);
+}
+
+/**
+ * Get the directory name of a path
+ */
+export function getDirname(filePath: string): string {
+  return path.dirname(filePath);
+}
+
+/**
+ * Get the base name of a path
+ */
+export function getBasename(filePath: string, ext?: string): string {
+  return path.basename(filePath, ext);
+}
+
+/**
+ * Get the extension of a path
+ */
+export function getExtension(filePath: string): string {
+  return path.extname(filePath);
+}

--- a/packages/file-factory/src/utils/templates.ts
+++ b/packages/file-factory/src/utils/templates.ts
@@ -1,0 +1,236 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import ejs from 'ejs';
+import glob from 'fast-glob';
+import {
+  getActualFilename,
+  interpolateFilename,
+  shouldIncludeConditionalFile,
+} from './interpolate.js';
+import { ensureDir, readFile, writeFile } from './paths.js';
+
+/**
+ * Template file information
+ */
+export interface TemplateFile {
+  /** Relative path within the template directory */
+  relativePath: string;
+  /** Absolute path to the template file */
+  absolutePath: string;
+  /** Whether this is a directory */
+  isDirectory: boolean;
+}
+
+/**
+ * Discover all template files in a directory
+ *
+ * Returns files in order suitable for processing (directories first)
+ */
+export async function discoverTemplateFiles(
+  templatesDir: string
+): Promise<TemplateFile[]> {
+  const entries = await glob('**/*', {
+    cwd: templatesDir,
+    dot: true,
+    onlyFiles: false,
+    markDirectories: true,
+  });
+
+  const templateFiles: TemplateFile[] = [];
+
+  for (const entry of entries) {
+    const isDirectory = entry.endsWith('/');
+    const relativePath = isDirectory ? entry.slice(0, -1) : entry;
+    const absolutePath = path.join(templatesDir, relativePath);
+
+    templateFiles.push({
+      relativePath,
+      absolutePath,
+      isDirectory,
+    });
+  }
+
+  // Sort to ensure directories come before their contents
+  templateFiles.sort((a, b) => {
+    // Directories first
+    if (a.isDirectory && !b.isDirectory) return -1;
+    if (!a.isDirectory && b.isDirectory) return 1;
+    // Then by path length (shorter first)
+    return a.relativePath.localeCompare(b.relativePath);
+  });
+
+  return templateFiles;
+}
+
+/**
+ * Render an EJS template string with the provided data
+ */
+export function renderTemplate(
+  template: string,
+  data: Record<string, unknown>
+): string {
+  return ejs.render(template, data, {
+    // Don't escape HTML entities
+    escape: (str: string) => str,
+  });
+}
+
+/**
+ * Render an EJS template file with the provided data
+ */
+export async function renderTemplateFile(
+  templatePath: string,
+  data: Record<string, unknown>
+): Promise<string> {
+  const template = await readFile(templatePath);
+  return renderTemplate(template, data);
+}
+
+/**
+ * Options for processing templates
+ */
+export interface ProcessTemplatesOptions {
+  /** Path to the template directory */
+  templatesDir: string;
+  /** Target directory for output */
+  targetDir: string;
+  /** Variables for filename interpolation */
+  filenameVariables: Record<string, string>;
+  /** Data for template rendering */
+  templateData: Record<string, unknown>;
+  /** Flags for conditional file inclusion */
+  conditionalFlags: Record<string, boolean>;
+  /** Dry run mode - don't write files */
+  dryRun?: boolean;
+}
+
+/**
+ * Result of processing templates
+ */
+export interface ProcessTemplatesResult {
+  /** List of created files (absolute paths) */
+  createdFiles: string[];
+  /** List of created directories (absolute paths) */
+  createdDirectories: string[];
+  /** List of skipped files (conditional files that weren't included) */
+  skippedFiles: string[];
+}
+
+/**
+ * Process a template directory and generate output files
+ *
+ * This function:
+ * 1. Walks the template directory tree
+ * 2. Interpolates {{VariableName}} in filenames
+ * 3. Handles conditional files (_when_condition_filename)
+ * 4. Processes .ejs files through the EJS template engine
+ * 5. Writes the results to the target directory
+ */
+export async function processTemplates(
+  options: ProcessTemplatesOptions
+): Promise<ProcessTemplatesResult> {
+  const {
+    templatesDir,
+    targetDir,
+    filenameVariables,
+    templateData,
+    conditionalFlags,
+    dryRun = false,
+  } = options;
+
+  const result: ProcessTemplatesResult = {
+    createdFiles: [],
+    createdDirectories: [],
+    skippedFiles: [],
+  };
+
+  // Discover all template files
+  const templateFiles = await discoverTemplateFiles(templatesDir);
+
+  for (const templateFile of templateFiles) {
+    const { relativePath, absolutePath, isDirectory } = templateFile;
+
+    // Get the filename (last segment of path)
+    const segments = relativePath.split('/');
+    const filename = segments[segments.length - 1];
+
+    // Check conditional inclusion
+    if (!shouldIncludeConditionalFile(filename, conditionalFlags)) {
+      result.skippedFiles.push(absolutePath);
+      continue;
+    }
+
+    // Get actual filename (without _when_ prefix)
+    const actualFilename = getActualFilename(filename);
+
+    // Interpolate the filename
+    const interpolatedFilename = interpolateFilename(
+      actualFilename,
+      filenameVariables
+    );
+
+    // Build the full target path
+    const parentPath = segments.slice(0, -1).join('/');
+    const interpolatedParentPath = parentPath
+      ? interpolateFilename(parentPath, filenameVariables)
+      : '';
+    const targetPath = path.join(
+      targetDir,
+      interpolatedParentPath,
+      interpolatedFilename
+    );
+
+    if (isDirectory) {
+      // Create directory
+      if (!dryRun) {
+        await ensureDir(targetPath);
+      }
+      result.createdDirectories.push(targetPath);
+    } else {
+      // Process file
+      const isEjsTemplate = absolutePath.endsWith('.ejs');
+
+      let content: string;
+      if (isEjsTemplate) {
+        // Render EJS template
+        content = await renderTemplateFile(absolutePath, templateData);
+      } else {
+        // Copy file as-is
+        content = await readFile(absolutePath);
+      }
+
+      if (!dryRun) {
+        await writeFile(targetPath, content);
+      }
+      result.createdFiles.push(targetPath);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Check if a template directory exists
+ */
+export function templateExists(templatesDir: string): boolean {
+  return fs.existsSync(templatesDir);
+}
+
+/**
+ * Get available template types in a directory
+ */
+export async function getAvailableTemplateTypes(
+  templatesDir: string
+): Promise<string[]> {
+  if (!fs.existsSync(templatesDir)) {
+    return [];
+  }
+
+  const entries = await fs.promises.readdir(templatesDir, {
+    withFileTypes: true,
+  });
+
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}

--- a/packages/file-factory/templates/component-with-context/{{ComponentName}}/_when_withCssModules_{{ComponentName}}.module.css.ejs
+++ b/packages/file-factory/templates/component-with-context/{{ComponentName}}/_when_withCssModules_{{ComponentName}}.module.css.ejs
@@ -1,0 +1,7 @@
+/**
+ * <%= ComponentName %> styles
+ */
+
+.root {
+  /* Add styles here */
+}

--- a/packages/file-factory/templates/component-with-context/{{ComponentName}}/_when_withTest_{{ComponentName}}.test.tsx.ejs
+++ b/packages/file-factory/templates/component-with-context/{{ComponentName}}/_when_withTest_{{ComponentName}}.test.tsx.ejs
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import <%= ComponentName %>, { <%= ComponentName %>Inner } from './<%= ComponentName %>';
+import { <%= ProviderName %> } from './<%= ComponentName %>Context';
+
+describe('<%= ComponentName %>', () => {
+  it('renders children with built-in provider', () => {
+    render(<<%= ComponentName %>>Test content</<%= ComponentName %>>);
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('renders children with external provider', () => {
+    render(
+      <<%= ProviderName %>>
+        <<%= ComponentName %>Inner>Test content</<%= ComponentName %>Inner>
+      </<%= ProviderName %>>
+    );
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <<%= ComponentName %> className="custom-class">Content</<%= ComponentName %>>
+    );
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});
+
+describe('<%= ComponentName %>Inner', () => {
+  it('throws error when used outside provider', () => {
+    // Suppress console.error for this test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      render(<<%= ComponentName %>Inner>Content</<%= ComponentName %>Inner>);
+    }).toThrow('use<%= baseName %> must be used within a <%= ProviderName %>');
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/file-factory/templates/component-with-context/{{ComponentName}}/index.ts.ejs
+++ b/packages/file-factory/templates/component-with-context/{{ComponentName}}/index.ts.ejs
@@ -1,0 +1,15 @@
+<% if (appRouterBarrel) { -%>
+// App Router compatible barrel
+export { default } from './<%= ComponentName %>';
+export type { <%= ComponentName %>Props } from './<%= ComponentName %>';
+<% } else { -%>
+export * from './<%= ComponentName %>';
+export { default } from './<%= ComponentName %>';
+<% } -%>
+
+// Context exports
+export { <%= ProviderName %>, use<%= baseName %> } from './<%= ComponentName %>Context';
+export type {
+  <%= ComponentName %>ContextValue,
+  <%= ProviderName %>Props,
+} from './<%= ComponentName %>Context';

--- a/packages/file-factory/templates/component-with-context/{{ComponentName}}/{{ComponentName}}.tsx.ejs
+++ b/packages/file-factory/templates/component-with-context/{{ComponentName}}/{{ComponentName}}.tsx.ejs
@@ -1,0 +1,77 @@
+<% if (styleSystem === 'css-modules') { -%>
+import styles from './<%= ComponentName %>.module.css';
+<% } else if (styleSystem === 'styled-components') { -%>
+import styled from 'styled-components';
+<% } -%>
+import { <%= ProviderName %>, use<%= baseName %> } from './<%= ComponentName %>Context';
+
+export type <%= ComponentName %>Props = {
+  /** Optional className for styling overrides */
+  className?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * <%= ComponentName %> component
+ *
+ * This component must be wrapped in a <%= ProviderName %> or use
+ * the default export which includes the provider.
+ *
+ * @example
+ * ```tsx
+ * <<%= ComponentName %>>Content</<%= ComponentName %>>
+ * ```
+ */
+export function <%= ComponentName %>Inner({
+  className,
+  children,
+}: <%= ComponentName %>Props) {
+  // Access context
+  const context = use<%= baseName %>();
+
+<% if (styleSystem === 'css-modules') { -%>
+  const rootClassName = className
+    ? `${styles.root} ${className}`
+    : styles.root;
+
+  return (
+    <div className={rootClassName}>
+      {children}
+    </div>
+  );
+<% } else if (styleSystem === 'styled-components') { -%>
+  return (
+    <Root className={className}>
+      {children}
+    </Root>
+  );
+<% } else { -%>
+  return (
+    <div className={className}>
+      {children}
+    </div>
+  );
+<% } -%>
+}
+<% if (styleSystem === 'styled-components') { -%>
+
+const Root = styled.div`
+  /* Add styles here */
+`;
+<% } -%>
+
+/**
+ * <%= ComponentName %> with its own Provider
+ *
+ * Use this when the component should manage its own state.
+ * For shared state, wrap multiple components in a single <%= ProviderName %>.
+ */
+export function <%= ComponentName %>(props: <%= ComponentName %>Props) {
+  return (
+    <<%= ProviderName %>>
+      <<%= ComponentName %>Inner {...props} />
+    </<%= ProviderName %>>
+  );
+}
+
+export default <%= ComponentName %>;

--- a/packages/file-factory/templates/component-with-context/{{ComponentName}}/{{ComponentName}}Context.tsx.ejs
+++ b/packages/file-factory/templates/component-with-context/{{ComponentName}}/{{ComponentName}}Context.tsx.ejs
@@ -1,0 +1,88 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  type ReactNode,
+} from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type <%= ComponentName %>ContextState = {
+  // Add state properties specific to <%= ComponentName %>
+};
+
+type <%= ComponentName %>ContextActions = {
+  // Add actions specific to <%= ComponentName %>
+};
+
+export type <%= ComponentName %>ContextValue =
+  <%= ComponentName %>ContextState & <%= ComponentName %>ContextActions;
+
+export type <%= ProviderName %>Props = {
+  children: ReactNode;
+};
+
+// ============================================================================
+// Context (internal - use the hook instead)
+// ============================================================================
+
+const <%= ComponentName %>Context = createContext<<%= ComponentName %>ContextValue | null>(null);
+<%= ComponentName %>Context.displayName = '<%= ComponentName %>Context';
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+/**
+ * Provides <%= ComponentName %> state to child components
+ *
+ * @example
+ * ```tsx
+ * <<%= ProviderName %>>
+ *   <<%= ComponentName %>Inner />
+ * </<%= ProviderName %>>
+ * ```
+ */
+export function <%= ProviderName %>({ children }: <%= ProviderName %>Props) {
+  const [state, setState] = useState<<%= ComponentName %>ContextState>({
+    // Initial state
+  });
+
+  const value = useMemo<<%= ComponentName %>ContextValue>(
+    () => ({
+      ...state,
+      // Add actions
+    }),
+    [state]
+  );
+
+  return (
+    <<%= ComponentName %>Context.Provider value={value}>
+      {children}
+    </<%= ComponentName %>Context.Provider>
+  );
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Access <%= ComponentName %> context
+ *
+ * Must be used within a <%= ProviderName %>
+ */
+export function use<%= baseName %>(): <%= ComponentName %>ContextValue {
+  const context = useContext(<%= ComponentName %>Context);
+
+  if (context === null) {
+    throw new Error(
+      'use<%= baseName %> must be used within a <%= ProviderName %>'
+    );
+  }
+
+  return context;
+}

--- a/packages/file-factory/templates/component/{{ComponentName}}/_when_withCssModules_{{ComponentName}}.module.css.ejs
+++ b/packages/file-factory/templates/component/{{ComponentName}}/_when_withCssModules_{{ComponentName}}.module.css.ejs
@@ -1,0 +1,7 @@
+/**
+ * <%= ComponentName %> styles
+ */
+
+.root {
+  /* Add styles here */
+}

--- a/packages/file-factory/templates/component/{{ComponentName}}/_when_withStory_{{ComponentName}}.stories.tsx.ejs
+++ b/packages/file-factory/templates/component/{{ComponentName}}/_when_withStory_{{ComponentName}}.stories.tsx.ejs
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import <%= ComponentName %> from './<%= ComponentName %>';
+
+const meta: Meta<typeof <%= ComponentName %>> = {
+  title: 'Components/<%= ComponentName %>',
+  component: <%= ComponentName %>,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof <%= ComponentName %>>;
+
+/**
+ * Default <%= ComponentName %> story
+ */
+export const Default: Story = {
+  args: {
+    children: '<%= ComponentName %> content',
+  },
+};
+
+/**
+ * <%= ComponentName %> with custom className
+ */
+export const WithClassName: Story = {
+  args: {
+    children: 'Styled content',
+    className: 'custom-class',
+  },
+};

--- a/packages/file-factory/templates/component/{{ComponentName}}/_when_withTest_{{ComponentName}}.test.tsx.ejs
+++ b/packages/file-factory/templates/component/{{ComponentName}}/_when_withTest_{{ComponentName}}.test.tsx.ejs
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import <%= ComponentName %> from './<%= ComponentName %>';
+
+describe('<%= ComponentName %>', () => {
+  it('renders children', () => {
+    render(<<%= ComponentName %>>Test content</<%= ComponentName %>>);
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const { container } = render(
+      <<%= ComponentName %> className="custom-class">Content</<%= ComponentName %>>
+    );
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+});

--- a/packages/file-factory/templates/component/{{ComponentName}}/index.ts.ejs
+++ b/packages/file-factory/templates/component/{{ComponentName}}/index.ts.ejs
@@ -1,0 +1,8 @@
+<% if (appRouterBarrel) { -%>
+// App Router compatible barrel (no wildcard exports)
+export { default } from './<%= ComponentName %>';
+export type { <%= ComponentName %>Props } from './<%= ComponentName %>';
+<% } else { -%>
+export * from './<%= ComponentName %>';
+export { default } from './<%= ComponentName %>';
+<% } -%>

--- a/packages/file-factory/templates/component/{{ComponentName}}/{{ComponentName}}.tsx.ejs
+++ b/packages/file-factory/templates/component/{{ComponentName}}/{{ComponentName}}.tsx.ejs
@@ -1,0 +1,56 @@
+<% if (styleSystem === 'css-modules') { -%>
+import styles from './<%= ComponentName %>.module.css';
+<% } else if (styleSystem === 'styled-components') { -%>
+import styled from 'styled-components';
+<% } -%>
+
+export type <%= ComponentName %>Props = {
+  /** Optional className for styling overrides */
+  className?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * <%= ComponentName %> component
+ *
+ * @example
+ * ```tsx
+ * <<%= ComponentName %>>Content</<%= ComponentName %>>
+ * ```
+ */
+export function <%= ComponentName %>({
+  className,
+  children,
+}: <%= ComponentName %>Props) {
+<% if (styleSystem === 'css-modules') { -%>
+  const rootClassName = className
+    ? `${styles.root} ${className}`
+    : styles.root;
+
+  return (
+    <div className={rootClassName}>
+      {children}
+    </div>
+  );
+<% } else if (styleSystem === 'styled-components') { -%>
+  return (
+    <Root className={className}>
+      {children}
+    </Root>
+  );
+<% } else { -%>
+  return (
+    <div className={className}>
+      {children}
+    </div>
+  );
+<% } -%>
+}
+<% if (styleSystem === 'styled-components') { -%>
+
+const Root = styled.div`
+  /* Add styles here */
+`;
+<% } -%>
+
+export default <%= ComponentName %>;

--- a/packages/file-factory/templates/context/{{ContextName}}/index.ts.ejs
+++ b/packages/file-factory/templates/context/{{ContextName}}/index.ts.ejs
@@ -1,0 +1,6 @@
+// Export Provider, hook, and types - NOT the raw context
+export { <%= ProviderName %>, <%= consumerHookName %> } from './<%= ContextName %>';
+export type {
+  <%= ContextName %>Value,
+  <%= ProviderName %>Props,
+} from './<%= ContextName %>';

--- a/packages/file-factory/templates/context/{{ContextName}}/{{ContextName}}.tsx.ejs
+++ b/packages/file-factory/templates/context/{{ContextName}}/{{ContextName}}.tsx.ejs
@@ -1,0 +1,103 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  type ReactNode,
+} from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type <%= ContextName %>State = {
+  // Add state properties here
+};
+
+type <%= ContextName %>Actions = {
+  // Add action methods here
+};
+
+export type <%= ContextName %>Value = <%= ContextName %>State & <%= ContextName %>Actions;
+
+export type <%= ProviderName %>Props = {
+  children: ReactNode;
+  /** Optional initial state override */
+  initialState?: Partial<<%= ContextName %>State>;
+};
+
+// ============================================================================
+// Context (internal - use the hook instead)
+// ============================================================================
+
+const <%= ContextName %> = createContext<<%= ContextName %>Value | null>(null);
+<%= ContextName %>.displayName = '<%= ContextName %>';
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+/**
+ * <%= ProviderName %> - Provides <%= contextDisplayName %> state to the app
+ *
+ * @example
+ * ```tsx
+ * // In your app root
+ * <<%= ProviderName %>>
+ *   <App />
+ * </<%= ProviderName %>>
+ * ```
+ */
+export function <%= ProviderName %>({
+  children,
+  initialState = {},
+}: <%= ProviderName %>Props) {
+  const [state, setState] = useState<<%= ContextName %>State>({
+    // Default state
+    ...initialState,
+  });
+
+  const value = useMemo<<%= ContextName %>Value>(
+    () => ({
+      ...state,
+      // Add actions here
+    }),
+    [state]
+  );
+
+  return (
+    <<%= ContextName %>.Provider value={value}>
+      {children}
+    </<%= ContextName %>.Provider>
+  );
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * <%= consumerHookName %> - Access <%= contextDisplayName %> state
+ *
+ * Must be used within a <%= ProviderName %>
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { someValue } = <%= consumerHookName %>();
+ *   // ...
+ * }
+ * ```
+ */
+export function <%= consumerHookName %>(): <%= ContextName %>Value {
+  const context = useContext(<%= ContextName %>);
+
+  if (context === null) {
+    throw new Error(
+      '<%= consumerHookName %> must be used within a <%= ProviderName %>. ' +
+      'Wrap your component tree with <<%= ProviderName %>> to fix this error.'
+    );
+  }
+
+  return context;
+}

--- a/packages/file-factory/templates/hook-with-directory/{{hookName}}/_when_withTest_{{hookName}}.test.ts.ejs
+++ b/packages/file-factory/templates/hook-with-directory/{{hookName}}/_when_withTest_{{hookName}}.test.ts.ejs
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { <%= hookName %> } from './<%= hookName %>';
+
+describe('<%= hookName %>', () => {
+  it('returns initial null value', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+    expect(result.current.value).toBeNull();
+  });
+
+  it('updates value', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+
+    act(() => {
+      result.current.setValue('test');
+    });
+
+    expect(result.current.value).toBe('test');
+  });
+
+  it('resets value', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+
+    act(() => {
+      result.current.setValue('test');
+    });
+
+    expect(result.current.value).toBe('test');
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.value).toBeNull();
+  });
+});

--- a/packages/file-factory/templates/hook-with-directory/{{hookName}}/index.ts.ejs
+++ b/packages/file-factory/templates/hook-with-directory/{{hookName}}/index.ts.ejs
@@ -1,0 +1,1 @@
+export { <%= hookName %>, default } from './<%= hookName %>';

--- a/packages/file-factory/templates/hook-with-directory/{{hookName}}/{{hookName}}.ts.ejs
+++ b/packages/file-factory/templates/hook-with-directory/{{hookName}}/{{hookName}}.ts.ejs
@@ -1,0 +1,28 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * <%= hookName %> hook
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { value, setValue, reset } = <%= hookName %>();
+ *   // ...
+ * }
+ * ```
+ */
+export function <%= hookName %>() {
+  const [value, setValue] = useState<unknown>(null);
+
+  const reset = useCallback(() => {
+    setValue(null);
+  }, []);
+
+  return {
+    value,
+    setValue,
+    reset,
+  } as const;
+}
+
+export default <%= hookName %>;

--- a/packages/file-factory/templates/hook/_when_withTest_{{hookName}}.test.ts.ejs
+++ b/packages/file-factory/templates/hook/_when_withTest_{{hookName}}.test.ts.ejs
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { <%= hookName %> } from './<%= hookName %>';
+
+describe('<%= hookName %>', () => {
+  it('returns initial null value', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+    expect(result.current.value).toBeNull();
+  });
+
+  it('updates value', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+
+    act(() => {
+      result.current.setValue('test');
+    });
+
+    expect(result.current.value).toBe('test');
+  });
+
+  it('resets value', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+
+    act(() => {
+      result.current.setValue('test');
+    });
+
+    expect(result.current.value).toBe('test');
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.value).toBeNull();
+  });
+});

--- a/packages/file-factory/templates/hook/{{hookName}}.ts.ejs
+++ b/packages/file-factory/templates/hook/{{hookName}}.ts.ejs
@@ -1,0 +1,28 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * <%= hookName %> hook
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { value, setValue, reset } = <%= hookName %>();
+ *   // ...
+ * }
+ * ```
+ */
+export function <%= hookName %>() {
+  const [value, setValue] = useState<unknown>(null);
+
+  const reset = useCallback(() => {
+    setValue(null);
+  }, []);
+
+  return {
+    value,
+    setValue,
+    reset,
+  } as const;
+}
+
+export default <%= hookName %>;

--- a/packages/file-factory/templates/page-app/page.tsx.ejs
+++ b/packages/file-factory/templates/page-app/page.tsx.ejs
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '<%= pageTitle %>',
+  description: '<%= pageDescription %>',
+};
+
+type <%= PageName %>PageProps = {
+  params: Promise<{ /* Add route params here */ }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+};
+
+export default async function <%= PageName %>Page({
+  params,
+  searchParams,
+}: <%= PageName %>PageProps) {
+  return (
+    <main>
+      <h1><%= pageTitle %></h1>
+    </main>
+  );
+}

--- a/packages/file-factory/templates/page-pages/{{pageName}}.tsx.ejs
+++ b/packages/file-factory/templates/page-pages/{{pageName}}.tsx.ejs
@@ -1,0 +1,32 @@
+import type { NextPage, GetServerSideProps } from 'next';
+import Head from 'next/head';
+
+type <%= PageName %>PageProps = {
+  // Add props here
+};
+
+const <%= PageName %>Page: NextPage<<%= PageName %>PageProps> = (props) => {
+  return (
+    <>
+      <Head>
+        <title><%= pageTitle %></title>
+        <meta name="description" content="<%= pageDescription %>" />
+      </Head>
+      <main>
+        <h1><%= pageTitle %></h1>
+      </main>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<<%= PageName %>PageProps> = async (
+  context
+) => {
+  return {
+    props: {
+      // Add props here
+    },
+  };
+};
+
+export default <%= PageName %>Page;

--- a/packages/file-factory/tsconfig.json
+++ b/packages/file-factory/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@lsst-sqre/tsconfig/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/file-factory/tsup.config.ts
+++ b/packages/file-factory/tsup.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  // Main library and config exports
+  {
+    entry: {
+      index: 'src/index.ts',
+      'config/index': 'src/config/index.ts',
+    },
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    splitting: true,
+    sourcemap: true,
+    target: 'node18',
+  },
+  // CLI entry point with shebang
+  {
+    entry: {
+      cli: 'src/cli.ts',
+    },
+    format: ['esm'],
+    dts: false,
+    clean: false,
+    sourcemap: true,
+    target: 'node18',
+    banner: {
+      js: '#!/usr/bin/env node',
+    },
+  },
+]);

--- a/packages/file-factory/vitest.config.ts
+++ b/packages/file-factory/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/packages/squared/.file-factory/config.mts
+++ b/packages/squared/.file-factory/config.mts
@@ -1,0 +1,50 @@
+// Export plain object - defineConfig import not needed, loader validates config
+export default {
+  component: {
+    directory: 'src/components',
+    styleSystem: 'css-modules', // squared uses CSS Modules only
+    withTest: true,
+    withStory: true, // Generate Storybook stories
+    appRouterBarrel: false, // Library doesn't use App Router
+    updateBarrels: [
+      {
+        file: 'src/components/index.ts',
+        template: "export * from './{{ComponentName}}';\n",
+        position: 'alphabetical',
+      },
+      {
+        file: 'src/index.ts',
+        template: "export * from './components/{{ComponentName}}';\n",
+        position: 'alphabetical',
+      },
+    ],
+  },
+  hook: {
+    directory: 'src/hooks',
+    withTest: true,
+    useDirectory: true, // Hooks in their own directories
+    updateBarrels: [
+      {
+        file: 'src/hooks/index.ts',
+        template: "export { {{hookName}} } from './{{hookName}}';\n",
+        position: 'alphabetical',
+      },
+      {
+        file: 'src/index.ts',
+        template: "export { {{hookName}} } from './hooks/{{hookName}}';\n",
+        position: 'alphabetical',
+      },
+    ],
+  },
+  context: {
+    directory: 'src/contexts',
+    withTest: true,
+    updateBarrels: [
+      {
+        file: 'src/index.ts',
+        template: "export * from './contexts/{{ContextName}}';\n",
+        position: 'alphabetical',
+      },
+    ],
+  },
+};

--- a/packages/squared/.file-factory/templates/component/{{ComponentName}}/_when_withCssModules_{{ComponentName}}.module.css.ejs
+++ b/packages/squared/.file-factory/templates/component/{{ComponentName}}/_when_withCssModules_{{ComponentName}}.module.css.ejs
@@ -1,0 +1,7 @@
+/**
+ * <%= ComponentName %> styles
+ */
+
+.root {
+  /* Add styles here */
+}

--- a/packages/squared/.file-factory/templates/component/{{ComponentName}}/_when_withStory_{{ComponentName}}.stories.tsx.ejs
+++ b/packages/squared/.file-factory/templates/component/{{ComponentName}}/_when_withStory_{{ComponentName}}.stories.tsx.ejs
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import <%= ComponentName %> from './<%= ComponentName %>';
+
+const meta: Meta<typeof <%= ComponentName %>> = {
+  title: 'Components/<%= ComponentName %>',
+  component: <%= ComponentName %>,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { children: '<%= ComponentName %> content' },
+};
+
+export const InteractionTest: Story = {
+  args: { children: 'Test content' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Test content')).toBeInTheDocument();
+  },
+};

--- a/packages/squared/.file-factory/templates/component/{{ComponentName}}/_when_withTest_{{ComponentName}}.test.tsx.ejs
+++ b/packages/squared/.file-factory/templates/component/{{ComponentName}}/_when_withTest_{{ComponentName}}.test.tsx.ejs
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import <%= ComponentName %> from './<%= ComponentName %>';
+
+describe('<%= ComponentName %>', () => {
+  it('renders', () => {
+    render(<<%= ComponentName %>>Content</<%= ComponentName %>>);
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+});

--- a/packages/squared/.file-factory/templates/component/{{ComponentName}}/index.ts.ejs
+++ b/packages/squared/.file-factory/templates/component/{{ComponentName}}/index.ts.ejs
@@ -1,0 +1,8 @@
+<% if (appRouterBarrel) { -%>
+// App Router compatible barrel (no wildcard exports)
+export { default } from './<%= ComponentName %>';
+export type { <%= ComponentName %>Props } from './<%= ComponentName %>';
+<% } else { -%>
+export * from './<%= ComponentName %>';
+export { default } from './<%= ComponentName %>';
+<% } -%>

--- a/packages/squared/.file-factory/templates/component/{{ComponentName}}/{{ComponentName}}.tsx.ejs
+++ b/packages/squared/.file-factory/templates/component/{{ComponentName}}/{{ComponentName}}.tsx.ejs
@@ -1,0 +1,56 @@
+<% if (styleSystem === 'css-modules') { -%>
+import styles from './<%= ComponentName %>.module.css';
+<% } else if (styleSystem === 'styled-components') { -%>
+import styled from 'styled-components';
+<% } -%>
+
+export type <%= ComponentName %>Props = {
+  /** Optional className for styling overrides */
+  className?: string;
+  children?: React.ReactNode;
+};
+
+/**
+ * <%= ComponentName %> component
+ *
+ * @example
+ * ```tsx
+ * <<%= ComponentName %>>Content</<%= ComponentName %>>
+ * ```
+ */
+export function <%= ComponentName %>({
+  className,
+  children,
+}: <%= ComponentName %>Props) {
+<% if (styleSystem === 'css-modules') { -%>
+  const rootClassName = className
+    ? `${styles.root} ${className}`
+    : styles.root;
+
+  return (
+    <div className={rootClassName}>
+      {children}
+    </div>
+  );
+<% } else if (styleSystem === 'styled-components') { -%>
+  return (
+    <Root className={className}>
+      {children}
+    </Root>
+  );
+<% } else { -%>
+  return (
+    <div className={className}>
+      {children}
+    </div>
+  );
+<% } -%>
+}
+<% if (styleSystem === 'styled-components') { -%>
+
+const Root = styled.div`
+  /* Add styles here */
+`;
+<% } -%>
+
+export default <%= ComponentName %>;

--- a/packages/squared/.file-factory/templates/context/{{ContextName}}/_when_withTest_{{ContextName}}.test.tsx.ejs
+++ b/packages/squared/.file-factory/templates/context/{{ContextName}}/_when_withTest_{{ContextName}}.test.tsx.ejs
@@ -1,0 +1,20 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { <%= ProviderName %>, <%= consumerHookName %> } from './<%= ContextName %>';
+
+function TestConsumer() {
+  const value = <%= consumerHookName %>();
+  return <div data-testid="value">{JSON.stringify(value)}</div>;
+}
+
+describe('<%= ContextName %>', () => {
+  it('provides value to consumers', () => {
+    render(
+      <<%= ProviderName %>>
+        <TestConsumer />
+      </<%= ProviderName %>>
+    );
+    expect(screen.getByTestId('value')).toBeInTheDocument();
+  });
+});

--- a/packages/squared/.file-factory/templates/context/{{ContextName}}/index.ts.ejs
+++ b/packages/squared/.file-factory/templates/context/{{ContextName}}/index.ts.ejs
@@ -1,0 +1,6 @@
+// Export Provider, hook, and types - NOT the raw context
+export { <%= ProviderName %>, <%= consumerHookName %> } from './<%= ContextName %>';
+export type {
+  <%= ContextName %>Value,
+  <%= ProviderName %>Props,
+} from './<%= ContextName %>';

--- a/packages/squared/.file-factory/templates/context/{{ContextName}}/{{ContextName}}.tsx.ejs
+++ b/packages/squared/.file-factory/templates/context/{{ContextName}}/{{ContextName}}.tsx.ejs
@@ -1,0 +1,103 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  type ReactNode,
+} from 'react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type <%= ContextName %>State = {
+  // Add state properties here
+};
+
+type <%= ContextName %>Actions = {
+  // Add action methods here
+};
+
+export type <%= ContextName %>Value = <%= ContextName %>State & <%= ContextName %>Actions;
+
+export type <%= ProviderName %>Props = {
+  children: ReactNode;
+  /** Optional initial state override */
+  initialState?: Partial<<%= ContextName %>State>;
+};
+
+// ============================================================================
+// Context (internal - use the hook instead)
+// ============================================================================
+
+const <%= ContextName %> = createContext<<%= ContextName %>Value | null>(null);
+<%= ContextName %>.displayName = '<%= ContextName %>';
+
+// ============================================================================
+// Provider
+// ============================================================================
+
+/**
+ * <%= ProviderName %> - Provides <%= contextDisplayName %> state to the app
+ *
+ * @example
+ * ```tsx
+ * // In your app root
+ * <<%= ProviderName %>>
+ *   <App />
+ * </<%= ProviderName %>>
+ * ```
+ */
+export function <%= ProviderName %>({
+  children,
+  initialState = {},
+}: <%= ProviderName %>Props) {
+  const [state, setState] = useState<<%= ContextName %>State>({
+    // Default state
+    ...initialState,
+  });
+
+  const value = useMemo<<%= ContextName %>Value>(
+    () => ({
+      ...state,
+      // Add actions here
+    }),
+    [state]
+  );
+
+  return (
+    <<%= ContextName %>.Provider value={value}>
+      {children}
+    </<%= ContextName %>.Provider>
+  );
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * <%= consumerHookName %> - Access <%= contextDisplayName %> state
+ *
+ * Must be used within a <%= ProviderName %>
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { someValue } = <%= consumerHookName %>();
+ *   // ...
+ * }
+ * ```
+ */
+export function <%= consumerHookName %>(): <%= ContextName %>Value {
+  const context = useContext(<%= ContextName %>);
+
+  if (context === null) {
+    throw new Error(
+      '<%= consumerHookName %> must be used within a <%= ProviderName %>. ' +
+      'Wrap your component tree with <<%= ProviderName %>> to fix this error.'
+    );
+  }
+
+  return context;
+}

--- a/packages/squared/.file-factory/templates/hook-with-directory/{{hookName}}/_when_withTest_{{hookName}}.test.ts.ejs
+++ b/packages/squared/.file-factory/templates/hook-with-directory/{{hookName}}/_when_withTest_{{hookName}}.test.ts.ejs
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { <%= hookName %> } from './<%= hookName %>';
+
+describe('<%= hookName %>', () => {
+  it('returns expected initial value', () => {
+    const { result } = renderHook(() => <%= hookName %>());
+    expect(result.current).toBeDefined();
+  });
+});

--- a/packages/squared/.file-factory/templates/hook-with-directory/{{hookName}}/index.ts.ejs
+++ b/packages/squared/.file-factory/templates/hook-with-directory/{{hookName}}/index.ts.ejs
@@ -1,0 +1,1 @@
+export { <%= hookName %>, default } from './<%= hookName %>';

--- a/packages/squared/.file-factory/templates/hook-with-directory/{{hookName}}/{{hookName}}.ts.ejs
+++ b/packages/squared/.file-factory/templates/hook-with-directory/{{hookName}}/{{hookName}}.ts.ejs
@@ -1,0 +1,28 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * <%= hookName %> hook
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { value, setValue, reset } = <%= hookName %>();
+ *   // ...
+ * }
+ * ```
+ */
+export function <%= hookName %>() {
+  const [value, setValue] = useState<unknown>(null);
+
+  const reset = useCallback(() => {
+    setValue(null);
+  }, []);
+
+  return {
+    value,
+    setValue,
+    reset,
+  } as const;
+}
+
+export default <%= hookName %>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         version: 2.0.1
       '@sentry/nextjs':
         specifier: ^10.27.0
-        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0))(react@19.2.0)(webpack@5.101.3(esbuild@0.25.12))
+        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0))(react@19.2.0)(webpack@5.101.3(esbuild@0.27.1))
       ajv:
         specifier: ^8.11.0
         version: 8.17.1
@@ -137,7 +137,7 @@ importers:
         version: 10.0.8(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))
       '@storybook/addon-docs':
         specifier: 10.0.8
-        version: 10.0.8(@types/react@19.2.7)(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+        version: 10.0.8(@types/react@19.2.7)(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       '@storybook/addon-links':
         specifier: 10.0.8
         version: 10.0.8(react@19.2.0)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))
@@ -149,7 +149,7 @@ importers:
         version: 10.0.8(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vitest@3.2.4)
       '@storybook/nextjs-vite':
         specifier: ^10.0.8
-        version: 10.0.8(@babel/core@7.28.5)(esbuild@0.25.12)(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+        version: 10.0.8(@babel/core@7.28.5)(esbuild@0.27.1)(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       '@storybook/testing-library':
         specifier: ^0.2.2
         version: 0.2.2
@@ -185,7 +185,7 @@ importers:
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
       babel-loader:
         specifier: ^9.1.2
-        version: 9.2.1(@babel/core@7.28.5)(webpack@5.101.3(esbuild@0.25.12))
+        version: 9.2.1(@babel/core@7.28.5)(webpack@5.101.3(esbuild@0.27.1))
       chromatic:
         specifier: ^6.17.1
         version: 6.24.1
@@ -225,6 +225,46 @@ importers:
       eslint-plugin-react:
         specifier: ^7.33.1
         version: 7.37.5(eslint@8.57.1)
+
+  packages/file-factory:
+    dependencies:
+      '@inquirer/prompts':
+        specifier: ^7.2.1
+        version: 7.10.1(@types/node@22.19.1)
+      chalk:
+        specifier: ^5.4.1
+        version: 5.6.2
+      commander:
+        specifier: ^13.0.0
+        version: 13.1.0
+      ejs:
+        specifier: ^3.1.10
+        version: 3.1.10
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      '@lsst-sqre/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/ejs':
+        specifier: ^3.1.5
+        version: 3.1.5
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.19.1
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.1)(jsdom@26.1.0)(less@4.4.1)(lightningcss@1.30.2)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)
 
   packages/global-css:
     dependencies:
@@ -340,7 +380,7 @@ importers:
         version: 10.0.8(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))
       '@storybook/addon-docs':
         specifier: 10.0.8
-        version: 10.0.8(@types/react@19.2.7)(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+        version: 10.0.8(@types/react@19.2.7)(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       '@storybook/addon-links':
         specifier: 10.0.8
         version: 10.0.8(react@19.2.0)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))
@@ -355,7 +395,7 @@ importers:
         version: 10.0.8(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vitest@3.2.4)
       '@storybook/react-vite':
         specifier: 10.0.8
-        version: 10.0.8(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+        version: 10.0.8(esbuild@0.27.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       '@storybook/testing-library':
         specifier: ^0.2.2
         version: 0.2.2
@@ -725,16 +765,46 @@ packages:
   '@emotion/unitless@0.8.1':
     resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.1':
+    resolution: {integrity: sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.1':
+    resolution: {integrity: sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -743,16 +813,52 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.1':
+    resolution: {integrity: sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.27.1':
+    resolution: {integrity: sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.1':
+    resolution: {integrity: sha512-veg7fL8eMSCVKL7IW4pxb54QERtedFDfY/ASrumK/SbFsXnRazxY4YykN/THYqFnFwJ0aVjiUrVG2PwcdAEqQQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -761,10 +867,34 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.27.1':
+    resolution: {integrity: sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.1':
+    resolution: {integrity: sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -773,10 +903,34 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.27.1':
+    resolution: {integrity: sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.1':
+    resolution: {integrity: sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -785,10 +939,34 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.27.1':
+    resolution: {integrity: sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.1':
+    resolution: {integrity: sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -797,10 +975,34 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.27.1':
+    resolution: {integrity: sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.1':
+    resolution: {integrity: sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -809,10 +1011,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.27.1':
+    resolution: {integrity: sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.1':
+    resolution: {integrity: sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.12':
@@ -821,8 +1047,26 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.27.1':
+    resolution: {integrity: sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.12':
     resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.1':
+    resolution: {integrity: sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -833,8 +1077,26 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-arm64@0.27.1':
+    resolution: {integrity: sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.1':
+    resolution: {integrity: sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -845,8 +1107,26 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-arm64@0.27.1':
+    resolution: {integrity: sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.25.12':
     resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.1':
+    resolution: {integrity: sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -857,16 +1137,52 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/openharmony-arm64@0.27.1':
+    resolution: {integrity: sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.1':
+    resolution: {integrity: sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.1':
+    resolution: {integrity: sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.12':
@@ -875,8 +1191,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.1':
+    resolution: {integrity: sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.1':
+    resolution: {integrity: sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1103,6 +1437,15 @@ packages:
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
 
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/confirm@5.1.21':
     resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
     engines: {node: '>=18'}
@@ -1114,6 +1457,24 @@ packages:
 
   '@inquirer/core@10.3.2':
     resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -1133,6 +1494,69 @@ packages:
   '@inquirer/figures@1.0.15':
     resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
     engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   '@inquirer/type@3.0.10':
     resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
@@ -2493,6 +2917,9 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
+  '@types/ejs@3.1.5':
+    resolution: {integrity: sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -2552,6 +2979,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@22.19.1':
+    resolution: {integrity: sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==}
 
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
@@ -2830,8 +3260,22 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -2844,17 +3288,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -3018,6 +3477,9 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -3107,6 +3569,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -3184,6 +3649,12 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -3244,6 +3715,10 @@ packages:
 
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   change-case@3.1.0:
@@ -3374,8 +3849,16 @@ packages:
     resolution: {integrity: sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==}
     engines: {node: '>=16'}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
 
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -3389,6 +3872,13 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   constant-case@2.0.0:
     resolution: {integrity: sha512-eS0N9WwmjTqrOmR3o83F5vW8Z+9R1HnVz3xmzT2PMFug9ly+Au/fxRWlEBSb6LcZwspSsEn9Xs1uw9YgzAg1EQ==}
@@ -3642,6 +4132,11 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   electron-to-chromium@1.5.260:
     resolution: {integrity: sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==}
 
@@ -3721,8 +4216,18 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.1:
+    resolution: {integrity: sha512-yY35KZckJJuVVPXpvjgxiCuVEJT67F6zDeVTv4rizyPrfGBUpZQsvmxnN+C371c2esD/hNMjj4tpBhuueLN7aA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3983,6 +4488,9 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  filelist@1.0.4:
+    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -4006,6 +4514,9 @@ packages:
   find-up@6.3.0:
     resolution: {integrity: sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
@@ -4596,9 +5107,18 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4837,6 +5357,13 @@ packages:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   lint-staged@13.3.0:
     resolution: {integrity: sha512-mPRtrYnipYYv1FEE134ufbWpeggNTo+O/UPzngoaKzbzHAthvR55am+8GfHTnqNRQVRRrYQLGW9ZyUoD7DsBHQ==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -4850,6 +5377,10 @@ packages:
     peerDependenciesMeta:
       enquirer:
         optional: true
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
@@ -5261,6 +5792,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -5275,6 +5810,9 @@ packages:
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
+
+  mlly@1.8.0:
+    resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
   module-alias@2.2.3:
     resolution: {integrity: sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==}
@@ -5317,6 +5855,9 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -5635,6 +6176,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -5676,9 +6220,16 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
   pkg-dir@7.0.0:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
   playwright-core@1.57.0:
     resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
@@ -5704,6 +6255,24 @@ packages:
       postcss:
         optional: true
       ts-node:
+        optional: true
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   postcss-modules-extract-imports@3.1.0:
@@ -6414,6 +6983,11 @@ packages:
     resolution: {integrity: sha512-v3YCf31atbwJQIMtPNX8hcQ+okD4NQaTuKGUWfII8eaqn+3otrbttGL1zSMZAAtiPsBztQnujVBugg/cXFUpyg==}
     hasBin: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -6481,6 +7055,13 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -6514,8 +7095,16 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -6566,6 +7155,10 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -6581,6 +7174,9 @@ packages:
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -6621,6 +7217,25 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
 
   turbo-darwin-64@2.6.1:
     resolution: {integrity: sha512-Dm0HwhyZF4J0uLqkhUyCVJvKM9Rw7M03v3J9A7drHDQW0qAbIGBrUijQ8g4Q9Cciw/BXRRd8Uzkc3oue+qn+ZQ==}
@@ -6706,6 +7321,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.1:
+    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -6714,6 +7332,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -6879,6 +7500,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -6897,6 +7523,37 @@ packages:
       vite: '*'
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
         optional: true
 
   vite@7.1.3:
@@ -6937,6 +7594,31 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@3.2.4:
@@ -7153,6 +7835,9 @@ packages:
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7564,82 +8249,229 @@ snapshots:
 
   '@emotion/unitless@0.8.1': {}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.1':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/android-x64@0.27.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-x64@0.27.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-x64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm@0.27.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-loong64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-ppc64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.27.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
   '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.1':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.1':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1)':
@@ -7822,12 +8654,42 @@ snapshots:
 
   '@inquirer/ansi@1.0.2': {}
 
+  '@inquirer/checkbox@4.3.2(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/confirm@5.1.21(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/confirm@5.1.21(@types/node@24.10.1)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@24.10.1)
       '@inquirer/type': 3.0.10(@types/node@24.10.1)
     optionalDependencies:
       '@types/node': 24.10.1
+
+  '@inquirer/core@10.3.2(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
 
   '@inquirer/core@10.3.2(@types/node@24.10.1)':
     dependencies:
@@ -7842,6 +8704,29 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.1
 
+  '@inquirer/editor@4.2.23(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/expand@4.0.23(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.1)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.0
+    optionalDependencies:
+      '@types/node': 22.19.1
+
   '@inquirer/external-editor@1.0.3(@types/node@24.10.1)':
     dependencies:
       chardet: 2.1.1
@@ -7850,6 +8735,74 @@ snapshots:
       '@types/node': 24.10.1
 
   '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/number@3.0.23(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/password@4.0.23(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/prompts@7.10.1(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.19.1)
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.1)
+      '@inquirer/editor': 4.2.23(@types/node@22.19.1)
+      '@inquirer/expand': 4.0.23(@types/node@22.19.1)
+      '@inquirer/input': 4.3.1(@types/node@22.19.1)
+      '@inquirer/number': 3.0.23(@types/node@22.19.1)
+      '@inquirer/password': 4.0.23(@types/node@22.19.1)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.19.1)
+      '@inquirer/search': 3.2.2(@types/node@22.19.1)
+      '@inquirer/select': 4.4.2(@types/node@22.19.1)
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/search@3.2.2(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/select@4.4.2(@types/node@22.19.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.19.1)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.19.1)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+
+  '@inquirer/type@3.0.10(@types/node@22.19.1)':
+    optionalDependencies:
+      '@types/node': 22.19.1
 
   '@inquirer/type@3.0.10(@types/node@24.10.1)':
     optionalDependencies:
@@ -8956,7 +9909,7 @@ snapshots:
 
   '@sentry/core@10.27.0': {}
 
-  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0))(react@19.2.0)(webpack@5.101.3(esbuild@0.25.12))':
+  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0))(react@19.2.0)(webpack@5.101.3(esbuild@0.27.1))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -8968,7 +9921,7 @@ snapshots:
       '@sentry/opentelemetry': 10.27.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.38.0)
       '@sentry/react': 10.27.0(react@19.2.0)
       '@sentry/vercel-edge': 10.27.0
-      '@sentry/webpack-plugin': 4.6.1(webpack@5.101.3(esbuild@0.25.12))
+      '@sentry/webpack-plugin': 4.6.1(webpack@5.101.3(esbuild@0.27.1))
       next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0)
       resolve: 1.22.8
       rollup: 4.53.3
@@ -9060,12 +10013,12 @@ snapshots:
       '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@sentry/core': 10.27.0
 
-  '@sentry/webpack-plugin@4.6.1(webpack@5.101.3(esbuild@0.25.12))':
+  '@sentry/webpack-plugin@4.6.1(webpack@5.101.3(esbuild@0.27.1))':
     dependencies:
       '@sentry/bundler-plugin-core': 4.6.1
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.101.3(esbuild@0.25.12)
+      webpack: 5.101.3(esbuild@0.27.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9076,10 +10029,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))
 
-  '@storybook/addon-docs@10.0.8(@types/react@19.2.7)(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))':
+  '@storybook/addon-docs@10.0.8(@types/react@19.2.7)(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.0)
-      '@storybook/csf-plugin': 10.0.8(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+      '@storybook/csf-plugin': 10.0.8(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       '@storybook/icons': 1.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@storybook/react-dom-shim': 10.0.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))
       react: 19.2.0
@@ -9124,9 +10077,9 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.0.8(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))':
+  '@storybook/builder-vite@10.0.8(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.0.8(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+      '@storybook/csf-plugin': 10.0.8(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       storybook: 10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))
       ts-dedent: 2.2.0
       vite: 7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)
@@ -9135,15 +10088,15 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.0.8(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))':
+  '@storybook/csf-plugin@10.0.8(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))':
     dependencies:
       storybook: 10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))
       unplugin: 2.3.11
     optionalDependencies:
-      esbuild: 0.25.12
+      esbuild: 0.27.1
       rollup: 4.53.3
       vite: 7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)
-      webpack: 5.101.3(esbuild@0.25.12)
+      webpack: 5.101.3(esbuild@0.27.1)
 
   '@storybook/global@5.0.0': {}
 
@@ -9152,11 +10105,11 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/nextjs-vite@10.0.8(@babel/core@7.28.5)(esbuild@0.25.12)(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))':
+  '@storybook/nextjs-vite@10.0.8(@babel/core@7.28.5)(esbuild@0.27.1)(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))':
     dependencies:
-      '@storybook/builder-vite': 10.0.8(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+      '@storybook/builder-vite': 10.0.8(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       '@storybook/react': 10.0.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)
-      '@storybook/react-vite': 10.0.8(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+      '@storybook/react-vite': 10.0.8(esbuild@0.27.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(sass@1.91.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
@@ -9180,11 +10133,11 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
       storybook: 10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))
 
-  '@storybook/react-vite@10.0.8(esbuild@0.25.12)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))':
+  '@storybook/react-vite@10.0.8(esbuild@0.27.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
-      '@storybook/builder-vite': 10.0.8(esbuild@0.25.12)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.25.12))
+      '@storybook/builder-vite': 10.0.8(esbuild@0.27.1)(rollup@4.53.3)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))(webpack@5.101.3(esbuild@0.27.1))
       '@storybook/react': 10.0.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.8(@testing-library/dom@10.4.1)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -9366,6 +10319,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/ejs@3.1.5': {}
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -9432,6 +10387,10 @@ snapshots:
       '@types/node': 24.10.1
 
   '@types/node@12.20.55': {}
+
+  '@types/node@22.19.1':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@24.10.1':
     dependencies:
@@ -9749,6 +10708,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -9756,6 +10722,15 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@2.1.9(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.3(@types/node@22.19.1)(typescript@5.9.3)
+      vite: 5.4.21(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)
 
   '@vitest/mocker@3.2.4(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1))':
     dependencies:
@@ -9766,9 +10741,18 @@ snapshots:
       msw: 2.12.3(@types/node@24.10.1)(typescript@5.9.3)
       vite: 7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1)
 
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -9776,15 +10760,31 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.0.0
 
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.18
       pathe: 2.0.3
 
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -9960,6 +10960,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  any-promise@1.3.0: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -10078,6 +11080,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  async@3.2.6: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -10086,12 +11090,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.101.3(esbuild@0.25.12)):
+  babel-loader@9.2.1(@babel/core@7.28.5)(webpack@5.101.3(esbuild@0.27.1)):
     dependencies:
       '@babel/core': 7.28.5
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.101.3(esbuild@0.25.12)
+      webpack: 5.101.3(esbuild@0.27.1)
 
   bail@2.0.2: {}
 
@@ -10152,6 +11156,11 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bundle-require@5.1.0(esbuild@0.27.1):
+    dependencies:
+      esbuild: 0.27.1
+      load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
 
@@ -10223,6 +11232,8 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.3.0: {}
+
+  chalk@5.6.2: {}
 
   change-case@3.1.0:
     dependencies:
@@ -10364,7 +11375,11 @@ snapshots:
 
   commander@11.0.0: {}
 
+  commander@13.1.0: {}
+
   commander@2.20.3: {}
+
+  commander@4.1.1: {}
 
   commander@8.3.0: {}
 
@@ -10373,6 +11388,10 @@ snapshots:
   commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
 
   constant-case@2.0.0:
     dependencies:
@@ -10609,6 +11628,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.4
+
   electron-to-chromium@1.5.260: {}
 
   electron-to-chromium@1.5.263: {}
@@ -10767,6 +11790,32 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -10795,6 +11844,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.1
+      '@esbuild/android-arm': 0.27.1
+      '@esbuild/android-arm64': 0.27.1
+      '@esbuild/android-x64': 0.27.1
+      '@esbuild/darwin-arm64': 0.27.1
+      '@esbuild/darwin-x64': 0.27.1
+      '@esbuild/freebsd-arm64': 0.27.1
+      '@esbuild/freebsd-x64': 0.27.1
+      '@esbuild/linux-arm': 0.27.1
+      '@esbuild/linux-arm64': 0.27.1
+      '@esbuild/linux-ia32': 0.27.1
+      '@esbuild/linux-loong64': 0.27.1
+      '@esbuild/linux-mips64el': 0.27.1
+      '@esbuild/linux-ppc64': 0.27.1
+      '@esbuild/linux-riscv64': 0.27.1
+      '@esbuild/linux-s390x': 0.27.1
+      '@esbuild/linux-x64': 0.27.1
+      '@esbuild/netbsd-arm64': 0.27.1
+      '@esbuild/netbsd-x64': 0.27.1
+      '@esbuild/openbsd-arm64': 0.27.1
+      '@esbuild/openbsd-x64': 0.27.1
+      '@esbuild/openharmony-arm64': 0.27.1
+      '@esbuild/sunos-x64': 0.27.1
+      '@esbuild/win32-arm64': 0.27.1
+      '@esbuild/win32-ia32': 0.27.1
+      '@esbuild/win32-x64': 0.27.1
 
   escalade@3.2.0: {}
 
@@ -11155,6 +12233,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  filelist@1.0.4:
+    dependencies:
+      minimatch: 5.1.6
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -11182,6 +12264,12 @@ snapshots:
     dependencies:
       locate-path: 7.2.0
       path-exists: 5.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.0
+      rollup: 4.53.3
 
   flat-cache@3.2.0:
     dependencies:
@@ -11901,11 +12989,19 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.4
+      picocolors: 1.1.1
+
   jest-worker@27.5.1:
     dependencies:
       '@types/node': 24.10.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -12117,6 +13213,10 @@ snapshots:
 
   lilconfig@2.1.0: {}
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
   lint-staged@13.3.0(enquirer@2.4.1):
     dependencies:
       chalk: 5.3.0
@@ -12143,6 +13243,8 @@ snapshots:
       wrap-ansi: 8.1.0
     optionalDependencies:
       enquirer: 2.4.1
+
+  load-tsconfig@0.2.5: {}
 
   loader-runner@4.3.1: {}
 
@@ -12900,6 +14002,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -12911,6 +14017,13 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+
+  mlly@1.8.0:
+    dependencies:
+      acorn: 8.15.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.1
 
   module-alias@2.2.3: {}
 
@@ -12928,6 +14041,32 @@ snapshots:
     dependencies:
       is-node-process: 1.2.0
       msw: 2.12.3(@types/node@24.10.1)(typescript@5.9.3)
+
+  msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@22.19.1)
+      '@mswjs/interceptors': 0.40.0
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.0.2
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.7.0
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.2.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
 
   msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3):
     dependencies:
@@ -12957,6 +14096,12 @@ snapshots:
   mute-stream@0.0.8: {}
 
   mute-stream@2.0.0: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.11: {}
 
@@ -13318,6 +14463,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -13346,9 +14493,17 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pirates@4.0.7: {}
+
   pkg-dir@7.0.0:
     dependencies:
       find-up: 6.3.0
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.0
+      pathe: 2.0.3
 
   playwright-core@1.57.0: {}
 
@@ -13367,6 +14522,13 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
       ts-node: 10.9.2(@types/node@24.10.1)(typescript@5.9.3)
+
+  postcss-load-config@6.0.1(postcss@8.5.6)(yaml@2.8.1):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+      yaml: 2.8.1
 
   postcss-modules-extract-imports@3.1.0(postcss@8.5.6):
     dependencies:
@@ -14272,6 +15434,16 @@ snapshots:
       - supports-color
     optional: true
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -14305,16 +15477,16 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.14(esbuild@0.25.12)(webpack@5.101.3(esbuild@0.25.12)):
+  terser-webpack-plugin@5.3.14(esbuild@0.27.1)(webpack@5.101.3(esbuild@0.27.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.1
-      webpack: 5.101.3(esbuild@0.25.12)
+      webpack: 5.101.3(esbuild@0.27.1)
     optionalDependencies:
-      esbuild: 0.25.12
+      esbuild: 0.27.1
 
   terser@5.44.1:
     dependencies:
@@ -14330,6 +15502,14 @@ snapshots:
       minimatch: 9.0.5
 
   text-table@0.2.0: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   through@2.3.8: {}
 
@@ -14360,7 +15540,11 @@ snapshots:
 
   tinypool@1.1.1: {}
 
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   tinyspy@4.0.4: {}
 
@@ -14405,6 +15589,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  tree-kill@1.2.2: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -14414,6 +15600,8 @@ snapshots:
       typescript: 5.9.3
 
   ts-dedent@2.2.0: {}
+
+  ts-interface-checker@0.1.13: {}
 
   ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3):
     dependencies:
@@ -14455,6 +15643,34 @@ snapshots:
   tslib@2.6.2: {}
 
   tslib@2.8.1: {}
+
+  tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.1)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.1
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)(yaml@2.8.1)
+      resolve-from: 5.0.0
+      rollup: 4.53.3
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   turbo-darwin-64@2.6.1:
     optional: true
@@ -14558,6 +15774,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  ufo@1.6.1: {}
+
   uglify-js@3.19.3:
     optional: true
 
@@ -14567,6 +15785,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
 
@@ -14795,6 +16015,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.2.4(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
@@ -14842,6 +16080,20 @@ snapshots:
       - supports-color
       - typescript
 
+  vite@5.4.21(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.53.3
+    optionalDependencies:
+      '@types/node': 22.19.1
+      fsevents: 2.3.3
+      less: 4.4.1
+      lightningcss: 1.30.2
+      sass: 1.91.0
+      stylus: 0.62.0
+      terser: 5.44.1
+
   vite@7.1.3(@types/node@24.10.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.12
@@ -14859,6 +16111,42 @@ snapshots:
       stylus: 0.62.0
       terser: 5.44.1
       yaml: 2.8.1
+
+  vitest@2.1.9(@types/node@22.19.1)(jsdom@26.1.0)(less@4.4.1)(lightningcss@1.30.2)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(vite@5.4.21(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)
+      vite-node: 2.1.9(@types/node@22.19.1)(less@4.4.1)(lightningcss@1.30.2)(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.1
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/browser@3.2.4)(jsdom@26.1.0)(less@4.4.1)(lightningcss@1.30.2)(msw@2.12.3(@types/node@24.10.1)(typescript@5.9.3))(sass@1.91.0)(stylus@0.62.0)(terser@5.44.1)(yaml@2.8.1):
     dependencies:
@@ -14929,7 +16217,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.101.3(esbuild@0.25.12):
+  webpack@5.101.3(esbuild@0.27.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -14953,7 +16241,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.14(esbuild@0.25.12)(webpack@5.101.3(esbuild@0.25.12))
+      terser-webpack-plugin: 5.3.14(esbuild@0.27.1)(webpack@5.101.3(esbuild@0.27.1))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -15116,5 +16404,7 @@ snapshots:
   yocto-queue@1.2.1: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
Add a new CLI tool for scaffolding React components, hooks, context providers, and Next.js pages in the Squareone monorepo.

Features:

- Directory-as-template pattern (like cookiecutter)
- Component directory pattern with barrel files
- Component-scoped contexts with --with-context flag
- Automatic barrel file updates for exports
- Package-specific configuration via .file-factory/config.ts
- Custom template overrides
- CSS Modules by default with styled-components support
- TypeScript with Zod validation
- Interactive mode when no arguments provided

Commands:

- pnpm file-factory component <name> - Create React components
- pnpm file-factory hook <name> - Create React hooks
- pnpm file-factory context <name> - Create global contexts
- pnpm file-factory page <path> - Create Next.js pages

Includes:

- Example configurations for squareone and squared packages
- Comprehensive unit tests
- SKILL.md for Claude Code integration
- Full documentation