### PR TITLE
DM-55225: Add weekly OpenAPI spec drift-detection workflow

### DIFF
--- a/.agents/skills/project-mechanics/SKILL.md
+++ b/.agents/skills/project-mechanics/SKILL.md
@@ -81,7 +81,7 @@ Extras, run only when the change touches the relevant area:
 - Production build: `pnpm build` — CI builds the app; run it when a
   change could affect the Next.js/production build, since it catches
   errors `test`/`type-check` miss.
-- Docker versions: `node scripts/validate-docker-versions.js` — run
+- Docker versions: `node packages/repo-scripts/src/validate-docker-versions.js` — run
   when a `Dockerfile*` changes.
 - Docs: `uv run noxfile.py -s docs` (Sphinx via documenteer) — run
   when `docs/**` changes. For tasks that specifically refine the

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -231,7 +231,7 @@ Skills are modular capabilities that extend Claude's expertise with domain-speci
 
 **Supporting files**:
 
-- None (references validation script at `scripts/validate-docker-versions.js`)
+- None (references validation script at `packages/repo-scripts/src/validate-docker-versions.js`)
 
 #### file-factory
 

--- a/.claude/skills/docker-version-validation/SKILL.md
+++ b/.claude/skills/docker-version-validation/SKILL.md
@@ -8,7 +8,7 @@ description: |
   Dockerfile changes and in CI pipeline. Trigger keywords: Dockerfile, Docker version, Node version,
   pnpm version, turbo version, version mismatch, version sync, Docker update.
 allowed-tools:
-  - Bash(node scripts/validate-docker-versions.js:*)
+  - Bash(node packages/repo-scripts/src/validate-docker-versions.js:*)
   - Bash(pnpm validate-docker:*)
 ---
 
@@ -100,7 +100,9 @@ The validation runs automatically at three integration points:
 ```javascript
 // .lintstagedrc.mjs
 export default {
-  '**/Dockerfile*': ['node scripts/validate-docker-versions.js'],
+  '**/Dockerfile*': [
+    'node packages/repo-scripts/src/validate-docker-versions.js',
+  ],
 };
 ```
 
@@ -112,7 +114,7 @@ export default {
 ```yaml
 # .github/workflows/ci.yaml
 - name: Validate Docker versions
-  run: node scripts/validate-docker-versions.js
+  run: node packages/repo-scripts/src/validate-docker-versions.js
 ```
 
 - **Triggers:** On every push and pull request
@@ -367,7 +369,7 @@ RUN pnpx turbo@2.6.0 prune ...
 
 ### Validation Script
 
-**Location:** `scripts/validate-docker-versions.js`
+**Location:** `packages/repo-scripts/src/validate-docker-versions.js`
 
 **Key functions:**
 - `findDockerfiles(dir)` - Recursively finds all Dockerfiles

--- a/.claude/skills/project-mechanics/SKILL.md
+++ b/.claude/skills/project-mechanics/SKILL.md
@@ -81,7 +81,7 @@ Extras, run only when the change touches the relevant area:
 - Production build: `pnpm build` — CI builds the app; run it when a
   change could affect the Next.js/production build, since it catches
   errors `test`/`type-check` miss.
-- Docker versions: `node scripts/validate-docker-versions.js` — run
+- Docker versions: `node packages/repo-scripts/src/validate-docker-versions.js` — run
   when a `Dockerfile*` changes.
 - Docs: `uv run noxfile.py -s docs` (Sphinx via documenteer) — run
   when `docs/**` changes. For tasks that specifically refine the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate Docker versions
-        run: node scripts/validate-docker-versions.js
+        run: node packages/repo-scripts/src/validate-docker-versions.js
 
       - name: Check formatting with Biome
         run: pnpm run biome:format:check

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -1,0 +1,45 @@
+name: Periodic CI
+
+# Weekly check that no vendored OpenAPI client spec has drifted from its live
+# source. This runs in GitHub Actions (open egress), so it is not subject to the
+# development sandbox's egress firewall. Modeled on lsst-sqre/ook's periodic-ci.
+
+'on':
+  schedule:
+    - cron: '0 12 * * 1' # Mondays at 12:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  openapi-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+
+      - name: Set up node
+        uses: actions/setup-node@v6
+        with:
+          cache: 'pnpm'
+          node-version-file: '.nvmrc'
+
+      - name: Install npm packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for OpenAPI spec drift
+        run: pnpm run check-openapi-drift
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+          notification_title: 'OpenAPI spec drift check for {repo} failed'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -1,5 +1,7 @@
 export default {
   '*': ['biome check --write --staged --no-errors-on-unmatched'],
   '*.{yaml,yml}': ['prettier --write'],
-  '**/Dockerfile*': ['node scripts/validate-docker-versions.js'],
+  '**/Dockerfile*': [
+    'node packages/repo-scripts/src/validate-docker-versions.js',
+  ],
 };

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -402,7 +402,7 @@
       "type": "npm",
       "script": "validate-docker",
       "problemMatcher": [],
-      "detail": "Validate Dockerfile versions match package.json (runs: node scripts/validate-docker-versions.js)"
+      "detail": "Validate Dockerfile versions match package.json (runs: node packages/repo-scripts/src/validate-docker-versions.js)"
     }
   ]
 }

