### PR TITLE
Fix Dependabot auto-merge to fail closed on major bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -5,6 +5,12 @@ name: Dependabot Auto-Merge
 # 2. Have a changeset file
 # 3. Are not major version updates
 #
+# Update type comes from the `dependencies-{major,minor,patch}` label that
+# dependabot-label.yaml applies via dependabot/fetch-metadata (the authoritative
+# source) — NOT from parsing the PR title. The gate is a fail-closed allowlist:
+# auto-merge requires a `dependencies-patch` or `dependencies-minor` label. No
+# label or a `dependencies-major` label ⇒ no auto-merge.
+#
 # Security: Uses workflow_run trigger to run in the context of the default
 # branch, avoiding "pwn request" vulnerabilities. Verifies PR author before
 # taking any actions.
@@ -82,10 +88,13 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('head_ref', pr.head.ref);
 
-      # Extract Dependabot metadata for semver analysis
-      # We can't use dependabot/fetch-metadata action because it requires pull_request
-      # context, but we're running in workflow_run context for security reasons.
-      # Instead, we parse the PR title and commits to determine update type.
+      # Determine the semver update type from the `dependencies-*` label applied
+      # by dependabot-label.yaml (which uses dependabot/fetch-metadata — the
+      # authoritative source — in pull_request context). We can't run
+      # fetch-metadata here because this workflow uses the workflow_run trigger
+      # for security. The gate is a fail-closed allowlist: only dependencies-patch /
+      # dependencies-minor are safe to merge; a dependencies-major label or no label
+      # at all (e.g. labeling failed) keeps auto-merge disabled.
       - name: Get Dependabot metadata
         if: steps.verify.outputs.is_dependabot == 'true'
         id: metadata
@@ -93,110 +102,26 @@ jobs:
         with:
           script: |
             const prNumber = ${{ steps.pr.outputs.result }};
-
-            // Fetch PR details
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: prNumber
+              pull_number: prNumber,
             });
+            const labels = pr.labels.map(l => l.name);
+            console.log(`PR labels: ${labels.join(', ') || '(none)'}`);
 
-            console.log(`PR title: ${pr.title}`);
+            const isMajor = labels.includes('dependencies-major');
+            const isMinor = labels.includes('dependencies-minor');
+            const isPatch = labels.includes('dependencies-patch');
+            const safe = isMinor || isPatch;                 // allowlist; major/none => false
+            const updateType = isMajor ? 'dependencies-major'
+                             : isMinor ? 'dependencies-minor'
+                             : isPatch ? 'dependencies-patch'
+                             : 'unknown';
 
