### PR TITLE
DM-55227: Classify hydration errors in client-side Sentry

### DIFF
--- a/.changeset/sentry-hydration-classifier.md
+++ b/.changeset/sentry-hydration-classifier.md
@@ -1,0 +1,7 @@
+---
+"squareone": patch
+---
+
+Classify React hydration errors in the client-side Sentry pipeline so browser-extension DOM noise stops drowning out genuine mismatches.
+
+A new pure `hydrationClassifier` module recognises React's recoverable hydration errors (codes 418/419/421/422/423/425 and the "Hydration failed" / "didn't match" message patterns) and, given a snapshot of the `<body>`/`<html>` attribute names, conservatively labels each event `extension`, `in-app`, or `unknown` — only calling it `extension` when a known extension marker (Grammarly, Dark Reader, password managers, etc.) is present alongside a hydration error. A `beforeSend` wrapper wired into `instrumentation-client.js` tags every event with `hydration.classification`, attaches the matched markers plus a body-attribute fingerprint as context, and regroups extension noise under a single mutable Sentry issue via a custom fingerprint. The event is always kept (never dropped), and the wrapper is defensive — it returns the event unchanged if `document` is unavailable or any internal error occurs.

--- a/apps/squareone/instrumentation-client.js
+++ b/apps/squareone/instrumentation-client.js
@@ -8,6 +8,8 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { beforeSend } from './src/lib/sentry/beforeSend';
+
 // Get configuration injected by SentryConfigScript from server-side AppConfig.
 // Use defensive check: window.__SENTRY_CONFIG__ may be undefined if Sentry
 // is not configured (no SENTRY_DSN environment variable).
@@ -48,6 +50,11 @@ Sentry.init({
   // Setting this option to true will print useful information to the console
   // while you're setting up Sentry.
   debug: false,
+
+  // Classify hydration recoverable-errors before they're sent: regroup
+  // browser-extension DOM noise into one mutable issue while keeping genuine
+  // in-app mismatches loud. Defensive — always returns the event.
+  beforeSend,
 });
 
 // Surface the image tag (branch tag for branch builds, release version for

--- a/apps/squareone/src/lib/sentry/beforeSend.test.ts
+++ b/apps/squareone/src/lib/sentry/beforeSend.test.ts
@@ -1,0 +1,102 @@
+import type { ErrorEvent } from '@sentry/nextjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { beforeSend } from './beforeSend';
+
+const hydrationEvent = (): ErrorEvent => ({
+  type: undefined,
+  exception: {
+    values: [
+      {
+        type: 'Error',
+        value:
+          "Hydration failed because the server rendered HTML didn't match the client.",
+      },
+    ],
+  },
+});
+
+const nonHydrationEvent = (): ErrorEvent => ({
+  type: undefined,
+  exception: {
+    values: [{ type: 'TypeError', value: 'x is not a function' }],
+  },
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  // Remove any extension-style attributes a test stamped onto the live DOM.
+  for (const el of [document.body, document.documentElement]) {
+    for (const name of el.getAttributeNames()) {
+      if (name.startsWith('data-') || name === 'cz-shortcut-listen') {
+        el.removeAttribute(name);
+      }
+    }
+  }
+});
+
+describe('beforeSend', () => {
+  it('tags and regroups extension hydration noise without dropping it', () => {
+    document.body.setAttribute('data-gr-ext-installed', 'true');
+    const event = hydrationEvent();
+
+    const result = beforeSend(event);
+
+    // The event is kept, not dropped.
+    expect(result).toBe(event);
+    expect(result?.tags?.['hydration.classification']).toBe('extension');
+    expect(result?.fingerprint).toEqual(['hydration-extension-noise']);
+
+    const context = result?.contexts?.hydration;
+    expect(context?.classification).toBe('extension');
+    expect(context?.markers).toContain('grammarly');
+    expect(typeof context?.bodyAttributeFingerprint).toBe('string');
+  });
+
+  it('tags a clean hydration error as in-app and leaves grouping unchanged', () => {
+    const event = hydrationEvent();
+
+    const result = beforeSend(event);
+
+    expect(result?.tags?.['hydration.classification']).toBe('in-app');
+    expect(result?.fingerprint).toBeUndefined();
+    expect(result?.contexts?.hydration?.classification).toBe('in-app');
+  });
+
+  it('tags non-hydration errors as unknown and leaves grouping unchanged', () => {
+    const event = nonHydrationEvent();
+
+    const result = beforeSend(event);
+
+    expect(result?.tags?.['hydration.classification']).toBe('unknown');
+    expect(result?.fingerprint).toBeUndefined();
+  });
+
+  it('returns the event unchanged when document is unavailable', () => {
+    vi.stubGlobal('document', undefined);
+    const event = hydrationEvent();
+
+    const result = beforeSend(event);
+
+    expect(result).toBe(event);
+    expect(result?.tags).toBeUndefined();
+  });
+
+  it('never throws and returns the event when internal logic errors', () => {
+    // A document whose body access throws exercises the defensive try/catch.
+    vi.stubGlobal('document', {
+      get body() {
+        throw new Error('boom');
+      },
+      get documentElement() {
+        throw new Error('boom');
+      },
+    });
+    const event = hydrationEvent();
+
+    let result: ErrorEvent | null = null;
+    expect(() => {
+      result = beforeSend(event);
+    }).not.toThrow();
+    expect(result).toBe(event);
+  });
+});