--- a/docs/dev/github-actions-architecture.rst
+++ b/docs/dev/github-actions-architecture.rst
@@ -79,7 +79,7 @@ The container ensures consistent browser testing environments.
 
 Key steps:
 
-1. **Docker Version Validation**: Runs :file:`scripts/validate-docker-versions.js` to ensure Dockerfile version tags match :file:`package.json` versions for Node.js, pnpm, and Turborepo
+1. **Docker Version Validation**: Runs :file:`packages/repo-scripts/src/validate-docker-versions.js` to ensure Dockerfile version tags match :file:`package.json` versions for Node.js, pnpm, and Turborepo
 2. **Biome Format Check**: Verifies code formatting for JavaScript, TypeScript, JSON, and CSS with Biome_
 3. **YAML Format Check**: Verifies YAML file formatting with Prettier_ (Biome doesn't support YAML)
 4. **Biome Lint**: Runs Biome linting for correctness, accessibility, performance, security, and code style
@@ -131,7 +131,7 @@ The CI workflow uses several tools to ensure code quality, consistency, and corr
 Docker version validation
 -------------------------
 
-The :file:`scripts/validate-docker-versions.js` script ensures that all Dockerfile version tags stay synchronized with the versions specified in :file:`package.json`.
+The :file:`packages/repo-scripts/src/validate-docker-versions.js` script ensures that all Dockerfile version tags stay synchronized with the versions specified in :file:`package.json`.
 
 **What it validates:**
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:local": "turbo run build",
     "docs": "uv run noxfile.py -s docs",
     "validate-docker": "node scripts/validate-docker-versions.js",
+    "check-openapi-drift": "node packages/repo-scripts/src/check-openapi-drift.js",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\" && node scripts/install-playwright.js"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "localci": "node scripts/validate-docker-versions.js && node scripts/turbo-wrapper.js run biome:format:check prettier:yaml lint type-check test build && pnpm run biome:lint",
+    "localci": "node packages/repo-scripts/src/validate-docker-versions.js && node scripts/turbo-wrapper.js run biome:format:check prettier:yaml lint type-check test build && pnpm run biome:lint",
     "build": "node scripts/turbo-wrapper.js run build",
     "file-factory": "node packages/file-factory/dist/cli.js",
     "dev": "node scripts/turbo-wrapper.js run dev",
@@ -21,7 +21,7 @@
     "turbo": "node scripts/turbo-wrapper.js",
     "build:local": "turbo run build",
     "docs": "uv run noxfile.py -s docs",
-    "validate-docker": "node scripts/validate-docker-versions.js",
+    "validate-docker": "node packages/repo-scripts/src/validate-docker-versions.js",
     "check-openapi-drift": "node packages/repo-scripts/src/check-openapi-drift.js",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\" && node scripts/install-playwright.js"
   },

