### PR TITLE
DM-55225: Open sandbox firewall holes for RSP OpenAPI spec hosts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.stoker/settings.toml
+++ b/.stoker/settings.toml
@@ -24,11 +24,28 @@ TURBO_TOKEN = "$secret:turbo_token"
 #     the Storybook browser tests); without them `pnpm exec playwright install
 #     chromium` is blocked. See scripts/install-playwright.js for the on-demand
 #     install.
+#   - data.lsst.cloud is the production RSP; it hosts the vendored RSP OpenAPI
+#     specs synced by the repertoire (`/repertoire/openapi.json`), gafaelfawr
+#     (`/auth/openapi.json`), and semaphore (`/semaphore/openapi.json`) clients
+#     (see each package's `fetch-openapi` script). Reached during interactive
+#     spec re-syncs, not boot.
+#   - data-dev.lsst.cloud is the dev RSP equivalent of data.lsst.cloud, for
+#     syncing the same specs against the development deployment.
+#   - roundtable-dev.lsst.cloud is the dev roundtable deployment (the prod
+#     roundtable.lsst.cloud above is already allowlisted as the Turborepo cache
+#     host, so it is not duplicated here).
+#   - times-square.lsst.io hosts the times-square-client OpenAPI spec
+#     (`/_static/openapi.json`), which is served there rather than on
+#     data.lsst.cloud.
 [sandbox.firewall_extra_domains]
 domains = [
   "roundtable.lsst.cloud",
   "cdn.playwright.dev",
   "playwright.download.prss.microsoft.com",
+  "data.lsst.cloud",
+  "data-dev.lsst.cloud",
+  "roundtable-dev.lsst.cloud",
+  "times-square.lsst.io",
 ]
 
 [secrets_required.turbo_token]

--- a/.stoker/settings.toml
+++ b/.stoker/settings.toml
@@ -37,6 +37,12 @@ TURBO_TOKEN = "$secret:turbo_token"
 #   - times-square.lsst.io hosts the times-square-client OpenAPI spec
 #     (`/_static/openapi.json`), which is served there rather than on
 #     data.lsst.cloud.
+#   - gafaelfawr.lsst.io and phalanx.lsst.io host the Gafaelfawr (RSP auth
+#     service) and Phalanx (RSP Argo CD deployment platform) documentation on
+#     the lsst.io docs host (LSST the Docs, behind Fastly), read during
+#     interactive reference work. Like times-square.lsst.io these are exact
+#     hostnames: the firewall has no wildcard support, so each lsst.io doc
+#     site must be listed individually.
 [sandbox.firewall_extra_domains]
 domains = [
   "roundtable.lsst.cloud",
@@ -46,6 +52,8 @@ domains = [
   "data-dev.lsst.cloud",
   "roundtable-dev.lsst.cloud",
   "times-square.lsst.io",
+  "gafaelfawr.lsst.io",
+  "phalanx.lsst.io",
 ]
 
 [secrets_required.turbo_token]


### PR DESCRIPTION
## Summary

- Allowlist the science-platform hosts that serve the vendored RSP OpenAPI specs (repertoire, gafaelfawr, semaphore, times-square) so the AFK sandbox's egress firewall stops rejecting spec fetch/sync from inside the loop.
- Add prod + dev RSP hosts (`data.lsst.cloud`, `data-dev.lsst.cloud`), the dev roundtable (`roundtable-dev.lsst.cloud`), and `times-square.lsst.io` to `[sandbox.firewall_extra_domains].domains`, each with an explanatory comment per the existing convention. Prod `roundtable.lsst.cloud` stays single (already allowlisted as the Turborepo cache host).

## Validation steps

- From a freshly booted sandbox (firewall extras only propagate after postCreate / on a fresh boot), run `pnpm --filter @lsst-sqre/repertoire-client fetch-openapi` and confirm it reaches `data.lsst.cloud` instead of being firewall-rejected.

## References

- Closes #466
- PRD: #461
- Jira: https://rubinobs.atlassian.net/browse/DM-55225