--- a/apps/squareone/src/lib/sentry/beforeSend.ts
+++ b/apps/squareone/src/lib/sentry/beforeSend.ts
@@ -1,0 +1,85 @@
+// Client-side Sentry `beforeSend` hook wired into `instrumentation-client.js`.
+//
+// It snapshots the `<body>` / `<html>` attribute names, hands that DOM-free
+// snapshot to the pure `classifyHydrationEvent` classifier, and folds the
+// result back into the outgoing event in a single pass:
+//
+//   - `extension` → tag `hydration.classification=extension`, set a custom
+//     fingerprint so all extension noise collapses into ONE separate, mutable
+//     Sentry issue, and attach the matched markers + body-attribute fingerprint
+//     as diagnostic context. The event is KEPT, never dropped — we regroup, not
+//     suppress, to preserve an audit trail.
+//   - `in-app` / `unknown` → set the classification tag and attach the same
+//     context, but leave grouping and severity untouched so a genuine
+//     regression stays loud.
+//
+// Defensive by construction: a `document`/`window` guard plus a top-level
+// try/catch guarantee the event is always returned unchanged on any internal
+// error, so no event is ever silently lost.
+
+import type { ErrorEvent } from '@sentry/nextjs';
+import { classifyHydrationEvent } from './hydrationClassifier';
+
+/**
+ * Custom fingerprint that collapses every extension-classified hydration event
+ * into a single, separately mutable Sentry issue.
+ */
+export const EXTENSION_NOISE_FINGERPRINT = ['hydration-extension-noise'];
+
+/** Read an element's attribute names defensively (never throws on its own). */
+const snapshotAttributeNames = (el: Element | null | undefined): string[] => {
+  if (!el || typeof el.getAttributeNames !== 'function') {
+    return [];
+  }
+  return el.getAttributeNames();
+};
+
+/** Compact, stable representation of a DOM element's attribute-name set. */
+const fingerprintAttributes = (attrNames: string[]): string =>
+  [...attrNames].sort().join(',');
+
+/**
+ * Sentry `beforeSend` callback: classify hydration events, tag + enrich them,
+ * and regroup extension noise — always returning the (possibly mutated) event.
+ */
+export const beforeSend = (event: ErrorEvent): ErrorEvent => {
+  try {
+    if (typeof document === 'undefined' || typeof window === 'undefined') {
+      return event;
+    }
+
+    const bodyAttrs = snapshotAttributeNames(document.body);
+    const htmlAttrs = snapshotAttributeNames(document.documentElement);
+    const { classification, markers } = classifyHydrationEvent({
+      event,
+      bodyAttrs,
+      htmlAttrs,
+    });
+
+    event.tags = {
+      ...event.tags,
+      'hydration.classification': classification,
+    };
+    event.contexts = {
+      ...event.contexts,
+      hydration: {
+        classification,
+        markers,
+        bodyAttributeFingerprint: fingerprintAttributes(bodyAttrs),
+        bodyAttrs,
+        htmlAttrs,
+      },
+    };
+
+    if (classification === 'extension') {
+      event.fingerprint = [...EXTENSION_NOISE_FINGERPRINT];
+    }
+
+    return event;
+  } catch {
+    // Never let classification cost us an event — return it untouched.
+    return event;
+  }
+};
+
+export default beforeSend;

