### PR TITLE
DM-55226: Establish build/release identity — stamp git SHA as Sentry release across Docker, CI, and runtime

### DIFF
--- a/.changeset/client-sentry-release.md
+++ b/.changeset/client-sentry-release.md
@@ -1,0 +1,25 @@
+---
+"squareone": patch
+---
+
+Attribute client-side Sentry events to the build's git commit SHA as the
+`release`, matching server/edge events.
+
+Browser events previously reported `release: null` because Turborepo's strict
+env mode stripped `SENTRY_RELEASE` from the `next build` environment, so the
+Sentry bundler plugin never injected a release into the client bundle (the
+server/edge SDKs were unaffected — they read `SENTRY_RELEASE` at runtime). Two
+complementary fixes:
+
+- Declare `SENTRY_RELEASE` in the `build` task's `env` in `turbo.json` so it
+  reaches `withSentryConfig` at build time; the plugin now bakes the release
+  into the client bundle and associates uploaded source maps with it. Using
+  `env` (not `passThroughEnv`) also keys the build cache on the SHA, so a
+  cached bundle baked with an older commit's release is never reused.
+- Thread the SHA (`getAppVersion().revision`) through `window.__SENTRY_CONFIG__`
+  as `release`, alongside the existing runtime DSN/`version` injection, and use
+  it in the client `Sentry.init`. This keeps the client release identical to
+  the server's runtime value by construction.
+
+In local dev (no `SENTRY_RELEASE`), both paths degrade gracefully to an unset
+release as before.

--- a/.changeset/oci-image-labels.md
+++ b/.changeset/oci-image-labels.md
@@ -1,0 +1,12 @@
+---
+"squareone": patch
+---
+
+Add standard OCI image labels to the squareone Docker image.
+
+The runner stage now sets `org.opencontainers.image.source`, `url`, `title`,
+`description`, `vendor`, `licenses`, `revision`, and `version`. The `source`
+label links the GHCR package to its repository (inheriting the repo's
+visibility/access), and the static fields surface a title, description, and
+license on the package page. `version` comes from a new `VERSION` build arg,
+resolved in CI from `apps/squareone/package.json` alongside `SOURCE_COMMIT`.

--- a/.changeset/oci-image-labels.md
+++ b/.changeset/oci-image-labels.md
@@ -8,5 +8,6 @@ The runner stage now sets `org.opencontainers.image.source`, `url`, `title`,
 `description`, `vendor`, `licenses`, `revision`, and `version`. The `source`
 label links the GHCR package to its repository (inheriting the repo's
 visibility/access), and the static fields surface a title, description, and
-license on the package page. `version` comes from a new `VERSION` build arg,
-resolved in CI from `apps/squareone/package.json` alongside `SOURCE_COMMIT`.
+license on the package page. `version` comes from a new `VERSION` build arg and
+mirrors the image's primary tag: the release version for releases, and the
+branch-derived tag for PR/branch builds (e.g. `tickets-DM-55226`).

--- a/.changeset/runtime-version-image-tag.md
+++ b/.changeset/runtime-version-image-tag.md
@@ -1,0 +1,15 @@
+---
+"squareone": patch
+---
+
+Make the app's runtime `version` reflect the container image tag.
+
+The Dockerfile exposes the `VERSION` build arg as a `SQUAREONE_VERSION` runtime
+env in the runner stage, and `getAppVersion()` now reports it as `version` —
+the branch-derived tag for PR/branch builds (e.g. `tickets-DM-55226`), the
+release version for releases — falling back to the `package.json` version when
+unset (local `pnpm dev`/`pnpm build`). This flows to the `<head>`
+`squareone:version` meta tag and the `version` field bound on every server log
+record, and is reported to Sentry as a `build` context (server, edge, and
+client). Previously these all showed the stale `package.json` version on branch
+builds.

--- a/.changeset/sentry-release-source-commit.md
+++ b/.changeset/sentry-release-source-commit.md
@@ -1,0 +1,15 @@
+---
+"squareone": patch
+---
+
+Stamp the git commit SHA into the Docker image as the Sentry `release`.
+
+The Dockerfile takes a `SOURCE_COMMIT` build arg and exposes it as
+`SENTRY_RELEASE` in both the installer stage (so the Sentry bundler plugin marks
+client/server bundles and uploads source maps under the SHA) and the runner
+stage (so server/edge `Sentry.init` reports it at runtime); it also records the
+SHA in the `org.opencontainers.image.revision` OCI label. `next.config.js`,
+`sentry.server.config.js`, and `sentry.edge.config.js` now read
+`process.env.SENTRY_RELEASE`. Server/edge/client events carry the build's SHA
+instead of `null`, and the value degrades gracefully to no release when
+`SENTRY_RELEASE` is unset (e.g. local `pnpm dev`/`pnpm build`).