--- a/packages/repo-scripts/package.json
+++ b/packages/repo-scripts/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@lsst-sqre/repo-scripts",
+  "description": "Internal repository maintenance scripts (not published)",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/repo-scripts/src/check-openapi-drift.js
+++ b/packages/repo-scripts/src/check-openapi-drift.js
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+
+/**
+ * Checks whether any vendored OpenAPI client spec has drifted from its live
+ * source.
+ *
+ * For each Rubin Science Platform client package that defines a `fetch-openapi`
+ * script, the live spec URL is derived from that script (the single source of
+ * truth — the URLs are not duplicated here), the live spec is fetched, and it is
+ * compared against the committed `packages/<client>/openapi.json`. Both specs are
+ * normalized first (parsed, then re-serialized with recursively sorted object
+ * keys) so differences in key order or whitespace don't produce false positives.
+ *
+ * The comparison excludes `info.version`: an RSP service redeploy commonly bumps
+ * its spec's `info.version` (e.g. a setuptools-scm dev version) with no change to
+ * the API surface. Such a version-only difference is reported for visibility but
+ * does not fail the run, so re-vendoring is only prompted on a real API change.
+ *
+ * Per-client outcomes:
+ * - ok:           committed spec matches live (after normalization)
+ * - version-only: only `info.version` differs (server redeploy, no API change) ->
+ *                 reported but not a failure; no re-vendoring needed
+ * - drift:        committed spec differs from live beyond `info.version` ->
+ *                 needs re-vendoring
+ * - fetch-error:  a vendored spec exists but its live source could not be fetched
+ *                 (can't verify it isn't stale, so this is treated as a failure)
+ * - skipped:      no committed openapi.json is vendored for the client
+ * - config-error: the package.json could not be read or has no fetch-openapi URL
+ *
+ * Exit codes:
+ * - 0: every checked spec is in sync, including version-only differences
+ *      (skipped clients don't fail the run)
+ * - 1: at least one spec drifted or its live source could not be fetched
+ * - 2: a configuration/validation error prevented the check
+ *
+ * Runs weekly in GitHub Actions (open egress) via .github/workflows/periodic-ci.yaml,
+ * and is runnable locally / in the sandbox via `pnpm run check-openapi-drift`.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// ANSI color codes for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  bold: '\x1b[1m',
+};
+
+// Client packages whose vendored OpenAPI specs we guard against drift.
+const CLIENT_PACKAGES = [
+  'gafaelfawr-client',
+  'semaphore-client',
+  'repertoire-client',
+  'times-square-client',
+];
+
+// Abandon a live-spec fetch that takes longer than this (ms) so the job can't
+// hang on an unresponsive host.
+const FETCH_TIMEOUT_MS = 30000;
+
+// Repo root, resolved from this script's home in packages/repo-scripts/src.
+const rootDir = path.resolve(__dirname, '../../..');
+
+/**
+ * Extract the live spec URL from a package's `fetch-openapi` script.
+ *
+ * The script is a curl invocation such as
+ *   curl -o openapi.json https://data.lsst.cloud/auth/openapi.json
+ * We pull the first http(s) URL out of it, so the URL is sourced from the
+ * package's own script rather than duplicated in this file.
+ */
+function extractSpecUrl(fetchScript) {
+  if (!fetchScript) return null;
+  const match = fetchScript.match(/https?:\/\/\S+/);
+  return match ? match[0] : null;
+}
+
+/**
+ * Recursively sort object keys to produce a canonical representation. Array
+ * order is preserved (it is semantically significant in OpenAPI); only object
+ * keys are reordered so that key-order / whitespace differences compare equal.
+ */
+function canonicalize(value) {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === 'object') {
+    const sorted = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = canonicalize(value[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * Canonical JSON serialization used for drift comparison.
+ */
+function canonicalJson(spec) {
+  return JSON.stringify(canonicalize(spec));
+}
+
+/**
+ * Canonical JSON serialization with `info.version` excluded, used for the
+ * drift comparison. A server redeploy that only bumps `info.version` should
+ * not register as drift, so the version is removed before comparison. The spec
+ * is deep-cloned first (specs are pure JSON) so the original object — still
+ * needed for its version by `specVersion` — is not mutated.
+ */
+function comparableJson(spec) {
+  const clone = JSON.parse(JSON.stringify(spec));
+  if (clone?.info && 'version' in clone.info) {
+    delete clone.info.version;
+  }
+  return canonicalJson(clone);
+}
+
+/**
+ * Read the `info.version` from a parsed spec, falling back to a placeholder.
+ */
+function specVersion(spec) {
+  return spec?.info?.version ?? 'unknown';
+}
+
+/**
+ * Classify a committed spec against its live source, ignoring `info.version`.
+ * Returns one of:
+ * - 'ok':           specs are identical, version included
+ * - 'version-only': specs match apart from `info.version` (server redeploy)
+ * - 'drift':        specs differ beyond `info.version`
+ */
+function classifySpecs(committed, live) {
+  if (comparableJson(committed) === comparableJson(live)) {
+    return specVersion(committed) === specVersion(live) ? 'ok' : 'version-only';
+  }
+  return 'drift';
+}
+
+/**
+ * Fetch a live OpenAPI spec and parse it as JSON.
+ * Returns { ok: true, spec } or { ok: false, error }.
+ */
+async function fetchLiveSpec(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: `HTTP ${response.status} ${response.statusText}`,
+      };
+    }
+    const text = await response.text();
+    try {
+      return { ok: true, spec: JSON.parse(text) };
+    } catch (error) {
+      return {
+        ok: false,
+        error: `live response is not valid JSON: ${error.message}`,
+      };
+    }
+  } catch (error) {
+    const reason =
+      error.name === 'AbortError'
+        ? `request timed out after ${FETCH_TIMEOUT_MS}ms`
+        : error.message;
+    return { ok: false, error: reason };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Check a single client package's vendored spec against its live source.
+ */
+async function checkClient(clientPkg) {
+  const pkgDir = path.join(rootDir, 'packages', clientPkg);
+  const pkgJsonPath = path.join(pkgDir, 'package.json');
+  const specPath = path.join(pkgDir, 'openapi.json');
+
+  let pkg;
+  try {
+    pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+  } catch (error) {
+    return {
+      client: clientPkg,
+      status: 'config-error',
+      detail: `cannot read ${path.relative(rootDir, pkgJsonPath)}: ${error.message}`,
+    };
+  }
+
+  const url = extractSpecUrl(pkg.scripts?.['fetch-openapi']);
+  if (!url) {
+    return {
+      client: clientPkg,
+      status: 'config-error',
+      detail: 'no fetch-openapi script URL found in package.json',
+    };
+  }
+
+  const hasLocal = fs.existsSync(specPath);
+
+  // Always fetch the live spec so the check exercises every client's host.
+  const live = await fetchLiveSpec(url);
+
+  if (!live.ok) {
+    // With nothing vendored, a live hiccup isn't actionable drift -> skip.
+    if (!hasLocal) {
+      return {
+        client: clientPkg,
+        status: 'skipped',
+        url,
+        detail: `no committed openapi.json (live fetch also failed: ${live.error})`,
+      };
+    }
+    return {
+      client: clientPkg,
+      status: 'fetch-error',
+      url,
+      detail: live.error,
+    };
+  }
+
+  if (!hasLocal) {
+    return {
+      client: clientPkg,
+      status: 'skipped',
+      url,
+      detail: 'no committed openapi.json to compare against',
+    };
+  }
+
+  let committed;
+  try {
+    committed = JSON.parse(fs.readFileSync(specPath, 'utf8'));
+  } catch (error) {
+    return {
+      client: clientPkg,
+      status: 'config-error',
+      detail: `cannot parse ${path.relative(rootDir, specPath)}: ${error.message}`,
+    };
+  }
+
+  const committedVersion = specVersion(committed);
+  const liveVersion = specVersion(live.spec);
+
+  return {
+    client: clientPkg,
+    status: classifySpecs(committed, live.spec),
+    url,
+    committedVersion,
+    liveVersion,
+  };
+}
+
+/**
+ * Print the per-client result line(s).
+ */
+function printResult(result) {
+  switch (result.status) {
+    case 'ok':
+      console.log(
+        `  ${colors.green}✓${colors.reset} in sync (info.version ${result.committedVersion})`
+      );
+      break;
+    case 'version-only':
+      console.log(
+        `  ${colors.green}✓${colors.reset} in sync (info.version ${result.committedVersion} -> ${result.liveVersion}; server redeploy, no API change — not re-vendored)`
+      );
+      break;
+    case 'drift': {
+      const versionNote =
+        result.committedVersion === result.liveVersion
+          ? `info.version ${result.committedVersion} unchanged; spec content differs`
+          : `info.version ${result.committedVersion} -> ${result.liveVersion}`;
+      console.error(
+        `  ${colors.red}✗${colors.reset} DRIFT: vendored spec differs from live`
+      );
+      console.error(`    ${versionNote}`);
+      console.error(`    live source: ${result.url}`);
+      break;
+    }
+    case 'fetch-error':
+      console.error(
+        `  ${colors.red}✗${colors.reset} could not fetch live spec: ${result.detail}`
+      );
+      console.error(`    live source: ${result.url}`);
+      break;
+    case 'skipped':
+      console.warn(
+        `  ${colors.yellow}⚠${colors.reset} skipped: ${result.detail}`
+      );
+      break;
+    case 'config-error':
+      console.error(
+        `  ${colors.red}✗${colors.reset} config error: ${result.detail}`
+      );
+      break;
+    default:
+      console.error(`  ${colors.red}✗${colors.reset} unknown status`);
+  }
+}
+
+/**
+ * List the client names for a given status, for the summary.
+ */
+function namesWithStatus(results, status) {
+  return results
+    .filter((r) => r.status === status)
+    .map((r) => r.client)
+    .join(', ');
+}
+
+/**
+ * Main execution. Returns the process exit code.
+ */
+async function main() {
+  console.log(`${colors.bold}OpenAPI Drift Check${colors.reset}`);
+  console.log('Comparing vendored client specs against their live sources\n');
+
+  const results = [];
+  for (const clientPkg of CLIENT_PACKAGES) {
+    console.log(`${colors.blue}Checking:${colors.reset} ${clientPkg}`);
+    const result = await checkClient(clientPkg);
+    printResult(result);
+    results.push(result);
+    console.log('');
+  }
+
+  const ok = results.filter((r) => r.status === 'ok');
+  const versionOnly = results.filter((r) => r.status === 'version-only');
+  const drifted = results.filter((r) => r.status === 'drift');
+  const fetchErrors = results.filter((r) => r.status === 'fetch-error');
+  const skipped = results.filter((r) => r.status === 'skipped');
+  const configErrors = results.filter((r) => r.status === 'config-error');
+
+  console.log(`${colors.bold}Summary:${colors.reset}`);
+  console.log(`  Clients checked: ${results.length}`);
+  console.log(
+    `  ${colors.green}✓${colors.reset} In sync: ${ok.length}${
+      ok.length ? ` (${namesWithStatus(results, 'ok')})` : ''
+    }`
+  );
+  if (versionOnly.length) {
+    console.log(
+      `  ${colors.green}✓${colors.reset} Version-only (no API change): ${versionOnly.length} (${namesWithStatus(results, 'version-only')})`
+    );
+  }
+  if (drifted.length) {
+    console.log(
+      `  ${colors.red}✗${colors.reset} Drifted: ${drifted.length} (${namesWithStatus(results, 'drift')})`
+    );
+  }
+  if (fetchErrors.length) {
+    console.log(
+      `  ${colors.red}✗${colors.reset} Fetch errors: ${fetchErrors.length} (${namesWithStatus(results, 'fetch-error')})`
+    );
+  }
+  if (skipped.length) {
+    console.log(
+      `  ${colors.yellow}⚠${colors.reset} Skipped (no vendored spec): ${skipped.length} (${namesWithStatus(results, 'skipped')})`
+    );
+  }
+  if (configErrors.length) {
+    console.log(
+      `  ${colors.red}✗${colors.reset} Config errors: ${configErrors.length} (${namesWithStatus(results, 'config-error')})`
+    );
+  }
+
+  if (drifted.length || fetchErrors.length) {
+    console.log(`\n${colors.yellow}To fix drift:${colors.reset}`);
+    console.log(
+      '  Re-vendor the spec and commit the result, e.g. for a drifted client:'
+    );
+    console.log('    pnpm --filter @lsst-sqre/<client> fetch-openapi');
+    console.log(
+      '  then review and commit the updated packages/<client>/openapi.json.\n'
+    );
+  } else {
+    console.log(
+      `\n${colors.green}✓ All vendored specs are in sync.${colors.reset}\n`
+    );
+  }
+
+  if (configErrors.length) return 2;
+  if (drifted.length || fetchErrors.length) return 1;
+  return 0;
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((error) => {
+      console.error(
+        `${colors.red}✗${colors.reset} Unexpected error: ${error.stack || error}`
+      );
+      process.exit(2);
+    });
+}
+
+// Export for testing
+module.exports = {
+  extractSpecUrl,
+  canonicalize,
+  canonicalJson,
+  comparableJson,
+  classifySpecs,
+  specVersion,
+  fetchLiveSpec,
+  checkClient,
+};

--- a/packages/repo-scripts/src/check-openapi-drift.test.ts
+++ b/packages/repo-scripts/src/check-openapi-drift.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifySpecs, comparableJson } from './check-openapi-drift.js';
+
+// A minimal but representative OpenAPI spec used as the baseline for the
+// comparison tests. Each case clones and mutates this to model a real scenario.
+function baseSpec() {
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'Times Square',
+      version: '0.23.1.dev24+g576ef1393',
+    },
+    paths: {
+      '/v1/pages': {
+        get: {
+          summary: 'List pages',
+          responses: { '200': { description: 'OK' } },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Page: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+        },
+      },
+    },
+  };
+}
+
+describe('classifySpecs', () => {
+  it('returns "ok" for identical specs', () => {
+    expect(classifySpecs(baseSpec(), baseSpec())).toBe('ok');
+  });
+
+  it('returns "version-only" when only info.version differs', () => {
+    const committed = baseSpec();
+    const live = baseSpec();
+    // Model a setuptools-scm dev-version bump from a server redeploy.
+    live.info.version = '0.23.1.dev30+gabcdef123';
+
+    expect(classifySpecs(committed, live)).toBe('version-only');
+  });
+
+  it('returns "drift" when a path changes', () => {
+    const committed = baseSpec();
+    const live = baseSpec();
+    (live.paths as Record<string, unknown>)['/v1/pages/{id}'] = {
+      get: { summary: 'Get page', responses: { '200': { description: 'OK' } } },
+    };
+
+    expect(classifySpecs(committed, live)).toBe('drift');
+  });
+
+  it('returns "drift" when a schema changes', () => {
+    const committed = baseSpec();
+    const live = baseSpec();
+    live.components.schemas.Page.properties = {
+      name: { type: 'string' },
+      title: { type: 'string' },
+    };
+
+    expect(classifySpecs(committed, live)).toBe('drift');
+  });
+
+  it('returns "drift" when info.title changes but info.version is equal', () => {
+    const committed = baseSpec();
+    const live = baseSpec();
+    // Only info.version is excluded from comparison, not all of info.
+    live.info.title = 'Times Square (renamed)';
+
+    expect(classifySpecs(committed, live)).toBe('drift');
+  });
+});
+
+describe('comparableJson', () => {
+  it('is independent of info.version', () => {
+    const a = baseSpec();
+    const b = baseSpec();
+    b.info.version = 'something-completely-different';
+
+    expect(comparableJson(a)).toBe(comparableJson(b));
+  });
+
+  it('is independent of object key ordering', () => {
+    const ordered = {
+      openapi: '3.1.0',
+      info: { title: 'X', version: '1.0.0' },
+      paths: {},
+    };
+    const reordered = {
+      paths: {},
+      info: { version: '1.0.0', title: 'X' },
+      openapi: '3.1.0',
+    };
+
+    expect(comparableJson(ordered)).toBe(comparableJson(reordered));
+  });
+
+  it('reflects a real API change', () => {
+    const committed = baseSpec();
+    const live = baseSpec();
+    live.components.schemas.Page.properties = {
+      name: { type: 'string' },
+      published: { type: 'boolean' },
+    };
+
+    expect(comparableJson(committed)).not.toBe(comparableJson(live));
+  });
+});

