### PR TITLE
docs: fix incorrect Turborepo cache token scope

### DIFF
--- a/docs/dev/remote-cache.rst
+++ b/docs/dev/remote-cache.rst
@@ -64,7 +64,7 @@ To get a personal access token for the remote cache:
 1. Visit https://roundtable.lsst.cloud
 2. Log in with your credentials
 3. Navigate to the token management page
-4. Create a new token with the ``write:git-lfs`` scope
+4. Create a new token with the ``write:turborepo`` scope
 5. Store it securely in 1Password or your :file:`.env` file (never commit it to Git)
 
 The token is a Gafaelfawr user access token that authorizes access to the Turborepo cache server.

--- a/docs/dev/set-up.rst
+++ b/docs/dev/set-up.rst
@@ -58,7 +58,7 @@ You'll still use Turborepo's local caching, provides significant speedups for re
 The remote cache is optional and does not affect your ability to contribute.
 
 **Rubin Observatory staff:** If you want to use the remote cache, you'll need to authenticate.
-The ``TURBO_TOKEN`` is a Gafaelfawr user access token for roundtable.lsst.cloud with the ``write:git-lfs`` scope.
+The ``TURBO_TOKEN`` is a Gafaelfawr user access token for roundtable.lsst.cloud with the ``write:turborepo`` scope.
 
 .. note::
 


### PR DESCRIPTION
## Summary

- The remote Turborepo cache proxy enforces the `write:turborepo` Gafaelfawr scope, but the dev docs instructed minting a token with the `write:git-lfs` scope — a token minted that way would be rejected (401/403).
- Corrects the token-scope instructions in `docs/dev/remote-cache.rst` (Obtaining access tokens) and `docs/dev/set-up.rst` (`TURBO_TOKEN` description).
- Docs-only; no code or runtime impact.

## Validation steps

- Confirm `rg -n "write:git-lfs|write:turborepo" docs` reports only `write:turborepo` references and no remaining `write:git-lfs`.
- Optionally build the Sphinx docs (`pnpm docs`) and confirm no rST breakage in the two edited pages.