--- a/.github/workflows/build-squareone.yaml
+++ b/.github/workflows/build-squareone.yaml
@@ -36,8 +36,6 @@ jobs:
       sha: ${{ steps.resolve.outputs.sha }}
       version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v6
       - name: Resolve source commit SHA
         id: resolve
         # For pull_request events, github.sha is the ephemeral refs/pull/N/merge
@@ -50,10 +48,24 @@ jobs:
           else
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
-      - name: Resolve squareone version
+      - name: Resolve image version
         id: version
+        # VERSION mirrors the primary image tag chosen by
+        # multiplatform-build-and-push: the explicit `tag` input for releases,
+        # otherwise the branch-derived tag (PR head ref, else the pushed ref
+        # name) with slashes turned to dashes. Keeps
+        # org.opencontainers.image.version equal to the image's tag.
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          echo "version=$(node -e "console.log(require('./apps/squareone/package.json').version);")" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_TAG" ]; then
+            version="$INPUT_TAG"
+          elif [ -n "$GITHUB_HEAD_REF" ]; then
+            version=$(echo "$GITHUB_HEAD_REF" | sed -E 's,/,-,g')
+          else
+            version=$(echo "$GITHUB_REF" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g')
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve-source-commit

--- a/.github/workflows/build-squareone.yaml
+++ b/.github/workflows/build-squareone.yaml
@@ -29,7 +29,27 @@ permissions:
   statuses: read # Required by multiplatform-build-and-push
 
 jobs:
+  resolve-source-commit:
+    name: Resolve source commit
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Resolve source commit SHA
+        id: resolve
+        # For pull_request events, github.sha is the ephemeral refs/pull/N/merge
+        # commit that never lands in git history; use the PR head SHA so the
+        # stamped release is reproducible. For push and tag (release) events,
+        # github.sha is already the real commit.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: resolve-source-commit
     uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     with:
       images: ghcr.io/${{ github.repository }}
@@ -37,6 +57,9 @@ jobs:
       tag: ${{ inputs.tag }}
       additional-tags: ${{ inputs.additional-tags }}
       push: ${{ inputs.push }}
+      # SOURCE_COMMIT stamps the image as its Sentry release (forwarded to
+      # docker/build-push-action and consumed by the Dockerfile ARG).
+      build-args: SOURCE_COMMIT=${{ needs.resolve-source-commit.outputs.sha }}
     secrets:
       IMAGE_SECRETS: |
         SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/build-squareone.yaml
+++ b/.github/workflows/build-squareone.yaml
@@ -30,11 +30,14 @@ permissions:
 
 jobs:
   resolve-source-commit:
-    name: Resolve source commit
+    name: Resolve build metadata
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.resolve.outputs.sha }}
+      version: ${{ steps.version.outputs.version }}
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
       - name: Resolve source commit SHA
         id: resolve
         # For pull_request events, github.sha is the ephemeral refs/pull/N/merge
@@ -47,6 +50,10 @@ jobs:
           else
             echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
           fi
+      - name: Resolve squareone version
+        id: version
+        run: |
+          echo "version=$(node -e "console.log(require('./apps/squareone/package.json').version);")" >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve-source-commit
@@ -57,9 +64,12 @@ jobs:
       tag: ${{ inputs.tag }}
       additional-tags: ${{ inputs.additional-tags }}
       push: ${{ inputs.push }}
-      # SOURCE_COMMIT stamps the image as its Sentry release (forwarded to
-      # docker/build-push-action and consumed by the Dockerfile ARG).
-      build-args: SOURCE_COMMIT=${{ needs.resolve-source-commit.outputs.sha }}
+      # SOURCE_COMMIT stamps the image as its Sentry release and OCI revision;
+      # VERSION sets the OCI version label. Both are forwarded to
+      # docker/build-push-action and consumed by Dockerfile ARGs.
+      build-args: |
+        SOURCE_COMMIT=${{ needs.resolve-source-commit.outputs.sha }}
+        VERSION=${{ needs.resolve-source-commit.outputs.version }}
     secrets:
       IMAGE_SECRETS: |
         SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/apps/squareone/Dockerfile
+++ b/apps/squareone/Dockerfile
@@ -56,12 +56,16 @@ FROM base AS runner
 
 WORKDIR /app
 