--- a/packages/repo-scripts/src/validate-docker-versions.js
+++ b/packages/repo-scripts/src/validate-docker-versions.js
@@ -345,7 +345,8 @@ function validateDockerfile(dockerfilePath, rootDir) {
  * Main execution
  */
 function main() {
-  const rootDir = path.resolve(__dirname, '..');
+  // Repo root, resolved from this script's home in packages/repo-scripts/src.
+  const rootDir = path.resolve(__dirname, '../../..');
 
   console.log(`${colors.bold}Docker Version Validator${colors.reset}`);
   console.log(`Checking Dockerfiles in: ${rootDir}\n`);

--- a/packages/repo-scripts/src/validate-docker-versions.test.ts
+++ b/packages/repo-scripts/src/validate-docker-versions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareVersions } from './validate-docker-versions.js';
+
+describe('compareVersions', () => {
+  describe('exact match', () => {
+    it('matches identical versions', () => {
+      expect(compareVersions('10.20.0', '10.20.0', 'exact')).toBe(true);
+    });
+
+    it('rejects a differing patch version', () => {
+      expect(compareVersions('10.20.0', '10.20.1', 'exact')).toBe(false);
+    });
+
+    it('strips a range prefix before comparing', () => {
+      // package.json constraints like "^2.5.6" must compare equal to the
+      // exact version pinned in a Dockerfile.
+      expect(compareVersions('2.5.6', '^2.5.6', 'exact')).toBe(true);
+      expect(compareVersions('2.5.6', '~2.5.6', 'exact')).toBe(true);
+    });
+  });
+
+  describe('major.minor match', () => {
+    it('matches when only the patch differs', () => {
+      // Node.js is validated on major.minor; patch drift is allowed.
+      expect(compareVersions('22.14.0', '22.14.3', 'major.minor')).toBe(true);
+    });
+
+    it('rejects a differing minor version', () => {
+      expect(compareVersions('22.14.0', '22.15.0', 'major.minor')).toBe(false);
+    });
+
+    it('rejects a differing major version', () => {
+      expect(compareVersions('22.14.0', '23.14.0', 'major.minor')).toBe(false);
+    });
+  });
+
+  describe('missing operands', () => {
+    it('treats a missing version as a skipped (passing) comparison', () => {
+      // A version present in only one file is surfaced as a warning elsewhere;
+      // the comparison itself short-circuits to true rather than failing.
+      expect(compareVersions(null, '10.20.0', 'exact')).toBe(true);
+      expect(compareVersions('10.20.0', null, 'exact')).toBe(true);
+    });
+  });
+});

--- a/packages/repo-scripts/vitest.config.ts
+++ b/packages/repo-scripts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,12 @@ importers:
         specifier: ^4.1.0
         version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@25.2.3)(typescript@5.9.3))(vite@7.1.3(@types/node@25.2.3)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.46.0)(yaml@2.9.0))
 
