### PR TITLE
DM-55225: Refresh repertoire-client to Repertoire 2.0.0

### DIFF
--- a/.changeset/repertoire-client-2-0-0-refresh.md
+++ b/.changeset/repertoire-client-2-0-0-refresh.md
@@ -1,0 +1,9 @@
+---
+'@lsst-sqre/repertoire-client': minor
+---
+
+Refresh the vendored Repertoire client to match live Repertoire 2.0.0
+
+- Re-vendored `openapi.json` at 2.0.0: dropped the now-excluded `ivoa_standard_id` from `ApiVersion`, added `environment_name` to `Discovery`, and added the `local` flag to the InfluxDB database models.
+- Reconciled the Zod schemas: `DiscoverySchema` now accepts the optional `environment_name`, `InfluxDatabaseSchema` gained `local` (defaults to `false` when omitted, matching the server's `exclude_defaults` serialization), and `ApiVersionSchema` dropped `ivoa_standard_id` (removed from `ApiVersion` in 2.0.0; unknown keys are stripped by default, so legacy payloads still parse).
+- Rewrote `mockDiscovery` to mirror the live `dp1`/`dp02`/`dp03` datasets with real service and semantic version keys (`sia-query-2.0`, `soda-sync-1.0`, `soda-async-1.0`, `hips-list-1.0`, `tables`, `gms-search-1.0`) plus the `datalink`/`gms` services. The mock now matches live fidelity: `dp03` is catalog-only (no `cutout`), cutout version URLs are not dataset-scoped (`/api/cutout/sync`, `/api/cutout/jobs`), and `datalink` carries its `openapi` URL and `datalink-links-1.1` version. Internal services (`gafaelfawr`, `times-square`) keep their `v1` version key so `getGafaelfawrUrl()`/`getTimesSquareUrl()` and the Header nav / settings helpers still resolve.

--- a/packages/repertoire-client/openapi.json
+++ b/packages/repertoire-client/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Repertoire",
     "description": "Service discovery for the Rubin Science Platform",
-    "version": "0.6.1"
+    "version": "2.0.0"
   },
   "paths": {
     "/repertoire/": {
@@ -102,6 +102,30 @@
           }
         }
       }
+    },
+    "/api/registry": {
+      "get": {
+        "summary": "IVOA Publishing Registry",
+        "description": "Handle an OAI-PMH request.\n\nAccepts any OAI-PMH verb as a query parameter (GET) or form field\n(POST) and returns the corresponding XML response.  All responses\n(including errors) use HTTP 200 as specified in OAI-PMH.",
+        "operationId": "get_oai_api_registry_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      },
+      "post": {
+        "summary": "IVOA Publishing Registry",
+        "description": "Handle an OAI-PMH request.\n\nAccepts any OAI-PMH verb as a query parameter (GET) or form field\n(POST) and returns the corresponding XML response.  All responses\n(including errors) use HTTP 200 as specified in OAI-PMH.",
+        "operationId": "get_oai_api_registry_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": { "application/json": { "schema": {} } }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -116,12 +140,6 @@
             "title": "Service URL",
             "description": "Access URL for that version of the service",
             "examples": ["https://example.org/api/cutout/sync"]
-          },
-          "ivoa_standard_id": {
-            "anyOf": [{ "type": "string" }, { "type": "null" }],
-            "title": "IVOA standardID",
-            "description": "IVOA standardID used in service registrations",
-            "examples": ["ivo://ivoa.net/std/SODA#async-1.0"]
           }
         },
         "type": "object",
@@ -248,6 +266,11 @@
             "description": "All datasets available in the local environment",
             "default": {}
           },