--- a/apps/squareone/src/lib/sentry/hydrationClassifier.test.ts
+++ b/apps/squareone/src/lib/sentry/hydrationClassifier.test.ts
@@ -1,0 +1,115 @@
+import type { Event } from '@sentry/nextjs';
+import { describe, expect, it } from 'vitest';
+import {
+  classifyHydrationEvent,
+  isHydrationError,
+  KNOWN_EXTENSION_MARKERS,
+} from './hydrationClassifier';
+
+// A Grammarly body attribute is the canonical extension marker used across
+// these tests.
+const GRAMMARLY_ATTR = 'data-gr-ext-installed';
+
+const hydrationEventFromMessage = (value: string): Event => ({
+  exception: { values: [{ type: 'Error', value }] },
+});
+
+describe('isHydrationError', () => {
+  it('detects the React "Hydration failed" message', () => {
+    const event = hydrationEventFromMessage(
+      "Hydration failed because the server rendered HTML didn't match the client."
+    );
+    expect(isHydrationError(event)).toBe(true);
+  });
+
+  it('detects minified React hydration error codes (418-425)', () => {
+    for (const code of [418, 419, 421, 422, 423, 425]) {
+      const event = hydrationEventFromMessage(
+        `Minified React error #${code}; visit https://react.dev/errors/${code} for the full message.`
+      );
+      expect(isHydrationError(event)).toBe(true);
+    }
+  });
+
+  it('reads the top-level event message as well as exception values', () => {
+    const event: Event = {
+      message: 'Text content does not match server-rendered HTML.',
+    };
+    expect(isHydrationError(event)).toBe(true);
+  });
+
+  it('does not flag unrelated errors', () => {
+    const event = hydrationEventFromMessage('TypeError: x is not a function');
+    expect(isHydrationError(event)).toBe(false);
+  });
+
+  it('does not flag an unrelated React error code', () => {
+    const event = hydrationEventFromMessage(
+      'Minified React error #310; visit https://react.dev/errors/310'
+    );
+    expect(isHydrationError(event)).toBe(false);
+  });
+
+  it('is defensive against an empty event', () => {
+    expect(isHydrationError({})).toBe(false);
+  });
+});
+
+describe('KNOWN_EXTENSION_MARKERS', () => {
+  it('includes Grammarly and Dark Reader signatures', () => {
+    const ids = KNOWN_EXTENSION_MARKERS.map((marker) => marker.id);
+    expect(ids).toContain('grammarly');
+    expect(ids).toContain('darkreader');
+  });
+});
+
+describe('classifyHydrationEvent', () => {
+  it('classifies a hydration error with a known marker as extension', () => {
+    const result = classifyHydrationEvent({
+      event: hydrationEventFromMessage('Hydration failed'),
+      bodyAttrs: [GRAMMARLY_ATTR],
+      htmlAttrs: [],
+    });
+    expect(result.classification).toBe('extension');
+    expect(result.markers).toContain('grammarly');
+  });
+
+  it('matches markers on the documentElement snapshot too', () => {
+    const result = classifyHydrationEvent({
+      event: hydrationEventFromMessage('Hydration failed'),
+      bodyAttrs: [],
+      htmlAttrs: ['data-darkreader-mode'],
+    });
+    expect(result.classification).toBe('extension');
+    expect(result.markers).toContain('darkreader');
+  });
+
+  it('classifies a hydration error with a clean DOM as in-app', () => {
+    const result = classifyHydrationEvent({
+      event: hydrationEventFromMessage('Hydration failed'),
+      bodyAttrs: ['class'],
+      htmlAttrs: ['lang', 'data-theme'],
+    });
+    expect(result.classification).toBe('in-app');
+    expect(result.markers).toEqual([]);
+  });
+
+  it('classifies a non-hydration error as unknown even with markers present', () => {
+    const result = classifyHydrationEvent({
+      event: hydrationEventFromMessage('TypeError: boom'),
+      bodyAttrs: [GRAMMARLY_ATTR],
+      htmlAttrs: [],
+    });
+    expect(result.classification).toBe('unknown');
+  });
+
+  it('is defensive when the DOM snapshot is missing or empty', () => {
+    const result = classifyHydrationEvent({
+      event: hydrationEventFromMessage('Hydration failed'),
+      bodyAttrs: undefined,
+      htmlAttrs: undefined,
+    });
+    expect(result.classification).toBe('in-app');
+    expect(result.markers).toEqual([]);
+  });
+});

