### PR TITLE
fix(stoker): gitignore .pnpm-store/ so the sandbox tree stays clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/node_modules
 /.pnp
 .pnp.js
+.pnpm-store/
 
 # testing
 /coverage


### PR DESCRIPTION
## Summary

Adds `.pnpm-store/` to `.gitignore` so the stoker sandbox's clean-tree gate stops failing on an untracked pnpm store directory.

pnpm keeps its content-addressable store on the same filesystem as the project so it can hardlink into `node_modules`. In the stoker sandbox, `/workspace` is its own Docker volume separate from `$HOME`, and `.devcontainer/stoker/devcontainer.json` sets neither `PNPM_HOME` nor a `.pnpm-store` mount — so `pnpm install` materializes the store at `/workspace/.pnpm-store`, which `git status` flags as untracked. It never appears on a local macOS checkout, where the repo and `$HOME` share one filesystem. The standard `.devcontainer/devcontainer.json` already places a store at exactly that path (`squareone-pnpm-store` volume), so ignoring it is consistent and a no-op locally.

## Validation steps

- `git check-ignore .pnpm-store/` prints `.pnpm-store/` (confirms it is ignored).
- `git status` stays clean locally (the directory does not exist here).
- In a fresh stoker sandbox, `git -C /workspace status` no longer lists `.pnpm-store/` after postCreate's `pnpm install`, and the clean-tree gate passes.

## References

- Follow-up to persist the store across rebuilds: #427