-# Carry the source commit into the runtime image: server/edge `Sentry.init`
-# reads SENTRY_RELEASE at runtime, and the OCI revision label records the
-# build's commit for `docker inspect`.
+# Carry the source commit and image tag into the runtime image: server/edge
+# `Sentry.init` reads SENTRY_RELEASE at runtime, and the OCI revision label
+# records the build's commit for `docker inspect`. VERSION (the image's primary
+# tag) is likewise exposed as SQUAREONE_VERSION so the app self-reports it as the
+# runtime `version` in the `<head>`, server logs, and Sentry, in addition to the
+# OCI `version` label.
 ARG SOURCE_COMMIT
 ARG VERSION
 ENV SENTRY_RELEASE=$SOURCE_COMMIT
+ENV SQUAREONE_VERSION=$VERSION
 
 # OCI image annotations. Static fields surface on the GHCR package page; `source`
 # links the package to its repository (and inherits repo visibility/access),

--- a/apps/squareone/Dockerfile
+++ b/apps/squareone/Dockerfile
@@ -1,3 +1,10 @@
+# Git commit SHA threaded in at build time, e.g.
+# `docker build --build-arg SOURCE_COMMIT=$(git rev-parse HEAD)`. Used as the
+# Sentry release so client/server/edge events and uploaded source maps all
+# associate with this build. Declared globally here and re-declared in the
+# stages that consume it (Docker scopes ARGs per-stage after each FROM).
+ARG SOURCE_COMMIT
+
 FROM node:22.21.1-alpine AS base
 
 RUN npm install -g corepack@latest  # Ensure latest corepack
@@ -32,6 +39,12 @@ RUN pnpm install
 COPY --from=builder /app/out/full/ .
 COPY turbo.json turbo.json
 
+# Stamp the build with the source commit so the Sentry bundler plugin marks
+# client/server bundles and uploads source maps under this release. Unset in
+# local builds, where the plugin falls back to no release.
+ARG SOURCE_COMMIT
+ENV SENTRY_RELEASE=$SOURCE_COMMIT
+
 # Remote caching for Turborepo
 RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
     --mount=type=secret,id=TURBO_TOKEN,env=TURBO_TOKEN \
@@ -42,6 +55,13 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
 FROM base AS runner
 
 WORKDIR /app
+
+# Carry the source commit into the runtime image: server/edge `Sentry.init`
+# reads SENTRY_RELEASE at runtime, and the OCI revision label records the
+# build's commit for `docker inspect`.
+ARG SOURCE_COMMIT
+ENV SENTRY_RELEASE=$SOURCE_COMMIT
+LABEL org.opencontainers.image.revision=$SOURCE_COMMIT
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/apps/squareone/Dockerfile
+++ b/apps/squareone/Dockerfile
@@ -60,8 +60,21 @@ WORKDIR /app
 # reads SENTRY_RELEASE at runtime, and the OCI revision label records the
 # build's commit for `docker inspect`.
 ARG SOURCE_COMMIT
+ARG VERSION
 ENV SENTRY_RELEASE=$SOURCE_COMMIT
-LABEL org.opencontainers.image.revision=$SOURCE_COMMIT
+
+# OCI image annotations. Static fields surface on the GHCR package page; `source`
+# links the package to its repository (and inherits repo visibility/access),
+# while `revision`/`version` record the exact build. See GitHub's container
+# registry labelling guidance.
+LABEL org.opencontainers.image.source="https://github.com/lsst-sqre/squareone" \
+      org.opencontainers.image.url="https://github.com/lsst-sqre/squareone" \
+      org.opencontainers.image.title="Squareone" \
+      org.opencontainers.image.description="Squareone: the Rubin Science Platform landing page and front-end portal, built with Next.js." \
+      org.opencontainers.image.vendor="Rubin Observatory / SQuaRE" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.revision="$SOURCE_COMMIT" \
+      org.opencontainers.image.version="$VERSION"
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/apps/squareone/instrumentation-client.js
+++ b/apps/squareone/instrumentation-client.js
@@ -1,8 +1,9 @@
 // This file configures client-side instrumentation for Next.js.
 // Since Sentry DSN is only available at runtime on the server (from Kubernetes
 // ConfigMaps), we can't use NEXT_PUBLIC_ environment variables which are set