+          "environment_name": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Name of environment",
+            "description": "Human-readable name of the environment, intended for use in status or error reporting. This may be a hostname if that is the most descriptive name, but should not be assumed to be a hostname or used to construct any URLs."
+          },
           "influxdb_databases": {
             "additionalProperties": {
               "$ref": "#/components/schemas/InfluxDatabaseWithPointer"
@@ -316,6 +339,12 @@
             "description": "URL of corresponding Confluent schema registry",
             "examples": ["https://example.org/schema-registry"]
           },
+          "local": {
+            "type": "boolean",
+            "title": "Is database local",
+            "description": "Whether the database is local to this environment",
+            "default": false
+          },
           "username": {
             "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Client username",
@@ -368,6 +397,12 @@
             "title": "Schema registry URL",
             "description": "URL of corresponding Confluent schema registry",
             "examples": ["https://example.org/schema-registry"]
+          },
+          "local": {
+            "type": "boolean",
+            "title": "Is database local",
+            "description": "Whether the database is local to this environment",
+            "default": false
           },
           "credentials_url": {
             "type": "string",
@@ -525,7 +560,9 @@
             "title": "Location"
           },
           "msg": { "type": "string", "title": "Message" },
-          "type": { "type": "string", "title": "Error Type" }
+          "type": { "type": "string", "title": "Error Type" },
+          "input": { "title": "Input" },
+          "ctx": { "type": "object", "title": "Context" }
         },
         "type": "object",
         "required": ["loc", "msg", "type"],

--- a/packages/repertoire-client/src/hooks/useServiceDiscovery.test.tsx
+++ b/packages/repertoire-client/src/hooks/useServiceDiscovery.test.tsx
@@ -301,8 +301,10 @@ describe('useServiceDiscovery', () => {
       });
 
       const { query } = result.current;
-      expect(query?.hasDataset('dp0.2')).toBe(true);
-      expect(query?.getDataset('dp0.2')?.description).toBe('Data Preview 0.2');
+      expect(query?.hasDataset('dp02')).toBe(true);
+      expect(query?.getDataset('dp02')?.description).toContain(
+        'Data Preview 0.2'
+      );
     });
   });
 

--- a/packages/repertoire-client/src/mock-discovery.test.ts
+++ b/packages/repertoire-client/src/mock-discovery.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { mockDiscovery } from './mock-discovery';
+import { createDiscoveryQuery } from './query';
+import { DiscoverySchema } from './schemas';
+
+/**
+ * These tests pin the refreshed mock to the live Repertoire 2.0.0 discovery
+ * shape (datasets dp1/dp02/dp03 with real service + semantic version keys), so
+ * downstream slices test against realistic data.
+ */
+describe('mockDiscovery (Repertoire 2.0.0 shape)', () => {
+  it('parses cleanly against DiscoverySchema', () => {
+    const result = DiscoverySchema.safeParse(mockDiscovery);
+    expect(result.success).toBe(true);
+  });
+
+  it('models the live dp1/dp02/dp03 datasets', () => {
+    expect(Object.keys(mockDiscovery.datasets).sort()).toEqual([
+      'dp02',
+      'dp03',
+      'dp1',
+    ]);
+  });
+
+  it('uses semantic version keys for dataset services', () => {
+    const dp1 = mockDiscovery.datasets.dp1;
+
+    // SIA surfaces the sia-query-2.0 /query URL.
+    expect(dp1.services.sia.versions['sia-query-2.0'].url).toMatch(/\/query$/);
+    // HiPS surfaces the hips-list-1.0 /list URL.
+    expect(dp1.services.hips.versions['hips-list-1.0'].url).toMatch(/\/list$/);
+    // SODA Cutout exposes sync + async versions.
+    expect(dp1.services.cutout.versions['soda-sync-1.0'].url).toMatch(
+      /\/sync$/
+    );
+    expect(dp1.services.cutout.versions['soda-async-1.0'].url).toMatch(
+      /\/jobs$/
+    );
+    // TAP carries a VOSI tables version key.
+    expect(dp1.services.tap.versions.tables).toBeDefined();
+    // GMS carries the gms-search-1.0 version key.
+    expect(dp1.services.gms.versions['gms-search-1.0']).toBeDefined();
+  });
+
+  it('includes the datalink and gms services', () => {
+    expect(mockDiscovery.datasets.dp1.services.datalink).toBeDefined();
+    expect(
+      mockDiscovery.datasets.dp1.services.datalink.versions[
+        'datalink-links-1.1'
+      ]
+    ).toBeDefined();
+    expect(mockDiscovery.datasets.dp1.services.gms).toBeDefined();
+  });
+
+  it('routes dp03 TAP through the SSO TAP endpoint', () => {
+    expect(mockDiscovery.datasets.dp03.services.tap.url).toMatch(/\/ssotap$/);
+    // dp03 is catalog-only: no image services.
+    expect(mockDiscovery.datasets.dp03.services.sia).toBeUndefined();
+    expect(mockDiscovery.datasets.dp03.services.hips).toBeUndefined();
+    expect(mockDiscovery.datasets.dp03.services.cutout).toBeUndefined();
+  });
+
+  it('keeps internal gafaelfawr/times-square on v1 so helpers resolve', () => {
+    const query = createDiscoveryQuery(mockDiscovery);
+    expect(query.getGafaelfawrUrl()).toMatch(/\/v1$/);
+    expect(query.getTimesSquareUrl()).toMatch(/\/v1$/);
+    // UI + internal helpers used by Header nav / banners still resolve.
+    expect(query.getPortalUrl()).toBeDefined();
+    expect(query.getNubladoUrl()).toBeDefined();
+    expect(query.getSemaphoreUrl()).toBeDefined();
+  });
+});

