### PR TITLE
fix(squareone): emit absolute URLs from dev Repertoire discovery mock

### DIFF
--- a/.changeset/dev-server-discovery-urls.md
+++ b/.changeset/dev-server-discovery-urls.md
@@ -1,0 +1,18 @@
+---
+"squareone": patch
+---
+
+Fix the dev-mode Repertoire `/discovery` mock to return absolute service URLs so
+they pass URL-schema validation and are fetchable from server components.
+
+- The dev mock route previously overrode internal service URLs (gafaelfawr,
+  semaphore, times-square) with bare relative paths (`/auth`, `/semaphore`, …).
+  Those failed the repertoire-client `z.string().url()` schema, so
+  `DiscoverySchema.parse()` threw a `ZodError` and the app silently fell back to
+  empty discovery (no Semaphore broadcasts, etc.).
+- Relative paths are also unfetchable during server-side prefetch in
+  `RootLayout`, where there is no document origin.
+- The mock now prefixes each overridden internal URL with the dev server's own
+  origin (derived from the incoming request, so it stays port-agnostic). The
+  pathnames are unchanged, so the existing `next.config.js` rewrites still route
+  them to the local mock handlers.

--- a/apps/squareone/src/app/api/dev/repertoire/discovery/route.ts
+++ b/apps/squareone/src/app/api/dev/repertoire/discovery/route.ts
@@ -1,31 +1,36 @@
 import { mockDiscovery } from '@lsst-sqre/repertoire-client';
 import { NextResponse } from 'next/server';
 
-export async function GET() {
-  // Override internal service URLs to use relative paths so that
-  // Next.js rewrites in next.config.js route them to local mock handlers.
+export async function GET(request: Request) {
+  // Use absolute URLs at the dev server's own origin so the values pass the
+  // repertoire-client URL schema (z.string().url()) AND are fetchable from
+  // server components. Pathnames still match the next.config.js rewrites that
+  // route them to the local mock handlers.
+  const origin = new URL(request.url).origin;
   const devDiscovery = structuredClone(mockDiscovery);
 
   const internal = devDiscovery.services.internal;
   if (internal.gafaelfawr) {
-    internal.gafaelfawr.url = '/auth';
+    internal.gafaelfawr.url = `${origin}/auth`;
     if (internal.gafaelfawr.openapi) {
-      internal.gafaelfawr.openapi = '/auth/openapi.json';
+      internal.gafaelfawr.openapi = `${origin}/auth/openapi.json`;
     }
     if (internal.gafaelfawr.versions?.v1) {
-      internal.gafaelfawr.versions.v1.url = '/auth/api/v1';
+      internal.gafaelfawr.versions.v1.url = `${origin}/auth/api/v1`;
     }
   }
   if (internal.semaphore) {
-    internal.semaphore.url = '/semaphore';
+    internal.semaphore.url = `${origin}/semaphore`;
   }
   if (internal['times-square']) {
-    internal['times-square'].url = '/times-square/api';
+    internal['times-square'].url = `${origin}/times-square/api`;
     if (internal['times-square'].openapi) {
-      internal['times-square'].openapi = '/times-square/api/openapi.json';
+      internal['times-square'].openapi =
+        `${origin}/times-square/api/openapi.json`;
     }
     if (internal['times-square'].versions?.v1) {
-      internal['times-square'].versions.v1.url = '/times-square/api/v1';
+      internal['times-square'].versions.v1.url =
+        `${origin}/times-square/api/v1`;
     }
   }
 


### PR DESCRIPTION
## Summary

- The dev-mode Repertoire `/discovery` mock overrode internal service URLs (`gafaelfawr`, `semaphore`, `times-square`) with bare relative paths (`/auth`, `/semaphore`, …). Those failed the repertoire-client `z.string().url()` schema, so `DiscoverySchema.parse()` threw a `ZodError`, discovery silently fell back to empty, and the console showed a misleading `Failed to fetch discovery {}`.
- Relative paths are also fundamentally unfetchable during the server-side prefetch in `RootLayout` (discovery + Semaphore broadcasts), where there is no document origin.
- The mock now prefixes each overridden internal URL with the dev server's own origin (derived from the incoming `request`, so it stays port-agnostic). Pathnames are unchanged, so the existing `next.config.js` rewrites still route them to the local mock handlers — and the values now pass URL-schema validation and are fetchable from server components.

This is a pre-existing bug (the mock route is byte-identical to `main`); it merely surfaced while testing the Next.js 16 dependabot branch.

## Validation steps

- Start the dev server (`pnpm dev --filter squareone`) and load `http://localhost:3000/`.
- `curl -s http://localhost:3000/repertoire/discovery | jq '.services.internal'` — internal URLs are now `http://localhost:3000/...` (absolute).
- Confirm the server logs no longer show the `Failed to fetch discovery` / `Failed to prefetch broadcasts` `ZodError` blocks, and the browser console no longer shows `Failed to fetch discovery`.
- Confirm the rewrites still reach the mock handlers: `GET /semaphore/v1/broadcasts`, `/times-square/api/v1/pages`, and `/auth/api/v1/user-info` all return `200`.
- Sanity-check that Semaphore broadcast banners / Times Square / user-info features that depend on discovery still render.

## Notes

- UI services (`portal`, `nublado`) and dataset services (`tap`, `sia`) are intentionally left as their production `https://data.lsst.cloud/...` URLs — they are external links / not locally mocked and already pass validation.
- No change to `schemas.ts` — strict absolute-URL validation is correct for the real production Repertoire response.