+  packages/repo-scripts:
+    devDependencies:
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@25.2.3)(typescript@5.9.3))(vite@7.1.3(@types/node@25.2.3)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.46.0)(yaml@2.9.0))
+
   packages/rubin-style-dictionary:
     devDependencies:
       lodash:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,26 @@
+# scripts/
+
+Bootstrap scripts that have to run *before or around* the workspace toolchain
+itself. They are invoked by raw `node` (never through Turborepo) and cannot
+depend on workspace packages being installed or built.
+
+| Script | Used by | Why it lives here |
+| --- | --- | --- |
+| `turbo-wrapper.js` | every root `pnpm` script that runs Turborepo | Wraps `turbo` to inject remote-cache auth. It is the entry point *to* the toolchain, so it can't run through it. |
+| `install-playwright.js` | the root `prepare` lifecycle script | Runs during `pnpm install`, before any package is built. |
+
+## scripts/ vs. `packages/repo-scripts`
+
+Reach for **`packages/repo-scripts`** (`@lsst-sqre/repo-scripts`) for any new
+repository maintenance or validation script. As a regular private workspace
+package it gets the standard per-package Vitest convention for free, so its
+logic is covered by `pnpm test` / Turborepo automatically. Examples already
+there: `check-openapi-drift.js` and `validate-docker-versions.js`.
+
+Add a script to **`scripts/`** only when it genuinely can't live in a workspace
+package — i.e. it bootstraps the toolchain (like the two above) and so must be
+runnable by bare `node` without the workspace being installed or built.
+
+Rule of thumb: if the script has testable logic and runs as part of normal
+development or CI, put it in `packages/repo-scripts`. If it has to run to make
+the workspace usable in the first place, it belongs here.