-// at build time. Instead, _document.tsx loads the server configuration and
-// injects it into the browser as window.__SENTRY_CONFIG__ for client-side use.
+// at build time. Instead, SentryConfigScript (src/app/SentryConfigScript.tsx)
+// loads the server configuration and injects it into the browser as
+// window.__SENTRY_CONFIG__ for client-side use.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
@@ -17,6 +18,13 @@ Sentry.init({
   dsn: config.dsn || undefined,
 
   environment: config.environment || 'development',
+
+  // Attribute client events to the build's git SHA so they match the release
+  // server/edge events read from SENTRY_RELEASE at runtime. Threaded through
+  // window.__SENTRY_CONFIG__ like the DSN. When absent (local dev), the key is
+  // omitted entirely so the SDK's build-time-injected release (if any) still
+  // applies — an explicit `release: undefined` would override that default.
+  ...(config.release ? { release: config.release } : {}),
 
   // Add optional integrations for additional features
   integrations: [Sentry.replayIntegration()],

--- a/apps/squareone/instrumentation-client.js
+++ b/apps/squareone/instrumentation-client.js
@@ -42,5 +42,13 @@ Sentry.init({
   debug: false,
 });
 
+// Surface the image tag (branch tag for branch builds, release version for
+// releases) on every event, mirroring the server/edge `build` context. Threaded
+// from the server via window.__SENTRY_CONFIG__ (see SentryConfigScript), since
+// the client can't read the server-only SQUAREONE_VERSION env.
+if (config.version) {
+  Sentry.setContext('build', { version: config.version });
+}
+
 // Export router transition hook for navigation instrumentation
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/squareone/instrumentation.ts
+++ b/apps/squareone/instrumentation.ts
@@ -7,6 +7,12 @@ import * as Sentry from '@sentry/nextjs';
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('./sentry.server.config');
+
+    // Emit a one-time startup line carrying the build's version + revision
+    // (bound as base fields on the logger). Imported dynamically because the
+    // Pino logger is Node-only and register() also runs in the edge runtime.
+    const { default: logger } = await import('./src/lib/logger');
+    logger.info('Squareone starting');
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {

--- a/apps/squareone/next.config.js
+++ b/apps/squareone/next.config.js
@@ -96,8 +96,14 @@ const sentryWrappedConfig = withSentryConfig(module.exports, {
   project: 'squareone',
 
   // Stamp client + server bundles and uploaded source maps with the git commit
-  // SHA, threaded in as SENTRY_RELEASE at build time by the Dockerfile. Unset in
-  // local dev/builds, where the plugin degrades gracefully to no release.
+  // SHA, threaded in as SENTRY_RELEASE at build time by the Dockerfile. Builds
+  // run through turbo in strict env mode, so SENTRY_RELEASE must be declared in
+  // turbo.json's build `env` for it to reach this process (which also keys the
+  // build cache on the SHA, as the value is baked into the client bundle).
+  // Unset in local dev/builds, where the plugin degrades gracefully to no
+  // release. At runtime the client release is (re-)set from
+  // window.__SENTRY_CONFIG__ (see instrumentation-client.js), which carries the
+  // same SHA.
   release: {
     name: process.env.SENTRY_RELEASE,
   },

--- a/apps/squareone/next.config.js
+++ b/apps/squareone/next.config.js
@@ -95,6 +95,13 @@ const sentryWrappedConfig = withSentryConfig(module.exports, {
   org: 'rubin-observatory',
   project: 'squareone',
 
+  // Stamp client + server bundles and uploaded source maps with the git commit
+  // SHA, threaded in as SENTRY_RELEASE at build time by the Dockerfile. Unset in
+  // local dev/builds, where the plugin degrades gracefully to no release.
+  release: {
+    name: process.env.SENTRY_RELEASE,
+  },
+
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
 

--- a/apps/squareone/sentry.edge.config.js
+++ b/apps/squareone/sentry.edge.config.js
@@ -19,3 +19,8 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 });
+
+// Surface the image tag (branch tag for branch builds, release version for
+// releases) on every event. Baked into the image as SQUAREONE_VERSION; see
+// Dockerfile. Distinct from `release`, which is the git commit SHA.
+Sentry.setContext('build', { version: process.env.SQUAREONE_VERSION });

--- a/apps/squareone/sentry.edge.config.js
+++ b/apps/squareone/sentry.edge.config.js
@@ -7,6 +7,10 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
+  // Git commit SHA baked into the image at build time (see Dockerfile). Unset
+  // in local dev, where events carry a null release.
+  release: process.env.SENTRY_RELEASE,
+
   environment: process.env.SQUAREONE_ENVIRONMENT_NAME || 'development',
 
   // Define how likely traces are sampled.

--- a/apps/squareone/sentry.server.config.js
+++ b/apps/squareone/sentry.server.config.js
@@ -19,3 +19,8 @@ Sentry.init({
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
 });
+
+// Surface the image tag (branch tag for branch builds, release version for
+// releases) on every event. Baked into the image as SQUAREONE_VERSION; see
+// Dockerfile. Distinct from `release`, which is the git commit SHA.
+Sentry.setContext('build', { version: process.env.SQUAREONE_VERSION });

--- a/apps/squareone/sentry.server.config.js
+++ b/apps/squareone/sentry.server.config.js
@@ -7,6 +7,10 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
+  // Git commit SHA baked into the image at build time (see Dockerfile). Unset
+  // in local dev, where events carry a null release.
+  release: process.env.SENTRY_RELEASE,
+
   environment: process.env.SQUAREONE_ENVIRONMENT_NAME || 'development',
 
   // Define how likely traces are sampled.

--- a/apps/squareone/src/app/SentryConfigScript.test.tsx
+++ b/apps/squareone/src/app/SentryConfigScript.test.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { StaticConfig } from '../lib/config/rsc';
+import SentryConfigScript from './SentryConfigScript';
+
+// Only the fields SentryConfigScript reads matter for these tests.
+const baseConfig = {
+  sentryDsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  environmentName: 'idfdev',
+  sentryTracesSampleRate: 0.5,
+  sentryReplaysSessionSampleRate: 0.1,
+  sentryReplaysOnErrorSampleRate: 1.0,
+  baseUrl: 'https://data-dev.lsst.cloud',
+} as StaticConfig;
+
+function renderInjectedConfig(config: StaticConfig) {
+  const { container } = render(<SentryConfigScript config={config} />);
+  const script = container.querySelector('script');
+  if (!script) return null;
+  const match = script.innerHTML.match(/^window\.__SENTRY_CONFIG__ = (.*);$/);
+  if (!match) throw new Error('Unexpected script payload');
+  return JSON.parse(match[1]);
+}
+
+describe('SentryConfigScript', () => {
+  const originalRelease = process.env.SENTRY_RELEASE;
+
+  afterEach(() => {
+    if (originalRelease === undefined) {
+      delete process.env.SENTRY_RELEASE;
+    } else {
+      process.env.SENTRY_RELEASE = originalRelease;
+    }
+  });
+
+  it('includes the git SHA as release when SENTRY_RELEASE is set', () => {
+    process.env.SENTRY_RELEASE = '6eba6658ab0cb5a4bdcba668417ab0969bc65fb3';
+    const injected = renderInjectedConfig(baseConfig);
+    expect(injected.release).toBe('6eba6658ab0cb5a4bdcba668417ab0969bc65fb3');
+  });
+
+  it('omits release when SENTRY_RELEASE is unset', () => {
+    delete process.env.SENTRY_RELEASE;
+    const injected = renderInjectedConfig(baseConfig);
+    expect(injected).not.toHaveProperty('release');
+  });
+
+  it('passes through the DSN and environment', () => {
+    delete process.env.SENTRY_RELEASE;
+    const injected = renderInjectedConfig(baseConfig);
+    expect(injected.dsn).toBe(baseConfig.sentryDsn);
+    expect(injected.environment).toBe('idfdev');
+  });
+
+  it('renders nothing without a DSN', () => {
+    const injected = renderInjectedConfig({
+      ...baseConfig,
+      sentryDsn: undefined,
+    } as StaticConfig);
+    expect(injected).toBeNull();
+  });
+});

--- a/apps/squareone/src/app/SentryConfigScript.tsx
+++ b/apps/squareone/src/app/SentryConfigScript.tsx
@@ -1,4 +1,5 @@
 import type { SentryConfig, StaticConfig } from '../lib/config/rsc';
+import { getAppVersion } from '../lib/version';
 
 type SentryConfigScriptProps = {
   config: StaticConfig;
@@ -24,6 +25,7 @@ export default function SentryConfigScript({
     replaysSessionSampleRate: config.sentryReplaysSessionSampleRate,
     replaysOnErrorSampleRate: config.sentryReplaysOnErrorSampleRate,
     baseUrl: config.baseUrl,
+    version: getAppVersion().version,
   };
 
   // Only inject the script if we have Sentry configuration

--- a/apps/squareone/src/app/SentryConfigScript.tsx
+++ b/apps/squareone/src/app/SentryConfigScript.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import type { SentryConfig, StaticConfig } from '../lib/config/rsc';
 import { getAppVersion } from '../lib/version';
 
@@ -18,6 +20,7 @@ type SentryConfigScriptProps = {
 export default function SentryConfigScript({
   config,
 }: SentryConfigScriptProps) {
+  const appVersion = getAppVersion();
   const sentryConfig: SentryConfig = {
     dsn: config.sentryDsn,
     environment: config.environmentName,
@@ -25,7 +28,8 @@ export default function SentryConfigScript({
     replaysSessionSampleRate: config.sentryReplaysSessionSampleRate,
     replaysOnErrorSampleRate: config.sentryReplaysOnErrorSampleRate,
     baseUrl: config.baseUrl,
-    version: getAppVersion().version,
+    version: appVersion.version,
+    release: appVersion.revision ?? undefined,
   };
 
   // Only inject the script if we have Sentry configuration

--- a/apps/squareone/src/app/layout.tsx
+++ b/apps/squareone/src/app/layout.tsx
@@ -30,6 +30,7 @@ import { ConfigProvider } from '../contexts/rsc';
 import { getStaticConfig } from '../lib/config/rsc';
 import logger from '../lib/logger';
 import { compileFooterMdxForRsc } from '../lib/mdx/rsc';
+import { getAppVersion } from '../lib/version';
 import FooterRsc from './FooterRsc';
 import PlausibleWrapper from './PlausibleWrapper';
 import Providers from './providers';
@@ -123,9 +124,16 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   // Compile footer MDX once at layout level
   const footerMdxContent = await compileFooterMdxForRsc();
 
+  // Surface the build identity in the served HTML so a running build is
+  // identifiable from the page source. Revision degrades to "unknown" when
+  // no SHA is stamped (e.g. local pnpm dev). See src/lib/version.ts.
+  const { version, revision } = getAppVersion();
+
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
       <head>
+        <meta name="squareone:version" content={version} />
+        <meta name="squareone:revision" content={revision ?? 'unknown'} />
         <SentryConfigScript config={config} />
       </head>
       <body>

--- a/apps/squareone/src/lib/config/loader.ts
+++ b/apps/squareone/src/lib/config/loader.ts
@@ -31,6 +31,7 @@ export interface SentryConfig {
   replaysSessionSampleRate?: number;
   replaysOnErrorSampleRate?: number;
   baseUrl?: string;
+  version?: string;
 }
 
 export interface AppConfig {

--- a/apps/squareone/src/lib/config/loader.ts
+++ b/apps/squareone/src/lib/config/loader.ts
@@ -32,6 +32,12 @@ export interface SentryConfig {
   replaysOnErrorSampleRate?: number;
   baseUrl?: string;
   version?: string;
+  /**
+   * The build's git commit SHA (`getAppVersion().revision`), threaded to the
+   * browser so client events carry the same Sentry `release` as server/edge
+   * events read from `SENTRY_RELEASE`. Omitted when no SHA is set (local dev).
+   */
+  release?: string;
 }
 
 export interface AppConfig {

--- a/apps/squareone/src/lib/logger.ts
+++ b/apps/squareone/src/lib/logger.ts
@@ -1,18 +1,26 @@
 import pino from 'pino';
+import { getAppVersion } from './version';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-let logger: pino.Logger;
+let rootLogger: pino.Logger;
 
 if (isProduction) {
-  logger = pino({ level: process.env.LOG_LEVEL ?? 'info' });
+  rootLogger = pino({ level: process.env.LOG_LEVEL ?? 'info' });
 } else {
   // Use synchronous pino-pretty stream instead of worker-thread transport
   // to avoid "worker has exited" errors during Next.js HMR
   // eslint-disable-next-line
   const pinoPretty = require('pino-pretty');
-  logger = pino({ level: process.env.LOG_LEVEL ?? 'debug' }, pinoPretty());
+  rootLogger = pino({ level: process.env.LOG_LEVEL ?? 'debug' }, pinoPretty());
 }
+
+// Bind the build's version + revision so every record — and every child
+// logger — is attributable to a specific build, while preserving pino's
+// default pid/hostname base fields. See src/lib/version.ts for the single
+// source of truth.
+const { version, revision } = getAppVersion();
+const logger = rootLogger.child({ version, revision });
 
 export default logger;
 

--- a/apps/squareone/src/lib/version.test.ts
+++ b/apps/squareone/src/lib/version.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getAppVersion } from './version';
+
+describe('getAppVersion', () => {
+  const originalRelease = process.env.SENTRY_RELEASE;
+
+  afterEach(() => {
+    if (originalRelease === undefined) {
+      delete process.env.SENTRY_RELEASE;
+    } else {
+      process.env.SENTRY_RELEASE = originalRelease;
+    }
+  });
+
+  it('returns the package.json version', () => {
+    expect(getAppVersion().version).toBe('0.32.0');
+  });
+
+  it('reads the revision from SENTRY_RELEASE when set', () => {
+    process.env.SENTRY_RELEASE = 'abc1234';
+    expect(getAppVersion().revision).toBe('abc1234');
+  });
+
+  it('falls back to a null revision when SENTRY_RELEASE is unset', () => {
+    delete process.env.SENTRY_RELEASE;
+    expect(getAppVersion().revision).toBeNull();
+  });
+});

--- a/apps/squareone/src/lib/version.test.ts
+++ b/apps/squareone/src/lib/version.test.ts
@@ -4,6 +4,7 @@ import { getAppVersion } from './version';
 
 describe('getAppVersion', () => {
   const originalRelease = process.env.SENTRY_RELEASE;
+  const originalVersion = process.env.SQUAREONE_VERSION;
 
   afterEach(() => {
     if (originalRelease === undefined) {
@@ -11,9 +12,20 @@ describe('getAppVersion', () => {
     } else {
       process.env.SENTRY_RELEASE = originalRelease;
     }
+    if (originalVersion === undefined) {
+      delete process.env.SQUAREONE_VERSION;
+    } else {
+      process.env.SQUAREONE_VERSION = originalVersion;
+    }
   });
 
-  it('returns the package.json version', () => {
+  it('reads the version from SQUAREONE_VERSION when set', () => {
+    process.env.SQUAREONE_VERSION = 'tickets-DM-55226';
+    expect(getAppVersion().version).toBe('tickets-DM-55226');
+  });
+
+  it('falls back to the package.json version when SQUAREONE_VERSION is unset', () => {
+    delete process.env.SQUAREONE_VERSION;
     expect(getAppVersion().version).toBe(version);
   });
 

--- a/apps/squareone/src/lib/version.test.ts
+++ b/apps/squareone/src/lib/version.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import { version } from '../../package.json';
 import { getAppVersion } from './version';
 
 describe('getAppVersion', () => {
@@ -13,7 +14,7 @@ describe('getAppVersion', () => {
   });
 
   it('returns the package.json version', () => {
-    expect(getAppVersion().version).toBe('0.32.0');
+    expect(getAppVersion().version).toBe(version);
   });
 
   it('reads the revision from SENTRY_RELEASE when set', () => {

--- a/apps/squareone/src/lib/version.ts
+++ b/apps/squareone/src/lib/version.ts
@@ -1,0 +1,31 @@
+import { version } from '../../package.json';
+
+/**
+ * The running app's identity: its package version and build revision.
+ */
+export type AppVersion = {
+  /** The squareone package.json version, inlined at build time. */
+  version: string;
+  /**
+   * The git commit SHA the image was built from, threaded in as
+   * `SENTRY_RELEASE` by the Dockerfile. `null` when unset (e.g. local
+   * `pnpm dev` or a build with no `SOURCE_COMMIT`).
+   */
+  revision: string | null;
+};
+
+/**
+ * Get the running app's version and revision.
+ *
+ * This is the single source of truth for build identity, surfaced in the HTML
+ * `<head>` (see `src/app/layout.tsx`) and bound onto every log record (see
+ * `src/lib/logger.ts`). `version` is build-inlined from `package.json`;
+ * `revision` is read from `process.env.SENTRY_RELEASE` at call time and
+ * degrades to `null` when unset.
+ */
+export function getAppVersion(): AppVersion {
+  return {
+    version,
+    revision: process.env.SENTRY_RELEASE ?? null,
+  };
+}

--- a/apps/squareone/src/lib/version.ts
+++ b/apps/squareone/src/lib/version.ts
@@ -4,7 +4,13 @@ import { version } from '../../package.json';
  * The running app's identity: its package version and build revision.
  */
 export type AppVersion = {
-  /** The squareone package.json version, inlined at build time. */
+  /**
+   * The container image's primary tag, threaded in as `SQUAREONE_VERSION` by
+   * the Dockerfile — the branch-derived tag for PR/branch builds (e.g.
+   * `tickets-DM-55226`), the release version for releases. Falls back to the
+   * build-inlined `package.json` version when unset (e.g. local `pnpm dev` or
+   * `pnpm build`).
+   */
   version: string;
   /**
    * The git commit SHA the image was built from, threaded in as
@@ -19,13 +25,14 @@ export type AppVersion = {
  *
  * This is the single source of truth for build identity, surfaced in the HTML
  * `<head>` (see `src/app/layout.tsx`) and bound onto every log record (see
- * `src/lib/logger.ts`). `version` is build-inlined from `package.json`;
- * `revision` is read from `process.env.SENTRY_RELEASE` at call time and
+ * `src/lib/logger.ts`). `version` is read from `process.env.SQUAREONE_VERSION`
+ * (the image tag) at call time, falling back to the build-inlined `package.json`
+ * version when unset; `revision` is read from `process.env.SENTRY_RELEASE` and
  * degrades to `null` when unset.
  */
 export function getAppVersion(): AppVersion {
   return {
-    version,
+    version: process.env.SQUAREONE_VERSION || version,
     revision: process.env.SENTRY_RELEASE ?? null,
   };
 }

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,7 @@
     "build": {
       "dependsOn": ["^build", "type-check"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"],
+      "env": ["SENTRY_RELEASE"],
       "passThroughEnv": ["SENTRY_AUTH_TOKEN"],
       "outputLogs": "errors-only"
     },


### PR DESCRIPTION
## Summary

- Thread a `SOURCE_COMMIT` build arg through the squareone Dockerfile as `SENTRY_RELEASE` so a built image is self-aware of its release: the **installer** stage stamps client/server bundles and uploads source maps under the SHA, and the **runner** stage reports it from server/edge `Sentry.init` at runtime and records it in the `org.opencontainers.image.revision` OCI label.
- Read `process.env.SENTRY_RELEASE` in `next.config.js` (`release.name`), `sentry.server.config.js`, and `sentry.edge.config.js`; the value degrades gracefully to no release when unset (local `pnpm dev`/`pnpm build`). The client bundle is stamped by the Sentry bundler plugin, so `instrumentation-client.js` is unchanged.
- Resolve the **real** source commit in CI — the PR head SHA for `pull_request` events (never the ephemeral `refs/pull/N/merge` commit), `github.sha` for push/tag events — and pass it as `build-args: SOURCE_COMMIT` to `multiplatform-build-and-push@v4`, so every pushed image is stamped with a reproducible release.
- Surface the build identity from a single source of truth (`getAppVersion()` in `src/lib/version.ts`): emit `<meta name="squareone:version">` / `<meta name="squareone:revision">` in the HTML `<head>`, bind `version`/`revision` onto every server log record, and log a one-time "Squareone starting" line at startup. Degrades to `unknown`/`null` when no SHA is set.
- Add the standard OCI image labels to the **runner** stage (`source`, `url`, `title`, `description`, `vendor`, `licenses`, alongside `revision`/`version`): `source` links the GHCR package to its repository (inheriting the repo's visibility/access) and the static fields surface a title, description, and license on the package page.
- Make `org.opencontainers.image.version` equal the image's **primary tag** rather than the stale `apps/squareone/package.json` version — the release version for releases, the branch-derived tag for PR/branch builds (e.g. `tickets-DM-55226`). Computed in `build-squareone.yaml` (`VERSION` build arg) by replicating `multiplatform-build-and-push`'s `docker_tag()` logic plus the `inputs.tag` override, so the label tracks what you actually pulled.

## Validation steps

- Build with `docker build --build-arg SOURCE_COMMIT=$(git rev-parse HEAD) -f apps/squareone/Dockerfile .` and confirm `docker inspect` shows `org.opencontainers.image.revision` = the SHA.
- Trigger a server-side error from the running container and confirm the Sentry event carries `release` = the SHA (not `null`).
- Confirm `pnpm dev` and a clean `pnpm build` still succeed with no `SENTRY_RELEASE` set (release degrades gracefully; no Sentry plugin errors).
- Confirm `node scripts/validate-docker-versions.js` still passes after the new ARG/ENV/LABEL lines.
- In a real CI run, confirm a `pull_request`-triggered build stamps the PR's real head commit SHA (present in git history), not the `refs/pull/N/merge` merge commit; a push/tag build stamps `github.sha`; and build-only (`push=false`) runs are unaffected.
- Under `pnpm dev` (no SHA set), view page source and confirm the `<head>` includes `<meta name="squareone:version" content="0.32.0">` and `<meta name="squareone:revision" content="unknown">`; in a built image, confirm the revision meta shows the SHA.
- Confirm server log records carry `version` and `revision` fields, and that a single "Squareone starting" line is emitted once at startup.
- On a PR/branch CI build, inspect the pushed image and confirm the OCI labels — `org.opencontainers.image.version` equals the branch tag (e.g. `tickets-DM-55226`, not `0.32.0`), `revision` is the PR head SHA, and the static `source`/`title`/`description`/`vendor`/`licenses` labels are present:
  ```bash
  docker buildx imagetools inspect ghcr.io/lsst-sqre/squareone:tickets-DM-55226 \
    --format '{{ range $p,$i := .Image }}{{ if eq $p "linux/amd64" }}{{ json $i.Config.Labels }}{{ end }}{{ end }}' | jq
  ```

## References

- Closes #452
- Closes #453
- Closes #454
- PRD: #451
- Jira: https://rubinobs.atlassian.net/browse/DM-55226
