### PR TITLE
Fix description of the API rate limit window

### DIFF
--- a/.changeset/api-rate-limit-description-fix.md
+++ b/.changeset/api-rate-limit-description-fix.md
@@ -1,0 +1,7 @@
+---
+'squareone': patch
+---
+
+Fix API rate limit time window description
+
+Updated the rate limit description in QuotasView to correctly state that API rate limits are measured over a 60 second window (reset every minute) instead of the previous incorrect 15 minute window description.

--- a/apps/squareone/src/components/QuotasView/QuotasView.tsx
+++ b/apps/squareone/src/components/QuotasView/QuotasView.tsx
@@ -48,8 +48,8 @@ export default function QuotasView({ quota }: QuotasViewProps) {
         <section id="rate-limit" className={styles.section}>
           <h2 className={styles.sectionTitle}>Rate limits</h2>
           <p className={styles.sectionDescription}>
-            APIs limit the number of requests you can make in a 15 minute
-            window. Your request count resets every 15 minutes.
+            APIs limit the number of requests you can make in a 60 second
+            window. Your request count resets every minute.
           </p>
           <KeyValueList items={getApiItems(quota.api)} />
         </section>


### PR DESCRIPTION
Gafaelfawr changed the API rate limit quota to measure requests per minute and the count resets every minute.