### PR DESCRIPTION
## Summary

- Add a weekly `Periodic CI` GitHub Actions workflow (Mondays 12:00 UTC, plus manual `workflow_dispatch`) that flags when any vendored RSP client OpenAPI spec has drifted from its live source and posts to the SQuaRE Slack alert channel on failure. Modeled on `lsst-sqre/ook`'s `periodic-ci.yaml`; runs in GitHub Actions (open egress) so it doesn't depend on the sandbox firewall.
- Add `check-openapi-drift.js` (run locally via the `check-openapi-drift` root pnpm script) that, for each of the four client packages, derives the live spec URL from that package's own `fetch-openapi` script (single source of truth), fetches the live spec, and compares it — after canonical JSON normalization — against the committed `packages/<client>/openapi.json`, emitting a per-client report.
- **Ignore server-version-only changes.** `info.version` is excluded from the comparison: an RSP service redeploy commonly bumps its spec's `info.version` (e.g. a setuptools-scm dev version) with no API change. A version-only difference is now reported for visibility (status `version-only`) but does **not** fail the run — only a real API change (status `drift`) prompts re-vendoring. The script still fails on `drift` or on a vendored spec whose live source can't be fetched (so a spec we can't verify is never silently passed), and skips a client that has a `fetch-openapi` script but no committed spec.
- **Give the script a proper home.** It lives in a new private workspace package, `@lsst-sqre/repo-scripts` (`packages/repo-scripts/src/check-openapi-drift.js`), so the standard per-package vitest convention applies. The comparison logic (`classifySpecs`, `comparableJson`) is now covered by unit tests that `pnpm test` / Turborepo run automatically, gating PRs. The package defines only a `test` script (no `lint`/`type-check`/`build`): it's plain CJS, not imported by other packages, and Biome covers its linting repo-wide.
- **Consolidate repo-maintenance scripts (follow-up).** Move the pre-existing `validate-docker-versions.js` out of the bootstrap-only `scripts/` directory into the same `@lsst-sqre/repo-scripts` package (`packages/repo-scripts/src/`), so both repo-maintenance scripts now share one testable home. Added `validate-docker-versions.test.ts` covering its `compareVersions` logic, and a `scripts/README.md` documenting when to use `scripts/` (bootstrap scripts that must run by bare `node`, e.g. `turbo-wrapper`/`install-playwright`) versus `packages/repo-scripts` (testable maintenance scripts). Updated every invocation — the `validate-docker` and `localci` root scripts, the lint-staged Dockerfile hook, and the CI "Validate Docker versions" step — plus the related doc/skill path references.

## Validation steps

- `pnpm test --filter @lsst-sqre/repo-scripts` (and full `pnpm test`) → the new tests pass, covering the `ok` / `version-only` / `drift` classifications (the `version-only` case is the regression guard for this change).
- In a sandbox with #466's firewall holes merged, run `pnpm run check-openapi-drift` from its new path and confirm it reaches all four live hosts and prints an accurate per-client report. Current live state: gafaelfawr skipped (no vendored spec), semaphore fetch-error (prod `/semaphore/openapi.json` 404s), repertoire in sync, times-square drift — overall exit non-zero.
- Confirm the times-square diff is reported as `drift`, not `version-only`: although `info.version` moved (`0.23.1.dev24+g576ef1393` → `0.23.1.dev38+g5df525f0e`), the live `ValidationError` schema also gained `ctx`/`input` properties, so this is a genuine API change. A spec differing **only** by `info.version` would instead print `version-only` and exit `0`.
- Trigger the new `Periodic CI` workflow manually from the Actions tab (`workflow_dispatch`) and confirm it runs the drift check and, on failure, notifies the SQuaRE Slack alert channel via `secrets.SLACK_ALERT_WEBHOOK`.
- `pnpm validate-docker` from its new path → finds `apps/squareone/Dockerfile` and reports Node/pnpm/Turbo all in sync (exit `0`). `pnpm test --filter @lsst-sqre/repo-scripts` → 15 tests pass across both script test files (the new `compareVersions` cases plus the existing drift-classification cases).

## References

- Closes #467
- PRD: #461
- Jira: https://rubinobs.atlassian.net/browse/DM-55225