-            // Parse PR title for dependency information
-            // Formats:
-            // - "Bump package from 1.0.0 to 2.0.0"
-            // - "Bump package from 1.0.0 to 2.0.0 in /path"
-            // - "Bump the group-name group with X updates" (grouped updates)
-            // - "Bump the group-name group across 1 directory with X updates"
-
-            let updateType = 'version-update:semver-patch';
-            let dependencyNames = '';
-
-            // Check for grouped updates
-            const groupMatch = pr.title.match(/Bump the (.+) group/);
-            if (groupMatch) {
-              dependencyNames = `${groupMatch[1]} group`;
-
-              // For grouped updates, we need to check commits to determine if any are major
-              const { data: commits } = await github.rest.pulls.listCommits({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              // Check all commits for version changes
-              let hasMajor = false;
-              let hasMinor = false;
-
-              for (const commit of commits) {
-                const message = commit.commit.message;
-                const bumpMatch = message.match(/Bump .+ from ([\d.]+) to ([\d.]+)/);
-
-                if (bumpMatch) {
-                  const [, oldVersion, newVersion] = bumpMatch;
-                  const type = determineUpdateType(oldVersion, newVersion);
-
-                  if (type === 'major') {
-                    hasMajor = true;
-                    break;
-                  } else if (type === 'minor') {
-                    hasMinor = true;
-                  }
-                }
-              }
-
-              if (hasMajor) {
-                updateType = 'version-update:semver-major';
-              } else if (hasMinor) {
-                updateType = 'version-update:semver-minor';
-              } else {
-                updateType = 'version-update:semver-patch';
-              }
-            } else {
-              // Single dependency update
-              const bumpMatch = pr.title.match(/Bump (.+?) from ([\d.]+) to ([\d.]+)/);
-
-              if (bumpMatch) {
-                const [, packageName, oldVersion, newVersion] = bumpMatch;
-                dependencyNames = packageName;
-
-                const type = determineUpdateType(oldVersion, newVersion);
-                updateType = `version-update:semver-${type}`;
-              } else {
-                console.log('Could not parse Dependabot PR title format');
-                dependencyNames = 'unknown';
-              }
-            }
-
-            function determineUpdateType(oldVersion, newVersion) {
-              const oldParts = oldVersion.split('.').map(v => parseInt(v) || 0);
-              const newParts = newVersion.split('.').map(v => parseInt(v) || 0);
-
-              // Compare major version
-              if (newParts[0] > oldParts[0]) {
-                return 'major';
-              }
-
-              // Compare minor version
-              if (newParts[1] > oldParts[1]) {
-                return 'minor';
-              }
-
-              // Otherwise it's a patch
-              return 'patch';
-            }
-
-            console.log(`Dependency names: ${dependencyNames}`);
-            console.log(`Update type: ${updateType}`);
-
-            core.setOutput('dependency-names', dependencyNames);
             core.setOutput('update-type', updateType);
-
-            return {
-              dependency_names: dependencyNames,
-              update_type: updateType
-            };
+            core.setOutput('safe-to-merge', String(safe));
+            console.log(`safe-to-merge=${safe} (update-type=${updateType})`);
 
       # Check if PR has changeset files
       # The dependabot-changesets.yaml workflow should have already created these
@@ -226,11 +151,11 @@ jobs:
 
       # Enable auto-merge if all conditions are met:
       # 1. PR is from Dependabot (verified above)
-      # 2. Not a major version update
+      # 2. Update is safe to merge (dependencies-patch / dependencies-minor label present)
       # 3. Has a changeset file
       - name: Enable auto-merge with squash
         if: >
-          steps.verify.outputs.is_dependabot == 'true' && steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.changeset.outputs.has_changeset == 'true'
+          steps.verify.outputs.is_dependabot == 'true' && steps.metadata.outputs.safe-to-merge == 'true' && steps.changeset.outputs.has_changeset == 'true'
 
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
@@ -243,13 +168,12 @@ jobs:
       # Add comment for visibility
       - name: Comment on PR
         if: >
-          steps.verify.outputs.is_dependabot == 'true' && steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.changeset.outputs.has_changeset == 'true'
+          steps.verify.outputs.is_dependabot == 'true' && steps.metadata.outputs.safe-to-merge == 'true' && steps.changeset.outputs.has_changeset == 'true'
 
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           PR_NUMBER: ${{ steps.pr.outputs.result }}
           UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
-          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
         run: |
           gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body \
             "🤖 **Auto-merge enabled**
@@ -258,14 +182,13 @@ jobs:
             - ✅ CI passed
             - ✅ Changeset detected
             - ✅ Update type: \`$UPDATE_TYPE\`
-            - 📦 Dependencies: $DEPENDENCY_NAMES
 
             The PR will automatically merge once all branch protection requirements are satisfied."
 
       # Log when auto-merge is skipped
       - name: Log skip reason
         if: >
-          steps.verify.outputs.is_dependabot == 'true' && (steps.metadata.outputs.update-type == 'version-update:semver-major' ||
+          steps.verify.outputs.is_dependabot == 'true' && (steps.metadata.outputs.safe-to-merge != 'true' ||
            steps.changeset.outputs.has_changeset != 'true')
 
         env:
@@ -276,8 +199,10 @@ jobs:
           echo "  Update type: $UPDATE_TYPE"
           echo "  Has changeset: $HAS_CHANGESET"
 
-          if [ "$UPDATE_TYPE" = "version-update:semver-major" ]; then
+          if [ "$UPDATE_TYPE" = "dependencies-major" ]; then
             echo "  Reason: Major version updates require manual review"
+          elif [ "$UPDATE_TYPE" = "unknown" ]; then
+            echo "  Reason: No dependencies-* label found (fail-closed; labeling may have failed or be pending)"
           fi
 
           if [ "$HAS_CHANGESET" != "true" ]; then

--- a/.github/workflows/dependabot-label.yaml
+++ b/.github/workflows/dependabot-label.yaml
@@ -1,0 +1,56 @@
+name: Label Dependabot Update Type
+
+# Applies a `dependencies-{major,minor,patch}` label to Dependabot PRs based on
+# the authoritative update type reported by dependabot/fetch-metadata.
+#
+# Why a separate workflow:
+# - fetch-metadata only works in `pull_request` context (it reads the
+#   Dependabot-authored commit metadata), where the GITHUB_TOKEN is scoped to
+#   the PR. The auto-merge workflow runs in `workflow_run` context (for security)
+#   and cannot use fetch-metadata, so it reads the label this workflow applies.
+# - Kept as a separate workflow/job so a labeling hiccup never fails the required
+#   `dependabot-changesets` check or blocks the changeset push.
+#
+# The label is the input to dependabot-auto-merge.yaml's fail-closed allowlist:
+# only `dependencies-patch` / `dependencies-minor` enable auto-merge. No label
+# (e.g. labeling failed) or `dependencies-major` ⇒ no auto-merge.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write # add label to the PR
+  issues: write # create the label if it doesn't exist yet
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v3 # github-token defaults to github.token
+
+      - name: Apply semver label (fail-closed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          UPDATE_TYPE: ${{ steps.meta.outputs.update-type }} # e.g. version-update:semver-major
+        run: |
+          if [ -z "$UPDATE_TYPE" ]; then
+            echo "No update-type from fetch-metadata; not labeling (auto-merge stays disabled)."
+            exit 0
+          fi
+          SEMVER="${UPDATE_TYPE##*semver-}"   # major | minor | patch
+          LABEL="dependencies-$SEMVER"
+          case "$SEMVER" in
+            major) COLOR=D93F0B ;;
+            minor) COLOR=FBCA04 ;;
+            patch) COLOR=0E8A16 ;;
+            *)     COLOR=BFD4F2 ;;
+          esac
+          # idempotent create-if-missing, then add to PR
+          gh label create "$LABEL" --repo "$GITHUB_REPOSITORY" \
+            --color "$COLOR" --description "Dependabot semver update type" --force || true
+          gh pr edit "$PR_URL" --add-label "$LABEL"

--- a/docs/dev/github-actions-architecture.rst
+++ b/docs/dev/github-actions-architecture.rst
@@ -27,8 +27,13 @@ Squareone uses a combination of standalone and reusable workflows:
    dependabot-changesets.yaml
    └─→ Auto-generates changesets for Dependabot PRs
 
+   dependabot-label.yaml
+   └─→ Applies a dependencies-{major,minor,patch} label to Dependabot PRs
+       (via dependabot/fetch-metadata)
+
    dependabot-auto-merge.yaml (triggered by ci.yaml)
    └─→ Enables auto-merge for Dependabot PRs after CI passes
+       (reads the dependencies-* label as a fail-closed allowlist)
 
    codeql-analysis.yaml
    └─→ Security scanning (weekly + on main)
@@ -357,6 +362,48 @@ Without these Dependabot secrets configured, the workflow will fail with an erro
 
 For more information, see GitHub's documentation on `Automating Dependabot with GitHub Actions <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions>`__ and `Managing encrypted secrets for Dependabot <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-encrypted-secrets-for-dependabot>`__.
 
+Labeling Dependabot update types — dependabot-label.yaml
+========================================================
+
+The ``dependabot-label.yaml`` workflow applies a ``dependencies-{major,minor,patch}`` label to each Dependabot pull request, recording the authoritative update type so that ``dependabot-auto-merge.yaml`` can make a safe merge decision.
+
+**Triggers:**
+
+- ``pull_request``: ``opened``, ``synchronize``, ``reopened``
+- Runs only for PRs authored by ``dependabot[bot]``
+
+Why a separate workflow
+-----------------------
+
+The update type is determined with the `dependabot/fetch-metadata <https://github.com/dependabot/fetch-metadata>`__ action, which is the authoritative source (it reads Dependabot's own metadata rather than parsing the PR title).
+``fetch-metadata`` only works in ``pull_request`` context, where the ``GITHUB_TOKEN`` is scoped to the PR.
+The ``dependabot-auto-merge.yaml`` workflow runs in ``workflow_run`` context for security and therefore cannot run ``fetch-metadata`` itself — instead it reads the label this workflow applies.
+
+Keeping labeling in its own workflow (and job) ensures that a labeling hiccup never fails the required ``dependabot-changesets`` check or blocks the changeset push.
+
+For grouped updates, ``fetch-metadata`` reports the group's **highest** semver change, so a group that contains any major bump is labeled ``dependencies-major``.
+
+Behavior
+--------
+
+1. Runs ``dependabot/fetch-metadata`` to obtain the ``update-type`` output (e.g. ``version-update:semver-major``).
+2. Derives the label name (``dependencies-major``, ``dependencies-minor``, or ``dependencies-patch``).
+3. Idempotently creates the label if it doesn't exist yet (``gh label create --force``), then adds it to the PR.
+
+If ``fetch-metadata`` returns no update type, the workflow exits without labeling.
+Because the auto-merge gate is fail-closed, an unlabeled PR is simply not auto-merged (manual merge required) — it can never wrongly auto-merge.
+
+Permissions and authentication
+------------------------------
+
+This workflow uses only the default ``GITHUB_TOKEN`` (no GitHub App token or Dependabot secrets are required).
+The ``permissions:`` block elevates the token for this workflow:
+
+- ``pull-requests: write`` — add the label to the PR
+- ``issues: write`` — create the label if it doesn't exist yet
+
+GitHub supports elevating the default token for Dependabot ``pull_request`` events; this is GitHub's documented auto-label pattern.
+
 Auto-merging Dependabot PRs — dependabot-auto-merge.yaml
 ========================================================
 
@@ -376,7 +423,7 @@ The workflow follows these steps to safely enable auto-merge:
 
 1. **Extract PR information** from the workflow run event
 2. **Verify PR author** is ``dependabot[bot]`` using secure identity checking
-3. **Fetch Dependabot metadata** to determine the semantic version update type
+3. **Read the** ``dependencies-*`` **label** applied by ``dependabot-label.yaml`` to determine the semantic version update type
 4. **Check for changeset file** to ensure the PR has versioning information
 5. **Enable auto-merge** with squash strategy if all conditions are met
 6. **Comment on PR** for visibility and audit trail
@@ -384,17 +431,20 @@ The workflow follows these steps to safely enable auto-merge:
 Auto-merge conditions
 ^^^^^^^^^^^^^^^^^^^^^
 
-Auto-merge is enabled only when ALL of the following conditions are met:
+Auto-merge is enabled only when ALL of the following conditions are met (a **fail-closed allowlist**):
 
 - ✅ PR is authored by ``dependabot[bot]``
 - ✅ CI workflow completed successfully
-- ✅ Update type is NOT a major version update (``version-update:semver-major``)
+- ✅ A ``dependencies-patch`` or ``dependencies-minor`` label is present (fail-closed: no label or a ``dependencies-major`` label ⇒ skipped)
 - ✅ Changeset file exists in the PR (created by ``dependabot-changesets.yaml``)
 
 **Excluded updates:**
 
-- ❌ Major version updates (e.g., ``v1.x.x`` → ``v2.0.0``) - These require manual review due to potential breaking changes
+- ❌ Major version updates (``dependencies-major`` label) - These require manual review due to potential breaking changes
+- ❌ Updates with no ``dependencies-*`` label - If ``dependabot-label.yaml`` did not apply a label (e.g. labeling failed or is still pending), auto-merge stays disabled and a manual merge is required
 - ❌ PRs without changesets - The workflow waits for ``dependabot-changesets.yaml`` to complete first
+
+For grouped updates, ``dependabot/fetch-metadata`` reports the group's **highest** semver change, so a group containing any major bump is labeled ``dependencies-major`` and excluded.
 
 Merge strategy
 ^^^^^^^^^^^^^^
@@ -448,6 +498,10 @@ The ``dependabot-auto-merge.yaml`` workflow is designed to run after both the ``
       ├─→ Creates changeset file
       └─→ Commits to PR
       ↓
+   2b. dependabot-label.yaml runs (pull_request trigger)
+      ├─→ Reads update type via dependabot/fetch-metadata
+      └─→ Applies dependencies-{major,minor,patch} label to the PR
+      ↓
    3. ci.yaml runs (pull_request trigger, includes new changeset)
       ├─→ Runs tests
       ├─→ Runs linting
@@ -456,7 +510,7 @@ The ``dependabot-auto-merge.yaml`` workflow is designed to run after both the ``
       ↓
    4. dependabot-auto-merge.yaml runs (workflow_run trigger)
       ├─→ Verifies changeset exists
-      ├─→ Checks update type
+      ├─→ Reads the dependencies-* label (fail-closed allowlist)
       └─→ Enables auto-merge if all conditions met
       ↓
    5. GitHub auto-merges when branch protection satisfied
@@ -473,15 +527,15 @@ Workflow outputs and visibility
 The workflow adds a comment to the PR with details:
 
 - ✅ Confirmation that auto-merge was enabled
-- 📋 Update type (e.g., ``version-update:semver-minor``)
-- 📦 List of updated dependencies
+- 📋 Update type (e.g., ``dependencies-minor``)
 - ℹ️ Explanation of next steps (waiting for branch protection)
 
 **When auto-merge is skipped:**
 
 The workflow logs the skip reason to the GitHub Actions console:
 
-- Major version update requiring manual review
+- Major version update requiring manual review (``dependencies-major`` label)
+- No ``dependencies-*`` label found (fail-closed; labeling may have failed or be pending)
 - Changeset not yet created (workflow may retry on next push)
 
 **Example comment:**
@@ -493,8 +547,7 @@ The workflow logs the skip reason to the GitHub Actions console:
    This Dependabot PR has been configured for auto-merge with squash strategy:
    - ✅ CI passed
    - ✅ Changeset detected
-   - ✅ Update type: `version-update:semver-patch`
-   - 📦 Dependencies: @types/react, @types/react-dom
+   - ✅ Update type: `dependencies-patch`
 
    The PR will automatically merge once all branch protection requirements are satisfied.
 
@@ -505,11 +558,11 @@ This workflow respects the Dependabot configuration in :file:`.github/dependabot
 
 **Major version blocking:**
 
-The Dependabot configuration already blocks major version updates with ``open-pull-requests-limit: 0`` for major updates. The workflow adds an additional safety layer by checking ``update-type`` and explicitly skipping major updates even if they somehow bypass the Dependabot configuration.
+The Dependabot configuration already blocks major version updates globally with an ``ignore`` rule for ``version-update:semver-major``. The auto-merge workflow adds an independent safety layer: its fail-closed allowlist only merges PRs carrying a ``dependencies-patch`` or ``dependencies-minor`` label, so a major update that somehow bypasses the Dependabot configuration (e.g. a security update) is never auto-merged.
 
 **Grouped updates:**
 
-When Dependabot creates grouped update PRs (e.g., "Update React ecosystem"), the workflow treats the group as a single PR and applies auto-merge if ALL updates in the group meet the criteria (no major versions in the group).
+When Dependabot creates grouped update PRs (e.g., "Update React ecosystem"), ``dependabot/fetch-metadata`` reports the group's highest semver change. ``dependabot-label.yaml`` labels the PR with that single highest type, so the group is auto-merged only when its highest bump is a minor or patch (no major versions in the group).
 
 Disabling auto-merge
 ---------------------


### PR DESCRIPTION
## Summary

- The auto-merge workflow decided whether a Dependabot PR was a major bump by parsing the **PR title** with case-sensitive `Bump …` regexes. This repo sets a conventional-commit prefix in `dependabot.yml` (`prefix: chore`, `include: scope`), so real titles are lowercase and prefixed (e.g. `chore(deps): bump …`). None of the regexes matched, `updateType` fell through to its `semver-patch` default, and the denylist gate (`update-type != semver-major`) passed — **auto-merging every unparseable PR, including security-bypassed majors** (this is how #407 auto-merged).
- Stops parsing titles. A new `dependabot-label.yaml` workflow runs in `pull_request` context, reads the authoritative update type from `dependabot/fetch-metadata`, and applies a `dependencies-{major,minor,patch}` label (fetch-metadata reports the group's *highest* bump for grouped updates).
- The auto-merge workflow now reads that label as a **fail-closed allowlist**: auto-merge is enabled only when a `dependencies-patch` or `dependencies-minor` label is present. No label (e.g. labeling failed) or a `dependencies-major` label ⇒ no auto-merge.

> Note: `dependabot/fetch-metadata` is pinned to `@v3` (the current major; v2 was specified in planning but is now superseded — v3's only breaking change is requiring the Node 24 actions runtime, which `ubuntu-latest` provides).

## Validation steps

- On the next routine **non-major** Dependabot PR, confirm `dependabot-label.yaml` applies a `dependencies-minor`/`dependencies-patch` label and that auto-merge is enabled as before.
- On a deferred open **major** PR (#384 next 16, #414/#415 vitest 4), trigger a synchronize / re-run and confirm it gets a `dependencies-major` label and that auto-merge logs a skip — it must stay unmerged.
- Confirm the new `dependencies-{major,minor,patch}` labels appear under repo **Labels** after the first Dependabot PR event.
- Confirm that an unlabeled PR (labeling step skipped/failed) is **not** auto-merged (fail-closed).