### PR TITLE
DM-55135: Scaffold /admin section with index redirect

### DIFF
--- a/.changeset/admin-section-scaffold.md
+++ b/.changeset/admin-section-scaffold.md
@@ -1,0 +1,22 @@
+---
+"squareone": patch
+---
+
+Add the reusable `/admin` section scaffold, mirroring the `/settings`
+sidebar-layout pattern.
+
+- New `app/admin/layout.tsx` (server, loads config) → `AdminLayoutClient.tsx`
+  (client, `usePathname()`) → shared `<SidebarLayout sidebarTitle="Admin">`,
+  driven by a new flat `getAdminNavigation()` (a single `/admin/sentry` item, no
+  categories).
+- New reusable `getFirstNavItemHref(navSections)` helper in the `SidebarLayout`
+  module (exported from its `index.ts`): returns the first nav item's href, or
+  `null` as a safe fallback for an empty nav.
+- `app/admin/page.tsx` index route redirects to the first sidebar nav item via
+  that helper (currently `/admin/sentry`); reordering the nav changes the target
+  with no other code change. An empty nav renders a fallback instead of
+  redirecting.
+- Minimal `app/admin/sentry/page.tsx` placeholder so the redirect resolves.
+
+No access gating in this slice; the Phalanx ingress remains the deployment-time
+enforcement.

--- a/apps/squareone/squareone.config.schema.json
+++ b/apps/squareone/squareone.config.schema.json
@@ -95,6 +95,18 @@
       "description": "Setting this option to true will print useful information to the console while you're setting up Sentry.",
       "default": false
     },