--- a/apps/squareone/src/lib/sentry/hydrationClassifier.test.ts
+++ b/apps/squareone/src/lib/sentry/hydrationClassifier.test.ts
@@ -50,6 +50,20 @@ describe('isHydrationError', () => {
     expect(isHydrationError(event)).toBe(false);
   });
 
+  it('does not flag a generic "didn\'t match" error without a hydration stem', () => {
+    const event = hydrationEventFromMessage(
+      "Received value didn't match the expected snapshot"
+    );
+    expect(isHydrationError(event)).toBe(false);
+  });
+
+  it('flags a "didn\'t match" message when a hydration stem co-occurs', () => {
+    const event = hydrationEventFromMessage(
+      "While hydrating, the server rendered HTML didn't match the client."
+    );
+    expect(isHydrationError(event)).toBe(true);
+  });
+
   it('is defensive against an empty event', () => {
     expect(isHydrationError({})).toBe(false);
   });
@@ -97,6 +111,17 @@ describe('classifyHydrationEvent', () => {
   it('classifies a non-hydration error as unknown even with markers present', () => {
     const result = classifyHydrationEvent({
       event: hydrationEventFromMessage('TypeError: boom'),
+      bodyAttrs: [GRAMMARLY_ATTR],
+      htmlAttrs: [],
+    });
+    expect(result.classification).toBe('unknown');
+  });
+
+  it('does not bury a generic "didn\'t match" app error under extension noise', () => {
+    const result = classifyHydrationEvent({
+      event: hydrationEventFromMessage(
+        "Received value didn't match the expected snapshot"
+      ),
       bodyAttrs: [GRAMMARLY_ATTR],
       htmlAttrs: [],
     });

--- a/apps/squareone/src/lib/sentry/hydrationClassifier.ts
+++ b/apps/squareone/src/lib/sentry/hydrationClassifier.ts
@@ -1,0 +1,192 @@
+// Pure, DOM-free classifier that separates browser-extension hydration noise
+// from genuine in-app React hydration mismatches.
+//
+// This is a "deep module": a small, dependency-light surface (three exports)
+// hiding the heuristics for recognising React's recoverable hydration errors
+// and the DOM signatures left behind by common browser extensions. It performs
+// NO DOM access of its own — callers pass an attribute-name snapshot — so it is
+// trivially unit-testable and safe to run in any environment.
+//
+// Conservatism is the guiding principle: an event is only ever labelled
+// `extension` when it is BOTH a recognised hydration error AND a known
+// extension marker is present in the snapshot. A genuine in-app mismatch on a
+// clean DOM is never hidden.
+
+import type { Event } from '@sentry/nextjs';
+
+/**
+ * The classification buckets a hydration-relevant event can fall into.
+ *
+ * - `extension`: a hydration error with a known browser-extension DOM marker
+ *   present — almost certainly noise outside our control.
+ * - `in-app`: a hydration error with a clean DOM snapshot — treated as a
+ *   genuine mismatch and kept at full severity.
+ * - `unknown`: not a recognised hydration error (the classifier does not
+ *   apply).
+ */
+export type HydrationClassification = 'extension' | 'in-app' | 'unknown';
+
+/** A browser-extension DOM signature, matched by attribute-name prefix. */
+export type ExtensionMarker = {
+  /** Stable identifier reported in `markers` and event context. */
+  id: string;
+  /**
+   * Lower-cased attribute-name prefixes that signal this extension. Prefixes
+   * (rather than exact names) absorb the per-instance suffixes extensions add
+   * (e.g. Grammarly's `data-gr-ext-installed`, `data-gr-c-s-loaded`).
+   */
+  attrPrefixes: string[];
+};
+
+export type ClassifyHydrationEventInput = {
+  /** The Sentry event under consideration. */
+  event: Event | undefined | null;
+  /** Attribute names snapshotted from `document.body`. */
+  bodyAttrs?: string[];
+  /** Attribute names snapshotted from `document.documentElement`. */
+  htmlAttrs?: string[];
+};
+
+export type HydrationClassificationResult = {
+  classification: HydrationClassification;
+  /** IDs of the extension markers matched in the supplied snapshot. */
+  markers: string[];
+};
+
+/**
+ * In-code list of browser-extension DOM signatures. Kept as a const (not
+ * runtime-configurable, per the PRD) and matched case-insensitively by
+ * attribute-name prefix.
+ */
+export const KNOWN_EXTENSION_MARKERS: ExtensionMarker[] = [
+  // Grammarly injects data-gr-* and data-new-gr-c-s-* onto <body>.
+  { id: 'grammarly', attrPrefixes: ['data-gr-', 'data-new-gr-c-s-'] },
+  // Dark Reader rewrites styles and stamps the root/body with data-darkreader-*.
+  { id: 'darkreader', attrPrefixes: ['data-darkreader-'] },
+  // LastPass password manager.
+  { id: 'lastpass', attrPrefixes: ['data-lastpass-', 'data-lp-'] },
+  // 1Password.
+  { id: '1password', attrPrefixes: ['data-1p-', 'data-1password-'] },
+  // Dashlane.
+  { id: 'dashlane', attrPrefixes: ['data-dashlane', 'data-kwimpalastatus'] },
+  // Bitwarden.
+  { id: 'bitwarden', attrPrefixes: ['data-bitwarden-', 'data-bw-'] },
+  // LanguageTool grammar checker.
+  { id: 'languagetool', attrPrefixes: ['data-lt-installed', 'data-lt-'] },
+  // ColorZilla / other a11y or contrast extensions stamp the body too; cover
+  // the common "cz-shortcut-listen" sentinel.
+  { id: 'colorzilla', attrPrefixes: ['cz-shortcut-listen'] },
+];
+
+// Minified React error codes corresponding to hydration / recoverable
+// hydration failures.
+const HYDRATION_ERROR_CODES = [418, 419, 421, 422, 423, 425];
+
+// Lower-cased substrings that identify a hydration mismatch from the
+// human-readable error text (dev builds and some recoverable-error messages).
+const HYDRATION_MESSAGE_PATTERNS = [
+  'hydration failed',
+  "didn't match",
+  'did not match',
+  'error while hydrating',
+  'text content does not match',
+  'hydrating but react',
+];
+
+/**
+ * Gather the searchable text from a Sentry event (top-level message plus every
+ * exception type/value), lower-cased and joined, for substring matching.
+ */
+const collectEventText = (event: Event | undefined | null): string => {
+  if (!event) {
+    return '';
+  }
+  const parts: string[] = [];
+  if (typeof event.message === 'string') {
+    parts.push(event.message);
+  }
+  const values = event.exception?.values;
+  if (Array.isArray(values)) {
+    for (const value of values) {
+      if (value?.type) {
+        parts.push(value.type);
+      }
+      if (value?.value) {
+        parts.push(value.value);
+      }
+    }
+  }
+  return parts.join('\n').toLowerCase();
+};
+
+/**
+ * Detect a React hydration recoverable error from a Sentry event. Matches both
+ * minified error codes (418/419/421/422/423/425, via the bundled error URL)
+ * and the human-readable hydration-mismatch message patterns.
+ */
+export const isHydrationError = (event: Event | undefined | null): boolean => {
+  const text = collectEventText(event);
+  if (!text) {
+    return false;
+  }
+  for (const code of HYDRATION_ERROR_CODES) {
+    if (
+      text.includes(`react error #${code}`) ||
+      text.includes(`/errors/${code}`) ||
+      text.includes(`invariant=${code}`)
+    ) {
+      return true;
+    }
+  }
+  return HYDRATION_MESSAGE_PATTERNS.some((pattern) => text.includes(pattern));
+};
+
+/**
+ * Match the supplied attribute names against KNOWN_EXTENSION_MARKERS, returning
+ * the deduplicated IDs of every marker present. Defensive against non-string
+ * entries and undefined input.
+ */
+const matchMarkers = (attrNames: string[]): string[] => {
+  const matched = new Set<string>();
+  for (const raw of attrNames) {
+    if (typeof raw !== 'string') {
+      continue;
+    }
+    const name = raw.toLowerCase();
+    for (const marker of KNOWN_EXTENSION_MARKERS) {
+      if (marker.attrPrefixes.some((prefix) => name.startsWith(prefix))) {
+        matched.add(marker.id);
+      }
+    }
+  }
+  return Array.from(matched);
+};
+
+/**
+ * Conservatively classify a (possibly hydration-related) Sentry event given a
+ * snapshot of the `<body>` and `<html>` attribute names.
+ *
+ * - Not a hydration error → `unknown` (the classifier does not apply, even if
+ *   extension markers happen to be present).
+ * - Hydration error + known extension marker → `extension`.
+ * - Hydration error + clean DOM → `in-app` (kept loud).
+ */
+export const classifyHydrationEvent = ({
+  event,
+  bodyAttrs,
+  htmlAttrs,
+}: ClassifyHydrationEventInput): HydrationClassificationResult => {
+  const attrNames = [
+    ...(Array.isArray(bodyAttrs) ? bodyAttrs : []),
+    ...(Array.isArray(htmlAttrs) ? htmlAttrs : []),
+  ];
+  const markers = matchMarkers(attrNames);
+
+  if (!isHydrationError(event)) {
+    return { classification: 'unknown', markers };
+  }
+  if (markers.length > 0) {
+    return { classification: 'extension', markers };
+  }
+  return { classification: 'in-app', markers };
+};

--- a/apps/squareone/src/lib/sentry/hydrationClassifier.ts
+++ b/apps/squareone/src/lib/sentry/hydrationClassifier.ts
@@ -82,16 +82,22 @@ export const KNOWN_EXTENSION_MARKERS: ExtensionMarker[] = [
 // hydration failures.
 const HYDRATION_ERROR_CODES = [418, 419, 421, 422, 423, 425];
 
-// Lower-cased substrings that identify a hydration mismatch from the
-// human-readable error text (dev builds and some recoverable-error messages).
+// Unambiguous hydration phrasings from the human-readable error text (dev
+// builds and some recoverable-error messages). These appear only in hydration
+// errors, so they always classify as hydration.
 const HYDRATION_MESSAGE_PATTERNS = [
   'hydration failed',
-  "didn't match",
-  'did not match',
   'error while hydrating',
   'text content does not match',
   'hydrating but react',
 ];
+
+// Generic mismatch phrasings that also appear in unrelated errors (assertions,
+// routing, regex, checksums). Only treat these as hydration when a hydration
+// stem co-occurs in the event text, so a real app error is never buried under
+// extension noise just because its message happens to say "didn't match".
+const GENERIC_MISMATCH_PATTERNS = ["didn't match", 'did not match'];
+const HYDRATION_STEM = 'hydrat';
 
 /**
  * Gather the searchable text from a Sentry event (top-level message plus every
@@ -138,7 +144,15 @@ export const isHydrationError = (event: Event | undefined | null): boolean => {
       return true;
     }
   }
-  return HYDRATION_MESSAGE_PATTERNS.some((pattern) => text.includes(pattern));
+  if (HYDRATION_MESSAGE_PATTERNS.some((pattern) => text.includes(pattern))) {
+    return true;
+  }
+  // Generic mismatch phrasings only count as hydration when a hydration stem
+  // co-occurs, so unrelated "didn't match" errors are not mis-classified.
+  return (
+    text.includes(HYDRATION_STEM) &&
+    GENERIC_MISMATCH_PATTERNS.some((pattern) => text.includes(pattern))
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add a conservative client-side Sentry `beforeSend` classifier that separates browser-extension hydration noise from genuine in-app React hydration mismatches, then tags and regroups the noise so it stops paging while real mismatches stay loud.
- New pure `src/lib/sentry/hydrationClassifier.ts` recognises React's recoverable hydration errors (codes 418/419/421/422/423/425 and the "Hydration failed" / "didn't match" patterns) and, given a `<body>`/`<html>` attribute snapshot, labels each event `extension` (known marker + hydration error), `in-app` (clean DOM + hydration error), or `unknown`.
- New `src/lib/sentry/beforeSend.ts` (wired into `instrumentation-client.js`) tags every event with `hydration.classification`, attaches the matched markers plus a body-attribute fingerprint as context, and gives extension noise a custom fingerprint so it collapses into one mutable Sentry issue. The event is always kept, never dropped, and the wrapper is defensive (document/window guard + try/catch).

## Validation steps

- With a DOM-mutating browser extension installed (e.g. Grammarly or Dark Reader), exercise the running app and confirm a captured hydration event in Sentry carries `hydration.classification=extension`, the `hydration-extension-noise` fingerprint, and the matched markers in its context.
- Confirm extension-classified hydration events collapse into a single, separately mutable Sentry issue, while a clean in-app hydration mismatch still reports at full severity with classification context attached.
- Confirm normal (non-hydration) errors continue to report unchanged.

## References

- Closes #456
- PRD: #455
- Jira: https://rubinobs.atlassian.net/browse/DM-55227