--- a/packages/repertoire-client/src/mock-discovery.ts
+++ b/packages/repertoire-client/src/mock-discovery.ts
@@ -2,37 +2,196 @@ import type { ServiceDiscovery } from './schemas';
 
 /**
  * Hand-written mock data for deterministic tests and Storybook.
- * This mock represents a typical RSP deployment configuration.
+ *
+ * This mirrors the live Repertoire 2.0.0 `/discovery` response for the
+ * production RSP (`data.lsst.cloud`): the `dp1`/`dp02`/`dp03` datasets, each
+ * exposing its full set of user-facing data services keyed by real semantic
+ * version keys (`sia-query-2.0`, `soda-sync-1.0`, `soda-async-1.0`,
+ * `hips-list-1.0`, `tables`, `gms-search-1.0`). `ivoa_standard_id` was removed
+ * from `ApiVersion` in 2.0.0 — the IVOA standard is encoded in the version key.
+ *
+ * Internal services (`gafaelfawr`, `times-square`) deliberately keep their
+ * `v1` version key so the navigation/settings helpers
+ * (`getGafaelfawrUrl()` / `getTimesSquareUrl()`) continue to resolve.
  */
 export const mockDiscovery: ServiceDiscovery = {
-  applications: ['portal', 'nublado', 'times-square', 'vo-cutouts', 'tap'],
+  applications: [
+    'datalinker',
+    'gafaelfawr',
+    'hips',
+    'nublado',
+    'portal',
+    'semaphore',
+    'sia',
+    'squareone',
+    'ssotap',
+    'tap',
+    'times-square',
+    'vo-cutouts',
+  ],
+  environment_name: 'data.lsst.cloud',
   datasets: {
-    'dp0.2': {
-      description: 'Data Preview 0.2',
-      docs_url: 'https://dp0-2.lsst.io',
-      butler_config: null,
-      services: {
-        tap: {
-          url: 'https://data.lsst.cloud/api/tap',
-          openapi: null,
-          versions: {},
-        },
-        sia: {
-          url: 'https://data.lsst.cloud/api/sia',
-          openapi: null,
-          versions: {},
-        },
-      },
-    },
     dp1: {
-      description: 'Data Preview 1',
+      description:
+        'Data Preview 1 contains image and catalog products from the Rubin' +
+        ' Science Pipelines v29 processing of observations obtained with the' +
+        ' LSST Commissioning Camera of seven ~1 square degree fields, over' +
+        ' seven weeks in late 2024.',
       docs_url: 'https://dp1.lsst.io',
       butler_config: 'https://data.lsst.cloud/api/butler/repo/dp1/butler.yaml',
       services: {
+        cutout: {
+          url: 'https://data.lsst.cloud/api/cutout',
+          openapi: 'https://data.lsst.cloud/api/cutout/openapi.json',
+          versions: {
+            'soda-sync-1.0': {
+              url: 'https://data.lsst.cloud/api/cutout/sync',
+            },
+            'soda-async-1.0': {
+              url: 'https://data.lsst.cloud/api/cutout/jobs',
+            },
+          },
+        },
+        datalink: {
+          url: 'https://data.lsst.cloud/api/datalink',
+          openapi: 'https://data.lsst.cloud/api/datalink/openapi.json',
+          versions: {
+            'datalink-links-1.1': {
+              url: 'https://data.lsst.cloud/api/datalink/links',
+            },
+          },
+        },
+        gms: {
+          url: 'https://data.lsst.cloud/auth/gms',
+          openapi: null,
+          versions: {
+            'gms-search-1.0': {
+              url: 'https://data.lsst.cloud/auth/gms',
+            },
+          },
+        },
+        hips: {
+          url: 'https://data.lsst.cloud/api/hips/v2/dp1/list',
+          openapi: null,
+          versions: {
+            'hips-list-1.0': {
+              url: 'https://data.lsst.cloud/api/hips/v2/dp1/list',
+            },
+          },
+        },
+        sia: {
+          url: 'https://data.lsst.cloud/api/sia/dp1',
+          openapi: 'https://data.lsst.cloud/api/sia/openapi.json',
+          versions: {
+            'sia-query-2.0': {
+              url: 'https://data.lsst.cloud/api/sia/dp1/query',
+            },
+          },
+        },
         tap: {
           url: 'https://data.lsst.cloud/api/tap',
           openapi: null,
-          versions: {},
+          versions: {
+            tables: {
+              url: 'https://data.lsst.cloud/api/tap/tables',
+            },
+          },
+        },
+      },
+    },
+    dp02: {
+      description:
+        'Data Preview 0.2 contains the image and catalog products of the' +
+        ' Rubin Science Pipelines v23 processing of the DESC Data Challenge 2' +
+        ' simulation, which covered 300 square degrees of the wide-fast-deep' +
+        ' LSST survey region over 5 years.',
+      docs_url: 'https://dp0-2.lsst.io',
+      butler_config: 'https://data.lsst.cloud/api/butler/repo/dp02/butler.yaml',
+      services: {
+        cutout: {
+          url: 'https://data.lsst.cloud/api/cutout',
+          openapi: 'https://data.lsst.cloud/api/cutout/openapi.json',
+          versions: {
+            'soda-sync-1.0': {
+              url: 'https://data.lsst.cloud/api/cutout/sync',
+            },
+            'soda-async-1.0': {
+              url: 'https://data.lsst.cloud/api/cutout/jobs',
+            },
+          },
+        },
+        datalink: {
+          url: 'https://data.lsst.cloud/api/datalink',
+          openapi: 'https://data.lsst.cloud/api/datalink/openapi.json',
+          versions: {
+            'datalink-links-1.1': {
+              url: 'https://data.lsst.cloud/api/datalink/links',
+            },
+          },
+        },
+        gms: {
+          url: 'https://data.lsst.cloud/auth/gms',
+          openapi: null,
+          versions: {
+            'gms-search-1.0': {
+              url: 'https://data.lsst.cloud/auth/gms',
+            },
+          },
+        },
+        hips: {
+          url: 'https://data.lsst.cloud/api/hips/v2/dp02/list',
+          openapi: null,
+          versions: {
+            'hips-list-1.0': {
+              url: 'https://data.lsst.cloud/api/hips/v2/dp02/list',
+            },
+          },
+        },
+        sia: {
+          url: 'https://data.lsst.cloud/api/sia/dp02',
+          openapi: 'https://data.lsst.cloud/api/sia/openapi.json',
+          versions: {
+            'sia-query-2.0': {
+              url: 'https://data.lsst.cloud/api/sia/dp02/query',
+            },
+          },
+        },
+        tap: {
+          url: 'https://data.lsst.cloud/api/tap',
+          openapi: null,
+          versions: {
+            tables: {
+              url: 'https://data.lsst.cloud/api/tap/tables',
+            },
+          },
+        },
+      },
+    },
+    dp03: {
+      description:
+        'Data Preview 0.3 contains the catalog products of a Solar System' +
+        ' Science Collaboration simulation of the results of SSO analysis of' +
+        ' the wide-fast-deep data from the LSST dataset.',
+      docs_url: 'https://dp0-3.lsst.io',
+      butler_config: null,
+      services: {
+        gms: {
+          url: 'https://data.lsst.cloud/auth/gms',
+          openapi: null,
+          versions: {
+            'gms-search-1.0': {
+              url: 'https://data.lsst.cloud/auth/gms',
+            },
+          },
+        },
+        tap: {
+          url: 'https://data.lsst.cloud/api/ssotap',
+          openapi: null,
+          versions: {
+            tables: {
+              url: 'https://data.lsst.cloud/api/ssotap/tables',
+            },
+          },
         },
       },
     },
@@ -50,7 +209,7 @@ export const mockDiscovery: ServiceDiscovery = {
       },
       semaphore: {
         url: 'https://data.lsst.cloud/semaphore',
-        openapi: null,
+        openapi: 'https://data.lsst.cloud/semaphore/openapi.json',
         versions: {},
       },
       'times-square': {
@@ -64,7 +223,7 @@ export const mockDiscovery: ServiceDiscovery = {
       },
     },
     ui: {
-      // UI services only have url field per OpenAPI spec
+      // UI services only have a url field per the OpenAPI spec.
       portal: {
         url: 'https://data.lsst.cloud/portal/app',
       },

--- a/packages/repertoire-client/src/query.test.ts
+++ b/packages/repertoire-client/src/query.test.ts
@@ -132,16 +132,17 @@ describe('ServiceDiscoveryQuery', () => {
       const query = createDiscoveryQuery(mockDiscovery);
       const datasets = query.getDatasets();
 
-      expect(Object.keys(datasets)).toContain('dp0.2');
       expect(Object.keys(datasets)).toContain('dp1');
+      expect(Object.keys(datasets)).toContain('dp02');
+      expect(Object.keys(datasets)).toContain('dp03');
     });
 
     it('getDataset returns specific dataset', () => {
       const query = createDiscoveryQuery(mockDiscovery);
-      const dp02 = query.getDataset('dp0.2');
+      const dp02 = query.getDataset('dp02');
 
       expect(dp02).toBeDefined();
-      expect(dp02?.description).toBe('Data Preview 0.2');
+      expect(dp02?.description).toContain('Data Preview 0.2');
       expect(dp02?.docs_url).toBe('https://dp0-2.lsst.io');
     });
 
@@ -154,8 +155,9 @@ describe('ServiceDiscoveryQuery', () => {
     it('hasDataset returns true for existing datasets', () => {
       const query = createDiscoveryQuery(mockDiscovery);
 
-      expect(query.hasDataset('dp0.2')).toBe(true);
       expect(query.hasDataset('dp1')).toBe(true);
+      expect(query.hasDataset('dp02')).toBe(true);
+      expect(query.hasDataset('dp03')).toBe(true);
     });
 
     it('hasDataset returns false for non-existent datasets', () => {
@@ -168,22 +170,28 @@ describe('ServiceDiscoveryQuery', () => {
       const query = createDiscoveryQuery(mockDiscovery);
       const tapDatasets = query.getDatasetsWithService('tap');
 
-      expect(tapDatasets).toHaveLength(2);
-      expect(tapDatasets.map((d) => d.id)).toContain('dp0.2');
+      // Every dataset (dp1, dp02, dp03) serves TAP.
+      expect(tapDatasets).toHaveLength(3);
       expect(tapDatasets.map((d) => d.id)).toContain('dp1');
+      expect(tapDatasets.map((d) => d.id)).toContain('dp02');
+      expect(tapDatasets.map((d) => d.id)).toContain('dp03');
 
-      const dp02 = tapDatasets.find((d) => d.id === 'dp0.2');
-      expect(dp02?.serviceUrl).toBe('https://data.lsst.cloud/api/tap');
+      const dp1 = tapDatasets.find((d) => d.id === 'dp1');
+      expect(dp1?.serviceUrl).toBe('https://data.lsst.cloud/api/tap');
+      // dp03 routes through the SSO TAP endpoint.
+      const dp03 = tapDatasets.find((d) => d.id === 'dp03');
+      expect(dp03?.serviceUrl).toBe('https://data.lsst.cloud/api/ssotap');
     });
 
     it('getDatasetsWithService finds datasets with SIA service', () => {
       const query = createDiscoveryQuery(mockDiscovery);
       const siaDatasets = query.getDatasetsWithService('sia');
 
-      // Only dp0.2 has SIA service in mock data
-      expect(siaDatasets).toHaveLength(1);
-      expect(siaDatasets[0].id).toBe('dp0.2');
-      expect(siaDatasets[0].serviceUrl).toBe('https://data.lsst.cloud/api/sia');
+      // Only the image datasets (dp1, dp02) serve SIA.
+      expect(siaDatasets).toHaveLength(2);
+      expect(siaDatasets.map((d) => d.id).sort()).toEqual(['dp02', 'dp1']);
+      const dp1 = siaDatasets.find((d) => d.id === 'dp1');
+      expect(dp1?.serviceUrl).toBe('https://data.lsst.cloud/api/sia/dp1');
     });
 
     it('getDatasetsWithService returns empty array for non-existent service', () => {
@@ -229,6 +237,7 @@ describe('ServiceDiscoveryQuery', () => {
             database: 'efd',
             schema_registry: 'https://schema.lsst.cloud',
             credentials_url: 'https://creds.lsst.cloud/influx/efd',
+            local: false,
           },
         },
       };

--- a/packages/repertoire-client/src/schemas.test.ts
+++ b/packages/repertoire-client/src/schemas.test.ts
@@ -84,6 +84,46 @@ describe('DiscoverySchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts the 2.0.0 environment_name field', () => {
+    const result = DiscoverySchema.safeParse({
+      environment_name: 'data.lsst.cloud',
+      services: { internal: {}, ui: {} },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.environment_name).toBe('data.lsst.cloud');
+    }
+  });
+
+  it('accepts the 2.0.0 InfluxDB local flag and defaults it to false', () => {
+    const result = DiscoverySchema.safeParse({
+      services: { internal: {}, ui: {} },
+      influxdb_databases: {
+        local_metrics: {
+          url: 'https://data.lsst.cloud/influxdb/',
+          database: 'lsst.square.metrics',
+          schema_registry: 'http://schema-registry:8081/',
+          credentials_url:
+            'https://data.lsst.cloud/repertoire/discovery/influxdb/local_metrics',
+          local: true,
+        },
+        remote_efd: {
+          url: 'https://data.lsst.cloud/influxdb/',
+          database: 'efd',
+          schema_registry: 'http://schema-registry:8081/',
+          credentials_url:
+            'https://data.lsst.cloud/repertoire/discovery/influxdb/remote_efd',
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.influxdb_databases.local_metrics.local).toBe(true);
+      // Omitted (exclude_defaults) -> defaults to false
+      expect(result.data.influxdb_databases.remote_efd.local).toBe(false);
+    }
+  });
+
   it('validates randomly generated discovery data', () => {
     // Test with multiple seeds for broader coverage
     const seeds = [1, 42, 123, 999];

--- a/packages/repertoire-client/src/schemas.ts
+++ b/packages/repertoire-client/src/schemas.ts
@@ -6,7 +6,6 @@ const uriSchema = z.string().url().min(1).max(2083);
 // API Version (used in service versions)
 export const ApiVersionSchema = z.object({
   url: uriSchema,
-  ivoa_standard_id: z.string().nullable().optional(),
 });
 
 // Data Service (services within datasets)
@@ -50,12 +49,19 @@ export const InfluxDatabaseSchema = z.object({
   database: z.string(),
   schema_registry: uriSchema,
   credentials_url: uriSchema,
+  // Added in Repertoire 2.0.0; whether the database is local to the queried
+  // Phalanx environment. Serialized with exclude_defaults, so it is omitted
+  // when false.
+  local: z.boolean().default(false),
 });
 
 // Root Discovery response
 export const DiscoverySchema = z.object({
   applications: z.array(z.string()).default([]),
   datasets: z.record(DatasetSchema).default({}),
+  // Added in Repertoire 2.0.0; human-readable name of the environment, intended
+  // for status/error reporting only (not a hostname, not used to build URLs).
+  environment_name: z.string().nullable().optional(),
   influxdb_databases: z.record(InfluxDatabaseSchema).default({}),
   services: ServicesSchema,
 });


### PR DESCRIPTION
## Summary

- Re-vendor the Repertoire OpenAPI at **2.0.0** from canonical source (`data.lsst.cloud/repertoire/openapi.json` via the `fetch-openapi` script) and reconcile the Zod schemas: `Discovery` gains the optional `environment_name`, InfluxDB databases gain the `local` flag (defaults to `false`), and the now-excluded `ivoa_standard_id` is dropped from both the vendored `ApiVersion` **and** the hand-written Zod `ApiVersionSchema` (unknown keys are stripped by default, so legacy payloads still parse).
- Rewrite `mockDiscovery` to mirror the live `dp1`/`dp02`/`dp03` datasets with real service and semantic version keys (`sia-query-2.0`, `soda-sync-1.0`, `soda-async-1.0`, `hips-list-1.0`, `tables`, `gms-search-1.0`), so downstream `/api-aspect` slices test against realistic data.
- Match live fidelity, verified against live `data.lsst.cloud` (the spec was originally reverse-engineered in a firewalled sandbox): `dp03` is catalog-only (**no `cutout`** — it's a Solar System catalog simulation), cutout version URLs are not dataset-scoped (`/api/cutout/sync`, `/api/cutout/jobs`), and `datalink` carries its `openapi` URL and `datalink-links-1.1` version.
- Keep internal `gafaelfawr`/`times-square` on `v1` and preserve `portal`/`nublado`/`semaphore` URLs so the Header nav, broadcast banners, settings helpers, and the dev discovery route resolve against the new shape unchanged.

These changes also address the non-blocking stoker review on the prior revision (drop `ivoa_standard_id`, remove the invented dp03 `cutout`) plus the mock-faithfulness gaps surfaced when the live endpoints became reachable.

## Validation steps

- `pnpm test --filter @lsst-sqre/repertoire-client` — mock parses cleanly against `DiscoverySchema`; schema/query tests pass.
- `pnpm type-check --filter @lsst-sqre/repertoire-client` — the `ApiVersion` type still infers after dropping the field.
- `pnpm biome:format:check` + `pnpm lint --filter @lsst-sqre/repertoire-client` — clean.
- Re-vendored `openapi.json` diff vs. the reverse-engineered copy is limited to the `/api/registry` path and `ctx`/`input` on `ValidationError`; every client-relevant schema (`Discovery`, `ApiVersion`, `DataService`, `InfluxDatabaseWithPointer`, …) matches live exactly.
- Run `pnpm dev --filter squareone`, load the home page, and confirm the **Portal** and **Notebooks** nav links (and the broadcast banner) still resolve their service URLs from the refreshed mock via the dev discovery route.

## References

- Closes #463
- PRD: #461
- Jira: https://rubinobs.atlassian.net/browse/DM-55225
