### PR TITLE
Remove deprecated AMP configuration from Next.js

### DIFF
--- a/.changeset/remove-deprecated-amp-config.md
+++ b/.changeset/remove-deprecated-amp-config.md
@@ -1,0 +1,7 @@
+---
+'squareone': patch
+---
+
+Remove deprecated amp config inherited from defaultConfig
+
+The Next.js config was spreading `defaultConfig` which included the deprecated `amp` configuration option. This caused deprecation warnings during builds. The fix removes the unnecessary `defaultConfig` spread since Next.js applies sensible defaults automatically, and we only need to specify our custom configuration options.

--- a/apps/squareone/next.config.js
+++ b/apps/squareone/next.config.js
@@ -1,9 +1,8 @@
 // next.config.js
 // https://nextjs.org/docs/api-reference/next.config.js/introduction
 
-module.exports = (_phase, { defaultConfig }) => {
+module.exports = () => {
   const config = {
-    ...defaultConfig,
     transpilePackages: ['@lsst-sqre/squared'],
     compiler: {
       styledComponents: true,


### PR DESCRIPTION
Stop spreading defaultConfig in next.config.js to avoid inheriting the amp configuration that triggers the Next.js 16 deprecation warning. The explicit config options don't require anything from defaultConfig.