### PR TITLE
Add conditional Docker image building for feature branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,20 +103,23 @@ jobs:
     needs:
       - test
     with:
-      # Build-only (no push) for dependabot and u/ branches; push with "next" tag for changeset-release/main; push normally for others
-      push: ${{ !(startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'u/') || (startsWith(github.head_ref, 'changeset-release/') && github.head_ref != 'changeset-release/main') || (startsWith(github.ref, 'refs/heads/changeset-release/') && github.ref != 'refs/heads/changeset-release/main')) }}
+      # Build-only (no push) for dependabot, u/, copilot/, and claude/ branches; push with "next" tag for changeset-release/main; push normally for others.
+      # The "push-images" PR label overrides this to force pushing for any branch.
+      push: ${{ contains(github.event.pull_request.labels.*.name, 'push-images') || !(startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'u/') || startsWith(github.head_ref, 'copilot/') || startsWith(github.head_ref, 'claude/') || (startsWith(github.head_ref, 'changeset-release/') && github.head_ref != 'changeset-release/main') || (startsWith(github.ref, 'refs/heads/changeset-release/') && github.ref != 'refs/heads/changeset-release/main')) }}
       additional-tags: ${{ (github.head_ref == 'changeset-release/main' || github.ref == 'refs/heads/changeset-release/main') && 'next' || '' }}
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     # Do Docker builds for tagged releases, pull requests from ticket branches,
-    # u/ branches, dependabot PRs, and changeset-release branches (build-only
-    # for dependabot, changeset-release, and u/ branches). This will still
+    # u/ branches, dependabot PRs, copilot/ branches, claude/ branches, and
+    # changeset-release branches. Build-only (no push) for dependabot, u/,
+    # copilot/, claude/, and changeset-release branches. The "push-images" PR
+    # label can be used to force pushing images for any branch. This will still
     # trigger on pull requests from untrusted repositories whose branch names
     # match our conventions, but the build will fail with an error since the
     # secrets won't be set.
     if: >
-      github.event_name != 'merge_group' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/') || startsWith(github.head_ref, 'u/') || startsWith(github.head_ref, 'dependabot/') || github.ref == 'refs/heads/changeset-release/main')
+      github.event_name != 'merge_group' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.head_ref, 'tickets/') || startsWith(github.head_ref, 'u/') || startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'copilot/') || startsWith(github.head_ref, 'claude/') || github.ref == 'refs/heads/changeset-release/main')
 
   docs:
     needs: [changes]


### PR DESCRIPTION
- Add copilot/ and claude/ branch prefixes to the Docker build triggers
- These branches build Docker images but don't push by default
- Add "push-images" PR label support to force pushing images for any branch