+    "sentryOrg": {
+      "type": "string",
+      "title": "Sentry organization slug",
+      "description": "Sentry organization slug used to build the Sentry dashboard link on the admin page. The dashboard link is shown only when both sentryOrg and sentryProject are set.",
+      "default": "rubin-observatory"
+    },
+    "sentryProject": {
+      "type": "string",
+      "title": "Sentry project slug",
+      "description": "Sentry project slug used to build the Sentry dashboard link on the admin page. The dashboard link is shown only when both sentryOrg and sentryProject are set.",
+      "default": "squareone"
+    },
     "enableAppsMenu": {
       "type": "boolean",
       "title": "Enable the Apps menu",

--- a/apps/squareone/squareone.config.yaml
+++ b/apps/squareone/squareone.config.yaml
@@ -24,3 +24,5 @@ sentryTracesSampleRate: 0
 sentryReplaysSessionSampleRate: 0
 sentryReplaysOnErrorSampleRate: 1.0
 sentryDebug: false
+sentryOrg: 'rubin-observatory'
+sentryProject: 'squareone'

--- a/apps/squareone/src/app/admin/AdminLayoutClient.tsx
+++ b/apps/squareone/src/app/admin/AdminLayoutClient.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from 'next/navigation';
 import { type ReactNode, useMemo } from 'react';
 import { getAdminNavigation } from '../../components/AdminLayout/adminNavigation';
+import AdminRequired from '../../components/AdminRequired';
 import { SidebarLayout } from '../../components/SidebarLayout';
 import type { AppConfigContextValue } from '../../hooks/useStaticConfig';
 
@@ -17,6 +18,11 @@ type AdminLayoutClientProps = {
  * Receives config as a prop from the server component layout. Uses
  * usePathname() from next/navigation (App Router) to get the current path for
  * navigation highlighting. The admin navigation is flat (no categories).
+ *
+ * Wraps the layout in AdminRequired so every admin page inherits the
+ * client-side `exec:admin` scope gate (defense-in-depth alongside the Phalanx
+ * ingress). Unauthorized users see the gate's message instead of the admin
+ * sidebar and content.
  */
 export default function AdminLayoutClient({
   children,
@@ -28,12 +34,14 @@ export default function AdminLayoutClient({
   const navSections = useMemo(() => getAdminNavigation(config), [config]);
 
   return (
-    <SidebarLayout
-      sidebarTitle="Admin"
-      navSections={navSections}
-      currentPath={pathname}
-    >
-      {children}
-    </SidebarLayout>
+    <AdminRequired>
+      <SidebarLayout
+        sidebarTitle="Admin"
+        navSections={navSections}
+        currentPath={pathname}
+      >
+        {children}
+      </SidebarLayout>
+    </AdminRequired>
   );
 }

--- a/apps/squareone/src/app/admin/AdminLayoutClient.tsx
+++ b/apps/squareone/src/app/admin/AdminLayoutClient.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { type ReactNode, useMemo } from 'react';
+import { getAdminNavigation } from '../../components/AdminLayout/adminNavigation';
+import { SidebarLayout } from '../../components/SidebarLayout';
+import type { AppConfigContextValue } from '../../hooks/useStaticConfig';
+
+type AdminLayoutClientProps = {
+  children: ReactNode;
+  config: AppConfigContextValue;
+};
+
+/**
+ * Client component for the admin layout.
+ *
+ * Receives config as a prop from the server component layout. Uses
+ * usePathname() from next/navigation (App Router) to get the current path for
+ * navigation highlighting. The admin navigation is flat (no categories).
+ */
+export default function AdminLayoutClient({
+  children,
+  config,
+}: AdminLayoutClientProps) {
+  const pathname = usePathname();
+
+  // Dynamically generate navigation based on config
+  const navSections = useMemo(() => getAdminNavigation(config), [config]);
+
+  return (
+    <SidebarLayout
+      sidebarTitle="Admin"
+      navSections={navSections}
+      currentPath={pathname}
+    >
+      {children}
+    </SidebarLayout>
+  );
+}

--- a/apps/squareone/src/app/admin/layout.tsx
+++ b/apps/squareone/src/app/admin/layout.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+import { getStaticConfig } from '../../lib/config/rsc';
+import AdminLayoutClient from './AdminLayoutClient';
+
+type AdminLayoutProps = {
+  children: ReactNode;
+};
+
+/**
+ * Admin section layout for App Router.
+ *
+ * This server component loads configuration and passes it to the client
+ * component, ensuring config is fetched server-side rather than client-side.
+ * Mirrors the `/settings` layout pattern.
+ */
+export default async function AdminLayout({ children }: AdminLayoutProps) {
+  const config = await getStaticConfig();
+
+  return <AdminLayoutClient config={config}>{children}</AdminLayoutClient>;
+}

--- a/apps/squareone/src/app/admin/page.tsx
+++ b/apps/squareone/src/app/admin/page.tsx
@@ -1,0 +1,26 @@
+import { redirect } from 'next/navigation';
+
+import { getAdminNavigation } from '../../components/AdminLayout/adminNavigation';
+// Import the helper from its module (not the SidebarLayout barrel) so this
+// server component does not pull in the client-only SidebarLayout component.
+import { getFirstNavItemHref } from '../../components/SidebarLayout/getFirstNavItemHref';
+import { getStaticConfig } from '../../lib/config/rsc';
+
+/**
+ * Admin index route.
+ *
+ * Redirects to the first item in the admin sidebar navigation (currently
+ * `/admin/sentry`). Reordering `getAdminNavigation()` changes the target with
+ * no other code change. When the navigation is empty, renders a fallback
+ * instead of redirecting.
+ */
+export default async function AdminPage() {
+  const config = await getStaticConfig();
+  const firstNavItemHref = getFirstNavItemHref(getAdminNavigation(config));
+
+  if (firstNavItemHref) {
+    redirect(firstNavItemHref);
+  }
+
+  return <p>No admin pages are available.</p>;
+}

--- a/apps/squareone/src/app/admin/sentry/page.tsx
+++ b/apps/squareone/src/app/admin/sentry/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next';
+
+import { getStaticConfig } from '../../../lib/config/rsc';
+
+const pageDescription = 'Verify the Sentry monitoring integration';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const config = await getStaticConfig();
+  return {
+    title: `Sentry | ${config.siteName}`,
+    description: pageDescription,
+    openGraph: {
+      title: 'Sentry',
+      description: pageDescription,
+    },
+  };
+}
+
+/**
+ * Placeholder for the Sentry admin page.
+ *
+ * The Sentry test buttons and read-only configuration are added in a later
+ * slice; this minimal page exists so the `/admin` index redirect resolves.
+ */
+export default function SentryAdminPage() {
+  return (
+    <div>
+      <h1>Sentry</h1>
+      <p>Sentry monitoring administration.</p>
+    </div>
+  );
+}

--- a/apps/squareone/src/app/admin/sentry/page.tsx
+++ b/apps/squareone/src/app/admin/sentry/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 
+import SentryTestButtons from '../../../components/SentryTestButtons';
 import { getStaticConfig } from '../../../lib/config/rsc';
 
 const pageDescription = 'Verify the Sentry monitoring integration';
@@ -17,16 +18,21 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 /**
- * Placeholder for the Sentry admin page.
+ * Sentry admin page.
  *
- * The Sentry test buttons and read-only configuration are added in a later
- * slice; this minimal page exists so the `/admin` index redirect resolves.
+ * Renders the Sentry test buttons that exercise the error-reporting pipeline.
+ * The read-only Sentry configuration and dashboard link are added in a parallel
+ * slice.
  */
 export default function SentryAdminPage() {
   return (
     <div>
       <h1>Sentry</h1>
-      <p>Sentry monitoring administration.</p>
+      <p>
+        Verify the Sentry monitoring integration by triggering test errors that
+        should appear in the Sentry project.
+      </p>
+      <SentryTestButtons />
     </div>
   );
 }

--- a/apps/squareone/src/app/admin/sentry/page.tsx
+++ b/apps/squareone/src/app/admin/sentry/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 
+import SentryConfigInfo from '../../../components/SentryConfigInfo';
 import SentryTestButtons from '../../../components/SentryTestButtons';
 import { getStaticConfig } from '../../../lib/config/rsc';
 
@@ -20,9 +21,9 @@ export async function generateMetadata(): Promise<Metadata> {
 /**
  * Sentry admin page.
  *
- * Renders the Sentry test buttons that exercise the error-reporting pipeline.
- * The read-only Sentry configuration and dashboard link are added in a parallel
- * slice.
+ * Renders the Sentry test buttons that exercise the error-reporting pipeline,
+ * plus a read-only summary of the runtime Sentry configuration (and a link to
+ * the Sentry dashboard when the org/project are configured).
  */
 export default function SentryAdminPage() {
   return (
@@ -33,6 +34,7 @@ export default function SentryAdminPage() {
         should appear in the Sentry project.
       </p>
       <SentryTestButtons />
+      <SentryConfigInfo />
     </div>
   );
 }

--- a/apps/squareone/src/components/AdminLayout/adminNavigation.test.ts
+++ b/apps/squareone/src/components/AdminLayout/adminNavigation.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest';
+import type { AppConfigContextValue } from '../../hooks/useStaticConfig';
+import { getAdminNavigation } from './adminNavigation';
+
+// Mock AppConfig configuration for testing
+const baseConfig: AppConfigContextValue = {
+  siteName: 'Rubin Science Platform',
+  baseUrl: 'http://localhost:3000',
+  environmentName: 'test',
+  siteDescription: 'Test site description',
+  docsBaseUrl: 'https://rsp.lsst.io',
+  timesSquareUrl: 'http://localhost:3000/times-square/api',
+  coManageRegistryUrl: 'https://id.lsst.cloud',
+  enableAppsMenu: false,
+  appLinks: [],
+  showPreview: false,
+  mdxDir: 'src/content/pages',
+};
+
+test('generates a single flat section with the Sentry item', () => {
+  const navigation = getAdminNavigation(baseConfig);
+
+  expect(navigation).toHaveLength(1);
+  expect(navigation[0]).toEqual({
+    items: [{ href: '/admin/sentry', label: 'Sentry' }],
+  });
+});
+
+test('the section is flat (no category label)', () => {
+  const navigation = getAdminNavigation(baseConfig);
+
+  expect(navigation[0]).not.toHaveProperty('label');
+});
+
+test('all navigation items have string href and label under /admin', () => {
+  const navigation = getAdminNavigation(baseConfig);
+
+  navigation.forEach((section) => {
+    section.items.forEach((item) => {
+      expect(typeof item.href).toBe('string');
+      expect(typeof item.label).toBe('string');
+      expect(item.href).toMatch(/^\/admin/);
+    });
+  });
+});
+
+test('function is pure - repeated calls return identical results', () => {
+  expect(getAdminNavigation(baseConfig)).toEqual(
+    getAdminNavigation(baseConfig)
+  );
+});

--- a/apps/squareone/src/components/AdminLayout/adminNavigation.ts
+++ b/apps/squareone/src/components/AdminLayout/adminNavigation.ts
@@ -1,0 +1,23 @@
+import type { AppConfigContextValue } from '../../hooks/useStaticConfig';
+import type { NavSection } from '../SidebarLayout';
+
+/**
+ * Generates admin navigation configuration based on app config.
+ *
+ * The admin navigation is flat (a single section with no category label).
+ * Additional admin pages are added as further items in this section; the
+ * `/admin` index route redirects to the first item via
+ * {@link getFirstNavItemHref}, so ordering this list controls the redirect
+ * target.
+ */
+export function getAdminNavigation(
+  _config: AppConfigContextValue
+): NavSection[] {
+  const navigation: NavSection[] = [
+    {
+      items: [{ href: '/admin/sentry', label: 'Sentry' }],
+    },
+  ];
+
+  return navigation;
+}

--- a/apps/squareone/src/components/AdminRequired/AdminRequired.module.css
+++ b/apps/squareone/src/components/AdminRequired/AdminRequired.module.css
@@ -1,0 +1,8 @@
+.loading {
+  padding: var(--sqo-space-md-fixed);
+  color: var(--sqo-color-text-secondary);
+}
+
+.unauthorized {
+  padding: var(--sqo-space-md-fixed);
+}

--- a/apps/squareone/src/components/AdminRequired/AdminRequired.test.tsx
+++ b/apps/squareone/src/components/AdminRequired/AdminRequired.test.tsx
@@ -86,6 +86,26 @@ describe('AdminRequired', () => {
     expect(screen.queryByText('Admin Content')).not.toBeInTheDocument();
   });
 
+  test('renders an unauthorized state when the login-info fetch fails (query is null)', () => {
+    vi.mocked(useUserInfo).mockReturnValue(mockAuthenticated());
+    vi.mocked(useLoginInfo).mockReturnValue({
+      loginInfo: null,
+      query: null,
+      csrfToken: null,
+      isLoading: false,
+      isPending: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<AdminRequired>Admin Content</AdminRequired>);
+
+    expect(
+      screen.getByRole('heading', { name: /unauthorized/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Admin Content')).not.toBeInTheDocument();
+  });
+
   test('renders a loading state while login info is loading', () => {
     vi.mocked(useUserInfo).mockReturnValue(mockAuthenticated());
     vi.mocked(useLoginInfo).mockReturnValue(mockLoginInfoWithScopes([], true));

--- a/apps/squareone/src/components/AdminRequired/AdminRequired.test.tsx
+++ b/apps/squareone/src/components/AdminRequired/AdminRequired.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import AdminRequired from './AdminRequired';
+
+// Mock the gafaelfawr hooks. AdminRequired composes AuthRequired (which checks
+// login via useUserInfo) and additionally gates on the exec:admin scope via
+// useLoginInfo.
+vi.mock('@lsst-sqre/gafaelfawr-client', () => ({
+  useUserInfo: vi.fn(),
+  useLoginInfo: vi.fn(),
+}));
+
+vi.mock('../../hooks/useRepertoireUrl', () => ({
+  useRepertoireUrl: vi.fn(() => undefined),
+}));
+
+import type {
+  UseLoginInfoReturn,
+  UseUserInfoReturn,
+} from '@lsst-sqre/gafaelfawr-client';
+// Import after mocking
+import { useLoginInfo, useUserInfo } from '@lsst-sqre/gafaelfawr-client';
+
+// Helper: an authenticated useUserInfo return (so AuthRequired renders through
+// to the scope gate).
+function mockAuthenticated(isLoading = false): UseUserInfoReturn {
+  return {
+    userInfo: { username: 'testuser' } as UseUserInfoReturn['userInfo'],
+    query: null,
+    isLoggedIn: true,
+    isLoading,
+    isPending: false,
+    error: null,
+    refetch: vi.fn(),
+  };
+}
+
+// Helper: a useLoginInfo return whose query reports the given scopes.
+function mockLoginInfoWithScopes(
+  scopes: string[],
+  isLoading = false
+): UseLoginInfoReturn {
+  return {
+    loginInfo: null,
+    query: {
+      hasScope: (scope: string) => scopes.includes(scope),
+    } as UseLoginInfoReturn['query'],
+    csrfToken: null,
+    isLoading,
+    isPending: false,
+    error: null,
+    refetch: vi.fn(),
+  };
+}
+
+describe('AdminRequired', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('renders children when the user has the exec:admin scope', () => {
+    vi.mocked(useUserInfo).mockReturnValue(mockAuthenticated());
+    vi.mocked(useLoginInfo).mockReturnValue(
+      mockLoginInfoWithScopes(['exec:admin'])
+    );
+
+    render(<AdminRequired>Admin Content</AdminRequired>);
+
+    expect(screen.getByText('Admin Content')).toBeInTheDocument();
+    expect(screen.queryByText(/unauthorized/i)).not.toBeInTheDocument();
+  });
+
+  test('renders an unauthorized state for a logged-in user lacking the scope', () => {
+    vi.mocked(useUserInfo).mockReturnValue(mockAuthenticated());
+    vi.mocked(useLoginInfo).mockReturnValue(
+      mockLoginInfoWithScopes(['read:tap', 'exec:notebook'])
+    );
+
+    render(<AdminRequired>Admin Content</AdminRequired>);
+
+    expect(
+      screen.getByRole('heading', { name: /unauthorized/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Admin Content')).not.toBeInTheDocument();
+  });
+
+  test('renders a loading state while login info is loading', () => {
+    vi.mocked(useUserInfo).mockReturnValue(mockAuthenticated());
+    vi.mocked(useLoginInfo).mockReturnValue(mockLoginInfoWithScopes([], true));
+
+    render(<AdminRequired>Admin Content</AdminRequired>);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Admin Content')).not.toBeInTheDocument();
+    expect(screen.queryByText(/unauthorized/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/squareone/src/components/AdminRequired/AdminRequired.tsx
+++ b/apps/squareone/src/components/AdminRequired/AdminRequired.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useLoginInfo } from '@lsst-sqre/gafaelfawr-client';
+import React, { type ReactNode } from 'react';
+
+import { useRepertoireUrl } from '../../hooks/useRepertoireUrl';
+import AuthRequired from '../AuthRequired';
+
+import styles from './AdminRequired.module.css';
+
+/** Gafaelfawr scope required to access the admin section. */
+const ADMIN_SCOPE = 'exec:admin';
+
+type AdminRequiredProps = {
+  children: ReactNode;
+  /** Custom loading component while checking authorization */
+  loadingFallback?: ReactNode;
+};
+
+/**
+ * Wrapper component that requires login and the `exec:admin` Gafaelfawr scope.
+ *
+ * Use this component to gate admin-only content. It composes {@link AuthRequired}
+ * to require authentication (redirecting unauthenticated users to login) and
+ * additionally checks the `exec:admin` scope via `useLoginInfo()`. Logged-in
+ * users without the scope see an "unauthorized" state instead of the children.
+ *
+ * This is a client-side, defense-in-depth gate that runs alongside the Phalanx
+ * ingress restricting the `/admin` route prefix in deployment.
+ *
+ * @example
+ * ```tsx
+ * // Applied at the admin layout so every admin page inherits the gate
+ * export default function AdminLayoutClient({ children }: Props) {
+ *   return (
+ *     <AdminRequired>
+ *       <SidebarLayout sidebarTitle="Admin" ...>{children}</SidebarLayout>
+ *     </AdminRequired>
+ *   );
+ * }
+ * ```
+ */
+export default function AdminRequired({
+  children,
+  loadingFallback,
+}: AdminRequiredProps) {
+  return (
+    <AuthRequired loadingFallback={loadingFallback}>
+      <AdminScopeGate loadingFallback={loadingFallback}>
+        {children}
+      </AdminScopeGate>
+    </AuthRequired>
+  );
+}
+
+type AdminScopeGateProps = {
+  children: ReactNode;
+  loadingFallback?: ReactNode;
+};
+
+/**
+ * Inner gate that checks the `exec:admin` scope. Rendered only once
+ * {@link AuthRequired} has confirmed the user is logged in.
+ */
+function AdminScopeGate({ children, loadingFallback }: AdminScopeGateProps) {
+  const repertoireUrl = useRepertoireUrl();
+  const { query, isLoading } = useLoginInfo(repertoireUrl);
+
+  // Wait for login info before deciding, so authorized users never flash the
+  // unauthorized state.
+  if (isLoading) {
+    return loadingFallback ?? <div className={styles.loading}>Loading...</div>;
+  }
+
+  if (!query?.hasScope(ADMIN_SCOPE)) {
+    return (
+      <div className={styles.unauthorized}>
+        <h1>Unauthorized</h1>
+        <p>
+          You do not have permission to access the admin section. The{' '}
+          <code>{ADMIN_SCOPE}</code> scope is required. If you believe this is
+          an error, contact your administrator.
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/squareone/src/components/AdminRequired/AdminRequired.tsx
+++ b/apps/squareone/src/components/AdminRequired/AdminRequired.tsx
@@ -9,7 +9,7 @@ import AuthRequired from '../AuthRequired';
 import styles from './AdminRequired.module.css';
 
 /** Gafaelfawr scope required to access the admin section. */
-const ADMIN_SCOPE = 'exec:admin';
+export const ADMIN_SCOPE = 'exec:admin';
 
 type AdminRequiredProps = {
   children: ReactNode;

--- a/apps/squareone/src/components/AdminRequired/index.ts
+++ b/apps/squareone/src/components/AdminRequired/index.ts
@@ -1,1 +1,1 @@
-export { default } from './AdminRequired';
+export { ADMIN_SCOPE, default } from './AdminRequired';

--- a/apps/squareone/src/components/AdminRequired/index.ts
+++ b/apps/squareone/src/components/AdminRequired/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminRequired';

--- a/apps/squareone/src/components/Header/UserMenu.test.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// useGafaelfawrUser comes from @lsst-sqre/squared. Mock it while keeping the
+// real PrimaryNavigation / getLogoutUrl exports so the menu still renders.
+vi.mock('@lsst-sqre/squared', async () => {
+  const actual =
+    await vi.importActual<typeof import('@lsst-sqre/squared')>(
+      '@lsst-sqre/squared'
+    );
+  return {
+    ...actual,
+    useGafaelfawrUser: vi.fn(),
+  };
+});
+
+// useLoginInfo provides the exec:admin scope gate for the Admin link.
+vi.mock('@lsst-sqre/gafaelfawr-client', () => ({
+  useLoginInfo: vi.fn(),
+}));
+
+vi.mock('../../hooks/useRepertoireUrl', () => ({
+  useRepertoireUrl: vi.fn(() => undefined),
+}));
+
+import type { UseLoginInfoReturn } from '@lsst-sqre/gafaelfawr-client';
+// Import after mocking
+import { useLoginInfo } from '@lsst-sqre/gafaelfawr-client';
+import { PrimaryNavigation, useGafaelfawrUser } from '@lsst-sqre/squared';
+
+import UserMenu from './UserMenu';
+
+// Helper: a logged-in useGafaelfawrUser return.
+function mockUser(username = 'testuser') {
+  vi.mocked(useGafaelfawrUser).mockReturnValue({
+    user: { username },
+    isLoading: false,
+    isValidating: false,
+    isLoggedIn: true,
+    error: undefined,
+  } as ReturnType<typeof useGafaelfawrUser>);
+}
+
+// Helper: a useLoginInfo return whose query reports the given scopes.
+function mockLoginInfoWithScopes(scopes: string[]): UseLoginInfoReturn {
+  return {
+    loginInfo: null,
+    query: {
+      hasScope: (scope: string) => scopes.includes(scope),
+    } as UseLoginInfoReturn['query'],
+    csrfToken: null,
+    isLoading: false,
+    isPending: false,
+    error: null,
+    refetch: vi.fn(),
+  };
+}
+
+// Render the menu inside the navigation root it expects to live in.
+function renderMenu() {
+  return render(
+    <PrimaryNavigation>
+      <PrimaryNavigation.Item>
+        <UserMenu pageUrl={new URL('https://example.com/')} />
+      </PrimaryNavigation.Item>
+    </PrimaryNavigation>
+  );
+}
+
+describe('UserMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('shows an Admin link to /admin when the user has exec:admin', async () => {
+    const user = userEvent.setup();
+    mockUser();
+    vi.mocked(useLoginInfo).mockReturnValue(
+      mockLoginInfoWithScopes(['exec:admin'])
+    );
+
+    renderMenu();
+    await user.click(screen.getByRole('button', { name: /testuser/i }));
+
+    expect(screen.getByRole('link', { name: 'Admin' })).toHaveAttribute(
+      'href',
+      '/admin'
+    );
+  });
+
+  test('does not show an Admin link when the user lacks exec:admin', async () => {
+    const user = userEvent.setup();
+    mockUser();
+    vi.mocked(useLoginInfo).mockReturnValue(
+      mockLoginInfoWithScopes(['read:tap', 'exec:notebook'])
+    );
+
+    renderMenu();
+    await user.click(screen.getByRole('button', { name: /testuser/i }));
+
+    // The menu is open (Settings is visible) but the Admin link is absent.
+    expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Admin' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/squareone/src/components/Header/UserMenu.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 /* Menu for a user profile and settings. */
 
+import { useLoginInfo } from '@lsst-sqre/gafaelfawr-client';
 import {
   getLogoutUrl,
   PrimaryNavigation,
@@ -9,13 +10,24 @@ import {
 import { ChevronDown } from 'lucide-react';
 import NextLink from 'next/link';
 
+import { useRepertoireUrl } from '../../hooks/useRepertoireUrl';
+
+/** Gafaelfawr scope that unlocks the admin section. */
+const ADMIN_SCOPE = 'exec:admin';
+
 type UserMenuProps = {
   pageUrl: URL;
 };
 
 export default function UserMenu({ pageUrl }: UserMenuProps) {
   const { user } = useGafaelfawrUser();
+  const repertoireUrl = useRepertoireUrl();
+  const { query } = useLoginInfo(repertoireUrl);
   const logoutUrl = getLogoutUrl(pageUrl.toString());
+
+  // Only admins (holders of the exec:admin scope) see the Admin link, mirroring
+  // the client-side gate on the admin pages themselves.
+  const isAdmin = query?.hasScope(ADMIN_SCOPE) ?? false;
 
   // User data should be available when this component is rendered
   // since Login component handles the hydration logic
@@ -34,6 +46,13 @@ export default function UserMenu({ pageUrl }: UserMenuProps) {
             <NextLink href="/settings">Settings</NextLink>
           </PrimaryNavigation.Link>
         </PrimaryNavigation.ContentItem>
+        {isAdmin && (
+          <PrimaryNavigation.ContentItem>
+            <PrimaryNavigation.Link asChild>
+              <NextLink href="/admin">Admin</NextLink>
+            </PrimaryNavigation.Link>
+          </PrimaryNavigation.ContentItem>
+        )}
         <PrimaryNavigation.ContentItem>
           <PrimaryNavigation.Link href={logoutUrl}>
             Log out

--- a/apps/squareone/src/components/Header/UserMenu.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.tsx
@@ -11,9 +11,7 @@ import { ChevronDown } from 'lucide-react';
 import NextLink from 'next/link';
 
 import { useRepertoireUrl } from '../../hooks/useRepertoireUrl';
-
-/** Gafaelfawr scope that unlocks the admin section. */
-const ADMIN_SCOPE = 'exec:admin';
+import { ADMIN_SCOPE } from '../AdminRequired';
 
 type UserMenuProps = {
   pageUrl: URL;

--- a/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.module.css
+++ b/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.module.css
@@ -1,0 +1,41 @@
+/**
+ * SentryConfigInfo styles
+ *
+ * A two-column definition list (label / value), mirroring the metadata-list
+ * layout used elsewhere in the app (e.g. TokenHistoryDetails).
+ */
+
+.root {
+  margin-top: var(--sqo-space-lg);
+}
+
+.list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--sqo-space-xs) var(--sqo-space-md);
+  margin: var(--sqo-space-sm) 0;
+}
+
+.label {
+  color: var(--rsd-color-gray-500);
+  font-weight: 500;
+  margin: 0;
+}
+
+.value {
+  color: var(--rsd-component-text-color);
+  margin: 0;
+  word-break: break-word;
+}
+
+.dashboard {
+  margin: 0;
+}
+
+.link {
+  color: var(--rsd-component-text-link-color);
+}
+
+.link:hover {
+  text-decoration: underline;
+}

--- a/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.stories.tsx
+++ b/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.stories.tsx
@@ -84,3 +84,28 @@ export const Disabled: Story = {
     ).not.toBeInTheDocument();
   },
 };
+
+// Disabled but with org/project still set (their config defaults): status reads
+// "Disabled" and the dashboard link stays hidden because Sentry is not enabled,
+// even though the slugs that build the URL are populated.
+export const DisabledWithOrgProject: Story = {
+  render: () => (
+    <ConfigProvider
+      configPromise={Promise.resolve({
+        ...baseConfig,
+        sentryOrg: 'rubin-observatory',
+        sentryProject: 'squareone',
+      })}
+    >
+      <SentryConfigInfo />
+    </ConfigProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Disabled')).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('link', { name: /sentry dashboard/i })
+    ).not.toBeInTheDocument();
+  },
+};

--- a/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.stories.tsx
+++ b/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+import { ConfigProvider } from '../../contexts/rsc';
+import type { AppConfigContextValue } from '../../hooks/useStaticConfig';
+import SentryConfigInfo from './SentryConfigInfo';
+
+// Minimal app config shared by the stories; each story layers the Sentry
+// fields it wants to demonstrate on top.
+const baseConfig: AppConfigContextValue = {
+  siteName: 'Rubin Science Platform',
+  siteDescription: 'The Rubin Science Platform.',
+  showPreview: false,
+  previewLink: 'https://rsp.lsst.io/roadmap.html',
+  docsBaseUrl: 'https://rsp.lsst.io',
+  enableAppsMenu: false,
+  appLinks: [],
+  baseUrl: 'https://data.lsst.cloud',
+  coManageRegistryUrl: null,
+  timesSquareUrl: null,
+  environmentName: 'idfprod',
+  semaphoreUrl: null,
+  plausibleDomain: null,
+  mdxDir: '/mock/mdx',
+};
+
+const enabledConfig: AppConfigContextValue = {
+  ...baseConfig,
+  sentryDsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  sentryTracesSampleRate: 0.2,
+  sentryReplaysSessionSampleRate: 0,
+  sentryReplaysOnErrorSampleRate: 1,
+  sentryOrg: 'rubin-observatory',
+  sentryProject: 'squareone',
+};
+
+const meta: Meta<typeof SentryConfigInfo> = {
+  title: 'Components/SentryConfigInfo',
+  component: SentryConfigInfo,
+};
+
+export default meta;
+type Story = StoryObj<typeof SentryConfigInfo>;
+
+// SentryConfigInfo reads config via useStaticConfig(); each story renders it
+// inside a ConfigProvider so it can show a different configuration.
+
+// Sentry enabled with org/project set: all fields populated and the dashboard
+// link visible.
+export const Enabled: Story = {
+  render: () => (
+    <ConfigProvider configPromise={Promise.resolve(enabledConfig)}>
+      <SentryConfigInfo />
+    </ConfigProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Enabled')).toBeInTheDocument();
+
+    const link = await canvas.findByRole('link', {
+      name: /sentry dashboard/i,
+    });
+    await expect(link).toHaveAttribute(
+      'href',
+      'https://rubin-observatory.sentry.io/projects/squareone/'
+    );
+  },
+};
+
+// No DSN and no org/project: status reads "Disabled", unset sample rates show
+// "Not set", and the dashboard link is hidden.
+export const Disabled: Story = {
+  render: () => (
+    <ConfigProvider configPromise={Promise.resolve(baseConfig)}>
+      <SentryConfigInfo />
+    </ConfigProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText('Disabled')).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('link', { name: /sentry dashboard/i })
+    ).not.toBeInTheDocument();
+  },
+};

--- a/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.test.tsx
+++ b/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.test.tsx
@@ -100,4 +100,19 @@ describe('SentryConfigInfo', () => {
       screen.queryByRole('link', { name: /sentry dashboard/i })
     ).not.toBeInTheDocument();
   });
+
+  test('hides the dashboard link when Sentry is disabled even though sentryOrg and sentryProject are set', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(
+      makeConfig({
+        sentryDsn: undefined,
+        sentryOrg: 'rubin-observatory',
+        sentryProject: 'squareone',
+      })
+    );
+    render(<SentryConfigInfo />);
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /sentry dashboard/i })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.test.tsx
+++ b/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the config hook so the component can be rendered with arbitrary config
+// without a ConfigProvider/Suspense boundary.
+vi.mock('../../hooks/useStaticConfig', () => ({
+  useStaticConfig: vi.fn(),
+}));
+
+// Import after mocking.
+import { useStaticConfig } from '../../hooks/useStaticConfig';
+import type { AppConfig } from '../../lib/config/loader';
+import SentryConfigInfo from './SentryConfigInfo';
+
+// Build a config object with only the fields the component reads, cast to the
+// full AppConfig shape.
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    environmentName: 'production',
+    baseUrl: 'https://data.example.org',
+    sentryDsn: 'https://abc@o1.ingest.sentry.io/123',
+    sentryTracesSampleRate: 0.25,
+    sentryReplaysSessionSampleRate: 0.5,
+    sentryReplaysOnErrorSampleRate: 1,
+    sentryOrg: 'rubin-observatory',
+    sentryProject: 'squareone',
+    ...overrides,
+  } as AppConfig;
+}
+
+describe('SentryConfigInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('shows Sentry as enabled when a DSN is configured', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(makeConfig());
+    render(<SentryConfigInfo />);
+    expect(screen.getByText('Enabled')).toBeInTheDocument();
+  });
+
+  test('shows Sentry as disabled when no DSN is configured', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(
+      makeConfig({ sentryDsn: undefined })
+    );
+    render(<SentryConfigInfo />);
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
+
+  test('displays the environment name and base URL', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(makeConfig());
+    render(<SentryConfigInfo />);
+    expect(screen.getByText('production')).toBeInTheDocument();
+    expect(screen.getByText('https://data.example.org')).toBeInTheDocument();
+  });
+
+  test('displays the traces and replay sample rates', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(makeConfig());
+    render(<SentryConfigInfo />);
+    expect(screen.getByText('0.25')).toBeInTheDocument();
+    expect(screen.getByText('0.5')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  test('shows "Not set" for an unset sample rate', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(
+      makeConfig({ sentryTracesSampleRate: undefined })
+    );
+    render(<SentryConfigInfo />);
+    expect(screen.getByText('Not set')).toBeInTheDocument();
+  });
+
+  test('shows a Sentry dashboard link when sentryOrg and sentryProject are set', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(makeConfig());
+    render(<SentryConfigInfo />);
+    const link = screen.getByRole('link', { name: /sentry dashboard/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://rubin-observatory.sentry.io/projects/squareone/'
+    );
+  });
+
+  test('hides the dashboard link when sentryOrg is unset', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(
+      makeConfig({ sentryOrg: undefined })
+    );
+    render(<SentryConfigInfo />);
+    expect(
+      screen.queryByRole('link', { name: /sentry dashboard/i })
+    ).not.toBeInTheDocument();
+  });
+
+  test('hides the dashboard link when sentryProject is unset', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(
+      makeConfig({ sentryProject: undefined })
+    );
+    render(<SentryConfigInfo />);
+    expect(
+      screen.queryByRole('link', { name: /sentry dashboard/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.tsx
+++ b/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React from 'react';
+
+import { useStaticConfig } from '../../hooks/useStaticConfig';
+import styles from './SentryConfigInfo.module.css';
+import { getSentryDashboardUrl } from './sentryDashboardUrl';
+
+/**
+ * Render a sample rate for display. Sample rates are numbers in [0, 1]; `0` is
+ * a meaningful value, so an unset (undefined) rate is shown as "Not set"
+ * rather than being coerced to a falsy blank.
+ */
+function formatSampleRate(rate: number | undefined): string {
+  return rate === undefined ? 'Not set' : String(rate);
+}
+
+/**
+ * Read-only summary of the runtime Sentry configuration for the `/admin/sentry`
+ * page.
+ *
+ * Reads the resolved app config via {@link useStaticConfig} and displays the
+ * enabled status (whether a DSN is present), environment name, traces/replay
+ * sample rates, and the app base URL. When both `sentryOrg` and `sentryProject`
+ * are configured it also renders a link to the project's Sentry dashboard; the
+ * link is hidden when either slug is unset.
+ */
+export default function SentryConfigInfo() {
+  const config = useStaticConfig();
+
+  const enabled = Boolean(config.sentryDsn);
+  const dashboardUrl =
+    config.sentryOrg && config.sentryProject
+      ? getSentryDashboardUrl(config.sentryOrg, config.sentryProject)
+      : null;
+
+  return (
+    <section className={styles.root}>
+      <h2>Configuration</h2>
+      <dl className={styles.list}>
+        <dt className={styles.label}>Status</dt>
+        <dd className={styles.value}>{enabled ? 'Enabled' : 'Disabled'}</dd>
+
+        <dt className={styles.label}>Environment</dt>
+        <dd className={styles.value}>{config.environmentName}</dd>
+
+        <dt className={styles.label}>Traces sample rate</dt>
+        <dd className={styles.value}>
+          {formatSampleRate(config.sentryTracesSampleRate)}
+        </dd>
+
+        <dt className={styles.label}>Session replay sample rate</dt>
+        <dd className={styles.value}>
+          {formatSampleRate(config.sentryReplaysSessionSampleRate)}
+        </dd>
+
+        <dt className={styles.label}>Error replay sample rate</dt>
+        <dd className={styles.value}>
+          {formatSampleRate(config.sentryReplaysOnErrorSampleRate)}
+        </dd>
+
+        <dt className={styles.label}>Base URL</dt>
+        <dd className={styles.value}>{config.baseUrl}</dd>
+      </dl>
+
+      {dashboardUrl && (
+        <p className={styles.dashboard}>
+          <a
+            className={styles.link}
+            href={dashboardUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open Sentry dashboard
+          </a>
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.tsx
+++ b/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.tsx
@@ -21,16 +21,17 @@ function formatSampleRate(rate: number | undefined): string {
  *
  * Reads the resolved app config via {@link useStaticConfig} and displays the
  * enabled status (whether a DSN is present), environment name, traces/replay
- * sample rates, and the app base URL. When both `sentryOrg` and `sentryProject`
- * are configured it also renders a link to the project's Sentry dashboard; the
- * link is hidden when either slug is unset.
+ * sample rates, and the app base URL. When Sentry is enabled (a DSN is present)
+ * and both `sentryOrg` and `sentryProject` are configured it also renders a link
+ * to the project's Sentry dashboard; the link is hidden when Sentry is disabled
+ * or either slug is unset.
  */
 export default function SentryConfigInfo() {
   const config = useStaticConfig();
 
   const enabled = Boolean(config.sentryDsn);
   const dashboardUrl =
-    config.sentryOrg && config.sentryProject
+    enabled && config.sentryOrg && config.sentryProject
       ? getSentryDashboardUrl(config.sentryOrg, config.sentryProject)
       : null;
 

--- a/apps/squareone/src/components/SentryConfigInfo/index.ts
+++ b/apps/squareone/src/components/SentryConfigInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SentryConfigInfo';

--- a/apps/squareone/src/components/SentryConfigInfo/sentryDashboardUrl.test.ts
+++ b/apps/squareone/src/components/SentryConfigInfo/sentryDashboardUrl.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSentryDashboardUrl } from './sentryDashboardUrl';
+
+describe('getSentryDashboardUrl', () => {
+  it('builds the project dashboard URL from the org and project slugs', () => {
+    expect(getSentryDashboardUrl('rubin-observatory', 'squareone')).toBe(
+      'https://rubin-observatory.sentry.io/projects/squareone/'
+    );
+  });
+
+  it('URL-encodes org and project slugs with reserved characters', () => {
+    expect(getSentryDashboardUrl('my org', 'my/project')).toBe(
+      'https://my%20org.sentry.io/projects/my%2Fproject/'
+    );
+  });
+});

--- a/apps/squareone/src/components/SentryConfigInfo/sentryDashboardUrl.ts
+++ b/apps/squareone/src/components/SentryConfigInfo/sentryDashboardUrl.ts
@@ -1,0 +1,15 @@
+/**
+ * Build the Sentry project dashboard URL from the configured organization and
+ * project slugs.
+ *
+ * Uses the modern Sentry SaaS org-subdomain form
+ * (`https://<org>.sentry.io/projects/<project>/`). Both slugs are URL-encoded
+ * so reserved characters can't break out of the path.
+ *
+ * @param org - Sentry organization slug (e.g. `rubin-observatory`).
+ * @param project - Sentry project slug (e.g. `squareone`).
+ * @returns The absolute URL of the project's Sentry dashboard.
+ */
+export function getSentryDashboardUrl(org: string, project: string): string {
+  return `https://${encodeURIComponent(org)}.sentry.io/projects/${encodeURIComponent(project)}/`;
+}

--- a/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.module.css
+++ b/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.module.css
@@ -1,0 +1,9 @@
+/**
+ * SentryTestButtons styles
+ */
+
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sqo-space-sm);
+}

--- a/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.stories.tsx
+++ b/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, userEvent, within } from 'storybook/test';
+import SentryTestButtons from './SentryTestButtons';
+
+const meta: Meta<typeof SentryTestButtons> = {
+  title: 'Components/SentryTestButtons',
+  component: SentryTestButtons,
+};
+
+export default meta;
+type Story = StoryObj<typeof SentryTestButtons>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Both test buttons render.
+    const throwButton = canvas.getByRole('button', {
+      name: /throw uncaught error/i,
+    });
+    const handledButton = canvas.getByRole('button', {
+      name: /capture handled exception/i,
+    });
+    await expect(throwButton).toBeInTheDocument();
+    await expect(handledButton).toBeInTheDocument();
+
+    // Capturing a handled exception does not break the page: the button is
+    // still present afterwards. (The "Throw uncaught error" button is left
+    // unclicked here because it intentionally throws during render.)
+    await userEvent.click(handledButton);
+    await expect(handledButton).toBeInTheDocument();
+  },
+};

--- a/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.test.tsx
+++ b/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the Sentry SDK so the handled-exception path can be asserted without a
+// real Sentry client being initialized.
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+// Import after mocking.
+import * as Sentry from '@sentry/nextjs';
+import SentryTestButtons from './SentryTestButtons';
+
+// Minimal error boundary so the render-time throw can be observed in a test
+// the way the App Router's app/error.tsx boundary observes it at runtime.
+class TestErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return <div role="alert">Caught: {this.state.error.message}</div>;
+    }
+    return this.props.children;
+  }
+}
+
+describe('SentryTestButtons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('"Capture handled exception" sends a handled event to Sentry without breaking the page', async () => {
+    render(<SentryTestButtons />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /capture handled exception/i })
+    );
+
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
+
+    // The page is not broken: the button is still rendered after the click.
+    expect(
+      screen.getByRole('button', { name: /capture handled exception/i })
+    ).toBeInTheDocument();
+  });
+
+  test('"Throw uncaught error" throws "Sentry Test Error" for the error boundary to catch', async () => {
+    // React logs the boundary-caught error to console.error; silence it so the
+    // expected throw doesn't produce noisy output.
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    render(
+      <TestErrorBoundary>
+        <SentryTestButtons />
+      </TestErrorBoundary>
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /throw uncaught error/i })
+    );
+
+    // The error boundary caught the thrown error rather than the click handler
+    // swallowing it.
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Caught: Sentry Test Error'
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.tsx
+++ b/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Button } from '@lsst-sqre/squared';
+import * as Sentry from '@sentry/nextjs';
+import React, { useState } from 'react';
+import styles from './SentryTestButtons.module.css';
+
+/**
+ * Buttons that exercise the Sentry error-reporting pipeline from the
+ * `/admin/sentry` page.
+ *
+ * - "Throw uncaught error" throws during render (via a state flag) so the App
+ *   Router error boundary (`app/error.tsx`) catches it and reports it to
+ *   Sentry. Errors thrown directly in an event handler bypass React error
+ *   boundaries, so the throw is deferred to the next render instead.
+ * - "Capture handled exception" reports a handled exception with
+ *   `Sentry.captureException` without interrupting the page.
+ */
+export default function SentryTestButtons() {
+  const [shouldThrow, setShouldThrow] = useState(false);
+
+  if (shouldThrow) {
+    throw new Error('Sentry Test Error');
+  }
+
+  return (
+    <div className={styles.buttons}>
+      <Button type="button" tone="danger" onClick={() => setShouldThrow(true)}>
+        Throw uncaught error
+      </Button>
+      <Button
+        type="button"
+        appearance="outline"
+        onClick={() =>
+          Sentry.captureException(new Error('Sentry Test Error (handled)'))
+        }
+      >
+        Capture handled exception
+      </Button>
+    </div>
+  );
+}

--- a/apps/squareone/src/components/SentryTestButtons/index.ts
+++ b/apps/squareone/src/components/SentryTestButtons/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SentryTestButtons';

--- a/apps/squareone/src/components/SidebarLayout/getFirstNavItemHref.test.ts
+++ b/apps/squareone/src/components/SidebarLayout/getFirstNavItemHref.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest';
+import { getFirstNavItemHref } from './getFirstNavItemHref';
+import type { NavSection } from './SidebarLayout';
+
+test('returns the href of the first item in the first section', () => {
+  const navSections: NavSection[] = [
+    {
+      items: [
+        { href: '/admin/sentry', label: 'Sentry' },
+        { href: '/admin/other', label: 'Other' },
+      ],
+    },
+  ];
+
+  expect(getFirstNavItemHref(navSections)).toBe('/admin/sentry');
+});
+
+test('returns the first item of the first section when several sections exist', () => {
+  const navSections: NavSection[] = [
+    {
+      label: 'First',
+      items: [{ href: '/admin/sentry', label: 'Sentry' }],
+    },
+    {
+      label: 'Second',
+      items: [{ href: '/admin/other', label: 'Other' }],
+    },
+  ];
+
+  expect(getFirstNavItemHref(navSections)).toBe('/admin/sentry');
+});
+
+test('reordering the nav items changes the resolved href', () => {
+  const navSections: NavSection[] = [
+    {
+      items: [
+        { href: '/admin/other', label: 'Other' },
+        { href: '/admin/sentry', label: 'Sentry' },
+      ],
+    },
+  ];
+
+  expect(getFirstNavItemHref(navSections)).toBe('/admin/other');
+});
+
+test('returns null for an empty nav (no sections)', () => {
+  expect(getFirstNavItemHref([])).toBeNull();
+});
+
+test('returns null when the first section has no items', () => {
+  const navSections: NavSection[] = [{ items: [] }];
+
+  expect(getFirstNavItemHref(navSections)).toBeNull();
+});

--- a/apps/squareone/src/components/SidebarLayout/getFirstNavItemHref.ts
+++ b/apps/squareone/src/components/SidebarLayout/getFirstNavItemHref.ts
@@ -1,0 +1,14 @@
+import type { NavSection } from './SidebarLayout';
+
+/**
+ * Resolves the href of the first navigation item across the given sidebar
+ * navigation sections.
+ *
+ * Reusable across sidebar sections that want an index route to redirect to
+ * their first nav item. Returns `null` as a safe fallback when the navigation
+ * is empty (no sections, or the first section has no items) so callers can
+ * choose to render a fallback instead of redirecting.
+ */
+export function getFirstNavItemHref(navSections: NavSection[]): string | null {
+  return navSections[0]?.items[0]?.href ?? null;
+}

--- a/apps/squareone/src/components/SidebarLayout/index.ts
+++ b/apps/squareone/src/components/SidebarLayout/index.ts
@@ -1,2 +1,3 @@
+export { getFirstNavItemHref } from './getFirstNavItemHref';
 export type { NavItem, NavSection, SidebarLayoutProps } from './SidebarLayout';
 export { default as SidebarLayout } from './SidebarLayout';

--- a/apps/squareone/src/lib/config/loader.ts
+++ b/apps/squareone/src/lib/config/loader.ts
@@ -58,6 +58,8 @@ export interface AppConfig {
   sentryReplaysSessionSampleRate?: number;
   sentryReplaysOnErrorSampleRate?: number;
   sentryDebug?: boolean;
+  sentryOrg?: string;
+  sentryProject?: string;
   headerLogoUrl?: string;
   headerLogoData?: string;
   headerLogoMimeType?: string;

--- a/apps/squareone/src/lib/config/sentryConfigKeys.test.ts
+++ b/apps/squareone/src/lib/config/sentryConfigKeys.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+// Resolve the app-root config files relative to this test (src/lib/config/).
+const appRoot = join(__dirname, '../../../');
+
+const schema = JSON.parse(
+  readFileSync(join(appRoot, 'squareone.config.schema.json'), 'utf8')
+);
+const devConfig = yaml.load(
+  readFileSync(join(appRoot, 'squareone.config.yaml'), 'utf8')
+) as Record<string, unknown>;
+
+describe('sentryOrg / sentryProject config keys', () => {
+  it('declares sentryOrg in the schema with the documented default', () => {
+    expect(schema.properties.sentryOrg).toMatchObject({
+      type: 'string',
+      default: 'rubin-observatory',
+    });
+  });
+
+  it('declares sentryProject in the schema with the documented default', () => {
+    expect(schema.properties.sentryProject).toMatchObject({
+      type: 'string',
+      default: 'squareone',
+    });
+  });
+
+  it('sets the keys in the development squareone.config.yaml', () => {
+    expect(devConfig.sentryOrg).toBe('rubin-observatory');
+    expect(devConfig.sentryProject).toBe('squareone');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a reusable `/admin` section mirroring the `/settings` sidebar-layout pattern: a server `layout.tsx` loads config and delegates to `AdminLayoutClient`, which wires a flat `getAdminNavigation()` into the shared `<SidebarLayout sidebarTitle="Admin">`.
- `/admin` redirects to its first sidebar nav item (currently `/admin/sentry`) via a new reusable `getFirstNavItemHref()` helper on the `SidebarLayout` module; reordering the nav changes the target with no other code change, and an empty nav renders a fallback instead of redirecting.
- Gate the admin section client-side on the `exec:admin` Gafaelfawr scope via a new `AdminRequired` wrapper applied at `AdminLayoutClient`: it composes `AuthRequired` (login + redirect) and renders an "unauthorized" state for logged-in users who lack the scope — defense-in-depth alongside the Phalanx ingress. The `exec:admin` scope string lives in a single exported `ADMIN_SCOPE` constant that the user-menu link reuses.
- Surface an `Admin` link (to `/admin`) in the header user menu only for users holding the `exec:admin` scope, reusing the existing Settings-link markup.
- Build the `/admin/sentry` page: `SentryTestButtons` (a render-time throw the app error boundary catches and reports, plus a handled `Sentry.captureException`) alongside a read-only Sentry config summary (enabled status, environment, traces/replay sample rates, base URL) and a dashboard link derived from new `sentryOrg`/`sentryProject` config keys (defaults `rubin-observatory` / `squareone`), shown only when Sentry is enabled (a DSN is present) and both slugs are set.

## Validation steps

- Navigate to `/admin` and confirm it redirects to `/admin/sentry`.
- Confirm `/admin` and `/admin/sentry` render inside the shared sidebar layout titled "Admin", flat (no category headings), with the active page highlighted.
- Reorder the `getAdminNavigation()` items and confirm the `/admin` redirect target follows the new first item with no other code change.
- As a logged-in user **without** the `exec:admin` scope, visit an `/admin` page and confirm an "unauthorized" state appears instead of the admin sidebar and content.
- As a user **with** the `exec:admin` scope, confirm the admin pages render normally.
- As a user **with** the `exec:admin` scope, open the header user menu and confirm an `Admin` link to `/admin` appears.
- As a user **without** the `exec:admin` scope, open the header user menu and confirm no `Admin` link appears.
- On `/admin/sentry`, click "Throw uncaught error" and confirm the app's error boundary renders ("Something went wrong") and the error appears in the Sentry project.
- On `/admin/sentry`, click "Capture handled exception" and confirm a handled event reaches Sentry while the page stays usable (no error boundary shown).
- On `/admin/sentry`, confirm the configuration section shows the Sentry enabled status, environment name, traces/replay sample rates, and base URL.
- On `/admin/sentry`, confirm an "Open Sentry dashboard" link points to the configured org/project (e.g. `https://rubin-observatory.sentry.io/projects/squareone/`), and that it disappears when Sentry is disabled (no DSN) or when either `sentryOrg` or `sentryProject` is unset — including when the org/project defaults remain populated.

## References

- Closes #422
- Closes #423
- Closes #424
- Closes #425
- Closes #426
- Closes #430
- Closes #431
- Closes #432
- PRD: #421
- Jira: https://rubinobs.atlassian.net/browse/DM-55135
