### PR TITLE
DM-55225: Drive /api-aspect from Repertoire discovery

### DIFF
--- a/.changeset/api-aspect-discovery-skeleton.md
+++ b/.changeset/api-aspect-discovery-skeleton.md
@@ -1,0 +1,17 @@
+---
+"squareone": patch
+---
+
+Drive the `/api-aspect` endpoint listing from Repertoire service discovery.
+
+The page now resolves discovery server-side and renders one section per dataset
+(`dp1`/`dp02`/`dp03`), each listing every service by name with its base URL, so
+the endpoints are present in the server-rendered HTML with no client-side
+discovery fetch. The listing is embedded via an `<ApiEndpoints/>` MDX component
+so per-environment prose keeps control of the surrounding content.
+
+Degrades gracefully, mirroring the server-side discovery pattern in the App
+Router layout: the listing is omitted when `repertoireUrl` is unset, and a brief
+"temporarily unavailable" notice (plus a server-side log) is shown when the
+discovery fetch fails. This is the discovery-driven skeleton; curated labels,
+links, and URLs follow in later work.

--- a/apps/squareone/src/app/api-aspect/page.tsx
+++ b/apps/squareone/src/app/api-aspect/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
+import ApiEndpoints from '../../components/ApiEndpoints';
 import MainContent from '../../components/MainContent';
+import { resolveApiEndpoints } from '../../lib/apiEndpoints';
 import { getStaticConfig } from '../../lib/config/rsc';
+import logger from '../../lib/logger';
 import { commonMdxComponents, compileMdxForRsc } from '../../lib/mdx/rsc';
-
-const mdxComponents = { ...commonMdxComponents };
 
 const pageDescription =
   'Integrate Rubin data into your analysis tools with APIs.';
@@ -21,6 +22,23 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function ApiAspectPage() {
+  const config = await getStaticConfig();
+
+  // Resolve the discovery-driven endpoint listing server-side so the endpoints
+  // are present in the server-rendered HTML (no client-side discovery fetch).
+  // Degrades gracefully when repertoireUrl is unset or the fetch fails.
+  const apiEndpointsResult = await resolveApiEndpoints({
+    repertoireUrl: config.repertoireUrl,
+    logger,
+  });
+
+  // Bind the resolved listing into the <ApiEndpoints/> MDX component so the
+  // per-environment prose can place it wherever it wants.
+  const mdxComponents = {
+    ...commonMdxComponents,
+    ApiEndpoints: () => <ApiEndpoints result={apiEndpointsResult} />,
+  };
+
   const { content } = await compileMdxForRsc({
     contentPath: 'api-aspect.mdx',
     components: mdxComponents,

--- a/apps/squareone/src/components/ApiEndpoints/ApiEndpoints.module.css
+++ b/apps/squareone/src/components/ApiEndpoints/ApiEndpoints.module.css
@@ -1,0 +1,12 @@
+/**
+ * ApiEndpoints styles
+ *
+ * The discovery-bound wrapper only owns the "temporarily unavailable" notice;
+ * the successful listing is styled by ApiEndpointsList.
+ */
+
+.notice {
+  margin: var(--sqo-space-md) 0;
+  color: var(--rsd-color-gray-500);
+  font-style: italic;
+}

--- a/apps/squareone/src/components/ApiEndpoints/ApiEndpoints.test.tsx
+++ b/apps/squareone/src/components/ApiEndpoints/ApiEndpoints.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import type { ApiEndpointsResult } from '../../lib/apiEndpoints/types';
+import ApiEndpoints from './ApiEndpoints';
+
+describe('ApiEndpoints', () => {
+  test('renders nothing when the listing is omitted', () => {
+    const { container } = render(
+      <ApiEndpoints result={{ status: 'omitted' }} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('renders a temporarily-unavailable notice when discovery failed', () => {
+    render(<ApiEndpoints result={{ status: 'unavailable' }} />);
+
+    expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
+  });
+
+  test('renders the endpoint list when discovery succeeded', () => {
+    const result: ApiEndpointsResult = {
+      status: 'ok',
+      groups: [
+        {
+          datasetKey: 'dp1',
+          endpoints: [{ label: 'tap', url: 'https://example.org/api/tap' }],
+        },
+      ],
+    };
+
+    render(<ApiEndpoints result={result} />);
+
+    expect(screen.getByRole('heading', { name: 'dp1' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'https://example.org/api/tap' })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/squareone/src/components/ApiEndpoints/ApiEndpoints.tsx
+++ b/apps/squareone/src/components/ApiEndpoints/ApiEndpoints.tsx
@@ -1,0 +1,33 @@
+import type { ApiEndpointsResult } from '../../lib/apiEndpoints/types';
+import styles from './ApiEndpoints.module.css';
+import ApiEndpointsList from './ApiEndpointsList';
+
+type ApiEndpointsProps = {
+  /** Resolved outcome of fetching/transforming service discovery. */
+  result: ApiEndpointsResult;
+};
+
+/**
+ * Discovery-bound API endpoint listing for embedding in MDX via the
+ * `compileMdxForRsc` components map.
+ *
+ * The page resolves discovery server-side and passes the outcome in:
+ * - `omitted` -> render nothing (the section is left out);
+ * - `unavailable` -> render a brief notice;
+ * - `ok` -> render the {@link ApiEndpointsList} for the dataset groups.
+ */
+export default function ApiEndpoints({ result }: ApiEndpointsProps) {
+  if (result.status === 'omitted') {
+    return null;
+  }
+
+  if (result.status === 'unavailable') {
+    return (
+      <p className={styles.notice}>
+        The service endpoint listing is temporarily unavailable.
+      </p>
+    );
+  }
+
+  return <ApiEndpointsList groups={result.groups} />;
+}

--- a/apps/squareone/src/components/ApiEndpoints/ApiEndpointsList.module.css
+++ b/apps/squareone/src/components/ApiEndpoints/ApiEndpointsList.module.css
@@ -1,0 +1,45 @@
+/**
+ * ApiEndpointsList styles
+ *
+ * A stack of dataset sections, each with a heading and a list of endpoints.
+ * This is the base (skeleton) presentation; curated polish lands in #465.
+ */
+
+.root {
+  margin: var(--sqo-space-md) 0;
+}
+
+.group {
+  margin-bottom: var(--sqo-space-lg);
+}
+
+.heading {
+  margin-bottom: var(--sqo-space-xs);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.item {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sqo-space-xs) var(--sqo-space-md);
+  padding: var(--sqo-space-xxs) 0;
+}
+
+.label {
+  color: var(--rsd-component-text-color);
+  font-weight: 500;
+}
+
+.url {
+  color: var(--rsd-component-text-link-color);
+  word-break: break-all;
+}
+
+.url:hover {
+  text-decoration: underline;
+}

--- a/apps/squareone/src/components/ApiEndpoints/ApiEndpointsList.stories.tsx
+++ b/apps/squareone/src/components/ApiEndpoints/ApiEndpointsList.stories.tsx
@@ -1,0 +1,55 @@
+import { mockDiscovery } from '@lsst-sqre/repertoire-client';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { serviceDiscoveryToApiEndpointGroups } from '../../lib/apiEndpoints/transform';
+import ApiEndpointsList from './ApiEndpointsList';
+
+// Drive the story from the same transform the page uses, applied to the
+// refreshed Repertoire 2.0.0 mock, so the story exercises the real
+// discovery -> display shape (one group per dataset, every service listed).
+const discoveryGroups = serviceDiscoveryToApiEndpointGroups(mockDiscovery);
+
+const meta: Meta<typeof ApiEndpointsList> = {
+  title: 'Components/ApiEndpointsList',
+  component: ApiEndpointsList,
+};
+
+export default meta;
+type Story = StoryObj<typeof ApiEndpointsList>;
+
+// Rendered from mock discovery: one section per dataset, with every service
+// (including the unmapped datalink/gms) listed by its raw name and base URL.
+export const FromMockDiscovery: Story = {
+  args: { groups: discoveryGroups },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole('heading', { name: 'dp1' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', { name: 'dp02' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('heading', { name: 'dp03' })
+    ).toBeInTheDocument();
+
+    // Unmapped service falls back to raw name + base URL link. The datalink
+    // base URL is shared across datasets, so more than one link matches.
+    const datalinkLinks = canvas.getAllByRole('link', {
+      name: 'https://data.lsst.cloud/api/datalink',
+    });
+    await expect(datalinkLinks.length).toBeGreaterThan(0);
+    await expect(datalinkLinks[0]).toHaveAttribute(
+      'href',
+      'https://data.lsst.cloud/api/datalink'
+    );
+  },
+};
+
+// With no groups the component renders nothing (the page omits the section
+// entirely in this state).
+export const Empty: Story = {
+  args: { groups: [] },
+};

--- a/apps/squareone/src/components/ApiEndpoints/ApiEndpointsList.test.tsx
+++ b/apps/squareone/src/components/ApiEndpoints/ApiEndpointsList.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import type { ApiEndpointGroup } from '../../lib/apiEndpoints/types';
+import ApiEndpointsList from './ApiEndpointsList';
+
+const groups: ApiEndpointGroup[] = [
+  {
+    datasetKey: 'dp1',
+    endpoints: [
+      { label: 'tap', url: 'https://data.lsst.cloud/api/tap' },
+      { label: 'datalink', url: 'https://data.lsst.cloud/api/datalink' },
+    ],
+  },
+  {
+    datasetKey: 'dp02',
+    endpoints: [{ label: 'tap', url: 'https://data.lsst.cloud/api/tap' }],
+  },
+];
+
+describe('ApiEndpointsList', () => {
+  test('renders a heading for each dataset group', () => {
+    render(<ApiEndpointsList groups={groups} />);
+
+    expect(screen.getByRole('heading', { name: 'dp1' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'dp02' })).toBeInTheDocument();
+  });
+
+  test('renders each endpoint as a link to its url', () => {
+    render(<ApiEndpointsList groups={groups} />);
+
+    const datalink = screen.getByRole('link', {
+      name: 'https://data.lsst.cloud/api/datalink',
+    });
+    expect(datalink).toHaveAttribute(
+      'href',
+      'https://data.lsst.cloud/api/datalink'
+    );
+  });
+
+  test('shows the raw service name as the endpoint label', () => {
+    render(<ApiEndpointsList groups={groups} />);
+
+    // Only dp1 exposes a `datalink` service, so its label appears exactly once.
+    expect(screen.getAllByText('datalink')).toHaveLength(1);
+  });
+
+  test('renders no group headings when given an empty list', () => {
+    render(<ApiEndpointsList groups={[]} />);
+
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+});

--- a/apps/squareone/src/components/ApiEndpoints/ApiEndpointsList.tsx
+++ b/apps/squareone/src/components/ApiEndpoints/ApiEndpointsList.tsx
@@ -1,0 +1,39 @@
+import type { ApiEndpointGroup } from '../../lib/apiEndpoints/types';
+import styles from './ApiEndpointsList.module.css';
+
+type ApiEndpointsListProps = {
+  /** Endpoint groups to render, one section per group. */
+  groups: ApiEndpointGroup[];
+};
+
+/**
+ * Presentational listing of API endpoints, grouped by dataset.
+ *
+ * Purely props-driven (no data fetching) so it can be exercised from
+ * Storybook and unit tests. Each group renders a heading and a list of its
+ * endpoints; each endpoint shows its label alongside a link to its URL.
+ */
+export default function ApiEndpointsList({ groups }: ApiEndpointsListProps) {
+  return (
+    <div className={styles.root}>
+      {groups.map((group) => (
+        <section key={group.datasetKey} className={styles.group}>
+          <h2 className={styles.heading}>{group.datasetKey}</h2>
+          <ul className={styles.list}>
+            {group.endpoints.map((endpoint) => (
+              <li
+                key={`${endpoint.label}:${endpoint.url}`}
+                className={styles.item}
+              >
+                <span className={styles.label}>{endpoint.label}</span>
+                <a className={styles.url} href={endpoint.url}>
+                  {endpoint.url}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/squareone/src/components/ApiEndpoints/index.ts
+++ b/apps/squareone/src/components/ApiEndpoints/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ApiEndpoints';
+export { default as ApiEndpointsList } from './ApiEndpointsList';

--- a/apps/squareone/src/content/pages/api-aspect.mdx
+++ b/apps/squareone/src/content/pages/api-aspect.mdx
@@ -5,6 +5,8 @@
 To access most APIs you need an [*access token*](/auth/tokens).
 See our guide [Creating user tokens](https://rsp.lsst.io/guides/auth/creating-user-tokens.html) to learn more.
 
+<ApiEndpoints />
+
 ## Table Access Protocol
 
 You can access catalog data using the Table Access Protocol (TAP)

--- a/apps/squareone/src/lib/apiEndpoints/index.ts
+++ b/apps/squareone/src/lib/apiEndpoints/index.ts
@@ -1,0 +1,8 @@
+export type { ResolveApiEndpointsOptions } from './resolve';
+export { resolveApiEndpoints } from './resolve';
+export { serviceDiscoveryToApiEndpointGroups } from './transform';
+export type {
+  ApiEndpoint,
+  ApiEndpointGroup,
+  ApiEndpointsResult,
+} from './types';

--- a/apps/squareone/src/lib/apiEndpoints/resolve.test.ts
+++ b/apps/squareone/src/lib/apiEndpoints/resolve.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock only fetchServiceDiscovery; keep the real mock data, types, and
+// transform inputs from the client package.
+vi.mock('@lsst-sqre/repertoire-client', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@lsst-sqre/repertoire-client')>();
+  return {
+    ...actual,
+    fetchServiceDiscovery: vi.fn(),
+  };
+});
+
+import {
+  fetchServiceDiscovery,
+  mockDiscovery,
+} from '@lsst-sqre/repertoire-client';
+
+import { resolveApiEndpoints } from './resolve';
+import { serviceDiscoveryToApiEndpointGroups } from './transform';
+
+function makeLogger() {
+  return { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('resolveApiEndpoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('omits the listing when no repertoireUrl is configured', async () => {
+    const result = await resolveApiEndpoints({ repertoireUrl: undefined });
+
+    expect(result).toEqual({ status: 'omitted' });
+    expect(fetchServiceDiscovery).not.toHaveBeenCalled();
+  });
+
+  test('returns ok groups when discovery succeeds', async () => {
+    vi.mocked(fetchServiceDiscovery).mockResolvedValue(mockDiscovery);
+
+    const result = await resolveApiEndpoints({
+      repertoireUrl: 'https://example.org/repertoire',
+    });
+
+    expect(result).toEqual({
+      status: 'ok',
+      groups: serviceDiscoveryToApiEndpointGroups(mockDiscovery),
+    });
+  });
+
+  test('returns unavailable and logs the error when discovery fails', async () => {
+    const logger = makeLogger();
+    const error = new Error('discovery exploded');
+    vi.mocked(fetchServiceDiscovery).mockRejectedValue(error);
+
+    const result = await resolveApiEndpoints({
+      repertoireUrl: 'https://example.org/repertoire',
+      logger,
+    });
+
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: error }),
+      expect.any(String)
+    );
+  });
+
+  test('threads the logger into the discovery fetch', async () => {
+    const logger = makeLogger();
+    vi.mocked(fetchServiceDiscovery).mockResolvedValue(mockDiscovery);
+
+    await resolveApiEndpoints({
+      repertoireUrl: 'https://example.org/repertoire',
+      logger,
+    });
+
+    expect(fetchServiceDiscovery).toHaveBeenCalledWith(
+      'https://example.org/repertoire',
+      { logger }
+    );
+  });
+});

--- a/apps/squareone/src/lib/apiEndpoints/resolve.ts
+++ b/apps/squareone/src/lib/apiEndpoints/resolve.ts
@@ -1,0 +1,51 @@
+import {
+  fetchServiceDiscovery,
+  type Logger,
+} from '@lsst-sqre/repertoire-client';
+
+import { serviceDiscoveryToApiEndpointGroups } from './transform';
+import type { ApiEndpointsResult } from './types';
+
+export type ResolveApiEndpointsOptions = {
+  /** Configured Repertoire base URL, or undefined when discovery is not set. */
+  repertoireUrl?: string;
+  /** Optional server-side logger for recording fetch failures. */
+  logger?: Logger;
+};
+
+/**
+ * Resolve the API endpoint listing for the `/api-aspect` page server-side.
+ *
+ * Mirrors `HeaderNav`'s degrade-gracefully pattern:
+ * - no `repertoireUrl` -> `omitted` (the page leaves the section out);
+ * - a fetch/parse failure -> `unavailable` (the page shows a brief notice) and
+ *   the error is logged server-side;
+ * - success -> `ok` with the dataset groups from the base transform.
+ *
+ * Uses the repertoire-client's existing 5-minute in-process discovery cache.
+ */
+export async function resolveApiEndpoints({
+  repertoireUrl,
+  logger,
+}: ResolveApiEndpointsOptions): Promise<ApiEndpointsResult> {
+  if (!repertoireUrl) {
+    return { status: 'omitted' };
+  }
+
+  try {
+    const discovery = await fetchServiceDiscovery(
+      repertoireUrl,
+      logger ? { logger } : undefined
+    );
+    return {
+      status: 'ok',
+      groups: serviceDiscoveryToApiEndpointGroups(discovery),
+    };
+  } catch (error) {
+    logger?.error(
+      { err: error },
+      'Failed to fetch service discovery for /api-aspect'
+    );
+    return { status: 'unavailable' };
+  }
+}

--- a/apps/squareone/src/lib/apiEndpoints/transform.test.ts
+++ b/apps/squareone/src/lib/apiEndpoints/transform.test.ts
@@ -1,0 +1,76 @@
+import {
+  getEmptyDiscovery,
+  mockDiscovery,
+  type ServiceDiscovery,
+} from '@lsst-sqre/repertoire-client';
+import { describe, expect, test } from 'vitest';
+
+import { serviceDiscoveryToApiEndpointGroups } from './transform';
+
+describe('serviceDiscoveryToApiEndpointGroups', () => {
+  test('produces one group per dataset, in discovery order', () => {
+    const groups = serviceDiscoveryToApiEndpointGroups(mockDiscovery);
+
+    expect(groups.map((group) => group.datasetKey)).toEqual([
+      'dp1',
+      'dp02',
+      'dp03',
+    ]);
+  });
+
+  test('lists the full set of a dataset services, including unmapped ones', () => {
+    const groups = serviceDiscoveryToApiEndpointGroups(mockDiscovery);
+    const dp1 = groups.find((group) => group.datasetKey === 'dp1');
+
+    // Every service under dp1 is rendered, including the unmapped
+    // datalink/gms services that later curated work falls back on.
+    expect(dp1?.endpoints.map((endpoint) => endpoint.label)).toEqual([
+      'cutout',
+      'datalink',
+      'gms',
+      'hips',
+      'sia',
+      'tap',
+    ]);
+  });
+
+  test('uses the raw service name as the label and the base url as the endpoint url', () => {
+    const groups = serviceDiscoveryToApiEndpointGroups(mockDiscovery);
+    const dp1 = groups.find((group) => group.datasetKey === 'dp1');
+    const tap = dp1?.endpoints.find((endpoint) => endpoint.label === 'tap');
+
+    expect(tap).toEqual({
+      label: 'tap',
+      url: 'https://data.lsst.cloud/api/tap',
+    });
+  });
+
+  test('returns an empty array when discovery has no datasets', () => {
+    expect(serviceDiscoveryToApiEndpointGroups(getEmptyDiscovery())).toEqual(
+      []
+    );
+  });
+
+  test('returns a group with no endpoints when a dataset has no services', () => {
+    const discovery = {
+      ...getEmptyDiscovery(),
+      datasets: { dp1: { services: {} } },
+    } as ServiceDiscovery;
+
+    expect(serviceDiscoveryToApiEndpointGroups(discovery)).toEqual([
+      { datasetKey: 'dp1', endpoints: [] },
+    ]);
+  });
+
+  test('tolerates a dataset missing its services field', () => {
+    const discovery = {
+      ...getEmptyDiscovery(),
+      // Intentionally omit `services` to exercise the defensive fallback.
+      datasets: { dp1: {} },
+    } as unknown as ServiceDiscovery;
+
+    expect(serviceDiscoveryToApiEndpointGroups(discovery)).toEqual([
+      { datasetKey: 'dp1', endpoints: [] },
+    ]);
+  });
+});

--- a/apps/squareone/src/lib/apiEndpoints/transform.ts
+++ b/apps/squareone/src/lib/apiEndpoints/transform.ts
@@ -1,0 +1,35 @@
+import type { ServiceDiscovery } from '@lsst-sqre/repertoire-client';
+
+import type { ApiEndpointGroup } from './types';
+
+/**
+ * Transform Repertoire service discovery into the base `/api-aspect` listing.
+ *
+ * Emits one {@link ApiEndpointGroup} per discovered dataset, in discovery
+ * order. Every service under a dataset is rendered — including unmapped
+ * services such as `datalink` and `gms` — using the raw service name as the
+ * label and the service's base `url` as the endpoint URL. Curated labels,
+ * IVOA links, and version-selected URLs are layered on in later work (#465);
+ * this base transform is purely structural.
+ *
+ * Empty/missing fallbacks: a discovery with no datasets yields `[]`, and a
+ * dataset with no (or a missing) `services` map yields a group with no
+ * endpoints.
+ */
+export function serviceDiscoveryToApiEndpointGroups(
+  discovery: ServiceDiscovery
+): ApiEndpointGroup[] {
+  const datasets = discovery.datasets ?? {};
+
+  return Object.entries(datasets).map(([datasetKey, dataset]) => ({
+    datasetKey,
+    endpoints: Object.entries(dataset.services ?? {}).map(
+      ([serviceName, service]) => ({
+        label: serviceName,
+        url: service.url,
+      })
+    ),
+  }));
+}
+
+export type { ApiEndpoint, ApiEndpointGroup } from './types';

--- a/apps/squareone/src/lib/apiEndpoints/types.ts
+++ b/apps/squareone/src/lib/apiEndpoints/types.ts
@@ -1,0 +1,41 @@
+/**
+ * A single API endpoint rendered in the `/api-aspect` listing.
+ *
+ * The base (discovery-driven skeleton) transform fills `label` with the raw
+ * service name and `url` with the service's base URL. Later curated work
+ * (#465) can substitute human labels and version-selected URLs without
+ * changing this shape.
+ */
+export type ApiEndpoint = {
+  /** Display label for the endpoint. */
+  label: string;
+  /** Endpoint URL the label links to. */
+  url: string;
+};
+
+/**
+ * A group of API endpoints that share a section heading.
+ *
+ * The base transform emits one group per discovered dataset, keyed by the
+ * raw dataset key (`dp1`, `dp02`, `dp03`).
+ */
+export type ApiEndpointGroup = {
+  /** Section heading for the group (the dataset key in the base transform). */
+  datasetKey: string;
+  /** Endpoints served by this dataset. */
+  endpoints: ApiEndpoint[];
+};
+
+/**
+ * The outcome of resolving the API endpoint listing for the page.
+ *
+ * - `omitted`: no `repertoireUrl` configured, so the listing is left out
+ *   entirely and only the surrounding MDX prose renders.
+ * - `unavailable`: discovery was configured but the fetch/parse failed; the
+ *   page shows a brief notice instead of the listing.
+ * - `ok`: discovery succeeded and produced the dataset groups to render.
+ */
+export type ApiEndpointsResult =
+  | { status: 'omitted' }
+  | { status: 'unavailable' }
+  | { status: 'ok'; groups: ApiEndpointGroup[] };


### PR DESCRIPTION
## Summary

- Render the `/api-aspect` endpoint listing from Repertoire service discovery server-side: one section per dataset (`dp1`/`dp02`/`dp03`), each listing every service by name with its base URL.
- Degrade gracefully, mirroring `HeaderNav`: omit the listing when `repertoireUrl` is unset, and show a brief "temporarily unavailable" notice (plus a server-side log) when the discovery fetch fails.
- Embed the listing via an `<ApiEndpoints/>` MDX component so per-environment prose keeps control of the surrounding content. This is the discovery-driven skeleton; curated labels/links/URLs follow in #465.

## Validation steps

- Visit `/api-aspect` in dev (mock discovery) and confirm one section per dataset (`dp1`, `dp02`, `dp03`), each listing its full set of services — including the unmapped `datalink` and `gms` — with each entry linking to the service's base URL.
- View source on `/api-aspect` and confirm the dataset sections and endpoint URLs are present in the server-rendered HTML (no client-side discovery fetch required).
- Confirm the token-guidance intro and the Table Access Protocol / TOPCAT prose still render around the `<ApiEndpoints/>` listing.
- With `repertoireUrl` unset, confirm the page renders the prose and omits the endpoint section without error.
- Simulate a discovery fetch failure and confirm the page shows the brief "temporarily unavailable" notice and logs the error server-side.

## References

- Closes #464
- PRD: #461
- Jira: https://rubinobs.atlassian.net/browse/DM-55225