### PR TITLE
DM-55246: Add squared DataTable component

### DIFF
--- a/.changeset/squared-data-table.md
+++ b/.changeset/squared-data-table.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/squared': minor
+---
+
+Add a generic `DataTable` component backed by `@tanstack/react-table`. It renders rows from a `data` array using `columns` (`ColumnDef[]`), supports client-side sorting of the currently-loaded rows via sortable column headers, and exposes a caller-owned "Load more" footer for cursor pagination. Because rows arrive in the server's order (created-desc), client-side sorting reorders only the loaded rows rather than performing a global sort across unloaded pages.

--- a/packages/squared/package.json
+++ b/packages/squared/package.json
@@ -46,6 +46,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-tabs": "^1.1.7",
     "@radix-ui/react-visually-hidden": "^1.2.4",
+    "@tanstack/react-table": "^8.21.3",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.563.0",

--- a/packages/squared/src/components/DataTable/DataTable.module.css
+++ b/packages/squared/src/components/DataTable/DataTable.module.css
@@ -1,0 +1,106 @@
+/* DataTable styles */
+
+.wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  color: var(--rsd-component-text-color);
+}
+
+.caption {
+  caption-side: top;
+  text-align: left;
+  padding: 0 0 var(--sqo-space-xs) 0;
+  color: var(--rsd-color-gray-500);
+  font-size: 0.875rem;
+}
+
+.head {
+  border-bottom: 2px solid var(--rsd-color-gray-200);
+}
+
+.headerCell {
+  /* Reset default centered, bold th rendering */
+  text-align: left;
+  font-weight: 600;
+  color: var(--rsd-color-gray-700);
+  white-space: nowrap;
+  padding: 0;
+  vertical-align: bottom;
+}
+
+/* Non-sortable headers don't get a button, so pad the cell directly. */
+.headerCell:not(:has(.sortButton)) {
+  padding: var(--sqo-space-xs) var(--sqo-space-sm);
+}
+
+.sortButton {
+  /* A full-bleed button so the whole header cell is the click target. */
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sqo-space-xxs);
+  width: 100%;
+  padding: var(--sqo-space-xs) var(--sqo-space-sm);
+  border: none;
+  background: none;
+  font: inherit;
+  font-weight: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: var(--sqo-border-radius-1);
+  transition: var(--sqo-transition-basic);
+}
+
+.sortButton:hover {
+  background: var(--rsd-color-gray-50);
+  color: var(--rsd-color-primary-700);
+}
+
+.sortButton:focus-visible {
+  outline: 2px solid var(--rsd-color-primary-600);
+  outline-offset: -2px;
+}
+
+.headerLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sortIcon {
+  flex-shrink: 0;
+  color: var(--rsd-color-primary-600);
+}
+
+/* Inactive (sortable but not currently sorted) indicator is muted. */
+.sortIconInactive {
+  color: var(--rsd-color-gray-300);
+}
+
+.row {
+  border-bottom: 1px solid var(--rsd-color-gray-100);
+}
+
+.cell {
+  padding: var(--sqo-space-xs) var(--sqo-space-sm);
+  text-align: left;
+  vertical-align: top;
+}
+
+.emptyCell {
+  padding: var(--sqo-space-lg) var(--sqo-space-sm);
+  text-align: center;
+  color: var(--rsd-color-gray-500);
+}
+
+.footer {
+  display: flex;
+  justify-content: center;
+  padding: var(--sqo-space-md) 0 0 0;
+}

--- a/packages/squared/src/components/DataTable/DataTable.stories.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.stories.tsx
@@ -51,7 +51,8 @@ const meta: Meta<typeof DataTable> = {
       description: {
         component:
           'A generic, TanStack-Table-backed table. **Sorting caveat:** rows ' +
-          'arrive in the server order (created-desc for admin notifications). ' +
+          'arrive in the server order (for example created-desc, as in the ' +
+          'admin notifications UI). ' +
           'Clicking a sortable header sorts only the currently-loaded rows on ' +
           'the client — it does not re-query the server, so it is not a global ' +
           'sort across unloaded pages. "Load more" is a caller-owned slot: the ' +

--- a/packages/squared/src/components/DataTable/DataTable.stories.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.stories.tsx
@@ -1,0 +1,198 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ColumnDef } from '@tanstack/react-table';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Badge } from '../Badge';
+import { DataTable } from './DataTable';
+
+type NotificationRow = {
+  recipient: string;
+  sender: string;
+  created: string;
+  summary: string;
+};
+
+const columns: ColumnDef<NotificationRow>[] = [
+  { accessorKey: 'recipient', header: 'Recipient' },
+  { accessorKey: 'sender', header: 'Sender' },
+  { accessorKey: 'created', header: 'Created' },
+  { accessorKey: 'summary', header: 'Summary', enableSorting: false },
+];
+
+// Server order is most-recent-first (created-desc); recipients are
+// intentionally not alphabetical so an ascending sort visibly reorders.
+const rows: NotificationRow[] = [
+  {
+    recipient: 'zoya',
+    sender: 'times-square',
+    created: '2026-06-17 10:00 UTC',
+    summary: 'Your notebook finished executing.',
+  },
+  {
+    recipient: 'amir',
+    sender: 'mobu',
+    created: '2026-06-16 09:30 UTC',
+    summary: 'A monitored flock reported an error.',
+  },
+  {
+    recipient: 'mina',
+    sender: 'nublado',
+    created: '2026-06-15 08:15 UTC',
+    summary: 'Your CPU quota was increased.',
+  },
+];
+
+const meta: Meta<typeof DataTable> = {
+  title: 'Components/DataTable',
+  component: DataTable,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'A generic, TanStack-Table-backed table. **Sorting caveat:** rows ' +
+          'arrive in the server order (created-desc for admin notifications). ' +
+          'Clicking a sortable header sorts only the currently-loaded rows on ' +
+          'the client — it does not re-query the server, so it is not a global ' +
+          'sort across unloaded pages. "Load more" is a caller-owned slot: the ' +
+          'consumer fetches the next cursor page and appends it to `data`.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => <DataTable columns={columns} data={rows} />,
+};
+
+// Cells can render arbitrary React via a column `cell` renderer.
+export const WithRenderedCells: Story = {
+  name: 'With rendered cells',
+  render: () => {
+    const richColumns: ColumnDef<NotificationRow>[] = [
+      { accessorKey: 'recipient', header: 'Recipient' },
+      {
+        accessorKey: 'sender',
+        header: 'Sender',
+        cell: (info) => <Badge color="blue">{info.getValue<string>()}</Badge>,
+      },
+      { accessorKey: 'created', header: 'Created' },
+      { accessorKey: 'summary', header: 'Summary', enableSorting: false },
+    ];
+    return <DataTable columns={richColumns} data={rows} />;
+  },
+};
+
+export const Empty: Story = {
+  render: () => (
+    <DataTable
+      columns={columns}
+      data={[]}
+      emptyContent="No notifications match your filters."
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('No notifications match your filters.')
+    ).toBeInTheDocument();
+  },
+};
+
+// Loading is owned by the caller; the table only reflects it on the button.
+export const LoadingMore: Story = {
+  name: 'Loading more',
+  render: () => (
+    <DataTable
+      columns={columns}
+      data={rows}
+      hasMore
+      isLoadingMore
+      onLoadMore={() => {}}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('button', { name: /load more/i })
+    ).toBeDisabled();
+  },
+};
+
+// Interaction test: clicking a sortable header sorts the loaded rows.
+export const Sortable: Story = {
+  render: () => <DataTable columns={columns} data={rows} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Server order: the first body row is for recipient "zoya".
+    const initialBodyRows = canvas.getAllByRole('row').slice(1);
+    await expect(
+      within(initialBodyRows[0]).getByText('zoya')
+    ).toBeInTheDocument();
+
+    // Click the Recipient header to sort ascending.
+    await userEvent.click(canvas.getByRole('button', { name: /Recipient/ }));
+
+    await waitFor(async () => {
+      const sortedBodyRows = canvas.getAllByRole('row').slice(1);
+      await expect(
+        within(sortedBodyRows[0]).getByText('amir')
+      ).toBeInTheDocument();
+    });
+
+    // The header reports its sort state to assistive tech.
+    const recipientHeader = canvas.getByRole('columnheader', {
+      name: /Recipient/,
+    });
+    await expect(recipientHeader).toHaveAttribute('aria-sort', 'ascending');
+  },
+};
+
+// A stateful host that owns cursor loading; the table only exposes the slot.
+function LoadMoreDemo() {
+  const allRows: NotificationRow[] = Array.from({ length: 12 }, (_, i) => ({
+    recipient: `user-${String(i).padStart(2, '0')}`,
+    sender: 'mobu',
+    created: `2026-06-${String(17 - i).padStart(2, '0')} 12:00 UTC`,
+    summary: `Notification number ${i}`,
+  }));
+  const pageSize = 5;
+  const [visibleCount, setVisibleCount] = useState(pageSize);
+  const data = allRows.slice(0, visibleCount);
+
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      hasMore={visibleCount < allRows.length}
+      onLoadMore={() =>
+        setVisibleCount((count) => Math.min(count + pageSize, allRows.length))
+      }
+    />
+  );
+}
+
+// Interaction test: the "Load more" slot invokes the caller's handler,
+// which appends the next page of rows.
+export const LoadMore: Story = {
+  name: 'Load more',
+  render: () => <LoadMoreDemo />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 5 body rows + 1 header row to start.
+    await expect(canvas.getAllByRole('row')).toHaveLength(6);
+
+    await userEvent.click(canvas.getByRole('button', { name: /load more/i }));
+
+    await waitFor(() => {
+      // 10 body rows + 1 header row after one page.
+      expect(canvas.getAllByRole('row')).toHaveLength(11);
+    });
+  },
+};

--- a/packages/squared/src/components/DataTable/DataTable.test.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.test.tsx
@@ -26,6 +26,43 @@ describe('DataTable', () => {
     expect(container.querySelector('table')).toBeInTheDocument();
   });
 
+  it('applies aria-label to the table when no caption is provided', () => {
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={data}
+        aria-label="Recent notifications"
+      />
+    );
+
+    expect(container.querySelector('table')?.getAttribute('aria-label')).toBe(
+      'Recent notifications'
+    );
+  });
+
+  it('renders a visible caption', () => {
+    render(
+      <DataTable columns={columns} data={data} caption="Recent notifications" />
+    );
+
+    expect(screen.getByText('Recent notifications').tagName).toBe('CAPTION');
+  });
+
+  it('drops aria-label when a caption is present', () => {
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={data}
+        caption="Recent notifications"
+        aria-label="Recent notifications"
+      />
+    );
+
+    expect(container.querySelector('table')?.hasAttribute('aria-label')).toBe(
+      false
+    );
+  });
+
   it('renders a column header for each column def', () => {
     render(<DataTable columns={columns} data={data} />);
 

--- a/packages/squared/src/components/DataTable/DataTable.test.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.test.tsx
@@ -1,0 +1,136 @@
+import type { ColumnDef } from '@tanstack/react-table';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { DataTable } from './DataTable';
+
+type Row = { name: string; count: number };
+
+const columns: ColumnDef<Row>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'count', header: 'Count' },
+];
+
+// Intentionally not pre-sorted by name, so a single ascending sort click
+// visibly reorders the rows. This mirrors the server's created-desc order
+// being independent of any client-side column sort.
+const data: Row[] = [
+  { name: 'Bravo', count: 1 },
+  { name: 'Alpha', count: 3 },
+];
+
+describe('DataTable', () => {
+  it('renders a table element', () => {
+    const { container } = render(<DataTable columns={columns} data={data} />);
+
+    expect(container.querySelector('table')).toBeInTheDocument();
+  });
+
+  it('renders a column header for each column def', () => {
+    render(<DataTable columns={columns} data={data} />);
+
+    expect(
+      screen.getByRole('columnheader', { name: /Name/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: /Count/ })
+    ).toBeInTheDocument();
+  });
+
+  it('renders a body row for each data item with its cell values', () => {
+    render(<DataTable columns={columns} data={data} />);
+
+    // One header row + two data rows.
+    expect(screen.getAllByRole('row')).toHaveLength(3);
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+  });
+
+  it('shows the empty content when there are no rows', () => {
+    render(
+      <DataTable columns={columns} data={[]} emptyContent="No notifications" />
+    );
+
+    expect(screen.getByText('No notifications')).toBeInTheDocument();
+  });
+
+  it('does not render the Load more footer without onLoadMore', () => {
+    render(<DataTable columns={columns} data={data} />);
+
+    expect(
+      screen.queryByRole('button', { name: /load more/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders a Load more button and invokes the caller handler on click', async () => {
+    const onLoadMore = vi.fn();
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        hasMore
+        onLoadMore={onLoadMore}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /load more/i });
+    await userEvent.click(button);
+
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the Load more button when there is nothing more to load', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        hasMore={false}
+        onLoadMore={() => {}}
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /load more/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the Load more button while a load is in flight', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        hasMore
+        isLoadingMore
+        onLoadMore={() => {}}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /load more/i })).toBeDisabled();
+  });
+
+  it('sorts loaded rows client-side when a sortable header is clicked', async () => {
+    render(<DataTable columns={columns} data={data} />);
+
+    // Default order follows the data prop (server order): Bravo, then Alpha.
+    const initialCells = screen
+      .getAllByRole('cell')
+      .filter((cell) => /Alpha|Bravo/.test(cell.textContent ?? ''));
+    expect(initialCells[0]).toHaveTextContent('Bravo');
+
+    // Sorting by Name ascending reorders the loaded rows: Alpha before Bravo.
+    await userEvent.click(screen.getByRole('button', { name: /Name/ }));
+
+    const sortedCells = screen
+      .getAllByRole('cell')
+      .filter((cell) => /Alpha|Bravo/.test(cell.textContent ?? ''));
+    expect(sortedCells[0]).toHaveTextContent('Alpha');
+  });
+
+  it('applies a custom className to the table wrapper', () => {
+    const { container } = render(
+      <DataTable columns={columns} data={data} className="custom-class" />
+    );
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});

--- a/packages/squared/src/components/DataTable/DataTable.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from '@tanstack/react-table';
+import { ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react';
+import React from 'react';
+import { Button } from '../Button';
+import styles from './DataTable.module.css';
+
+export type DataTableProps<TData, TValue = unknown> = {
+  /** Column definitions, as TanStack Table `ColumnDef`s. */
+  columns: ColumnDef<TData, TValue>[];
+  /**
+   * The currently-loaded rows.
+   *
+   * Rows are expected in the server's order — for the admin notifications
+   * API that is most-recent-first (created-desc). Client-side sorting
+   * (below) reorders only these loaded rows, **not** the full server-side
+   * result set. See the caveat in the component description.
+   */
+  data: TData[];
+  /** Sort state applied on first render. Defaults to unsorted (server order). */
+  initialSorting?: SortingState;
+  /**
+   * Whether more rows are available from the server. When `true` (and an
+   * `onLoadMore` handler is supplied) the "Load more" footer is shown.
+   */
+  hasMore?: boolean;
+  /**
+   * Invoked when the user activates "Load more". The caller owns fetching
+   * the next page and appending it to `data`; the table never loads data
+   * itself.
+   */
+  onLoadMore?: () => void;
+  /**
+   * Whether a "Load more" request is currently in flight. Loading is owned
+   * by the caller; the table only reflects it on the button.
+   */
+  isLoadingMore?: boolean;
+  /** Label for the "Load more" button. */
+  loadMoreLabel?: string;
+  /** Content rendered in the table body when there are no rows. */
+  emptyContent?: React.ReactNode;
+  /** Optional visible caption describing the table. */
+  caption?: React.ReactNode;
+  /** Accessible label for the table, used when there is no visible caption. */
+  'aria-label'?: string;
+  /** Additional class name applied to the wrapper element. */
+  className?: string;
+};
+
+type SortDirection = false | 'asc' | 'desc';
+
+function SortIndicator({ direction }: { direction: SortDirection }) {
+  if (direction === 'asc') {
+    return (
+      <ChevronUp className={styles.sortIcon} size={16} aria-hidden="true" />
+    );
+  }
+  if (direction === 'desc') {
+    return (
+      <ChevronDown className={styles.sortIcon} size={16} aria-hidden="true" />
+    );
+  }
+  return (
+    <ChevronsUpDown
+      className={[styles.sortIcon, styles.sortIconInactive].join(' ')}
+      size={16}
+      aria-hidden="true"
+    />
+  );
+}
+
+/**
+ * A generic, reusable table built on TanStack Table.
+ *
+ * `DataTable` renders the rows it is given (`data`) using the supplied
+ * `columns`, with optional client-side sorting and a caller-owned
+ * "Load more" footer for cursor pagination.
+ *
+ * ## Sorting + cursor pagination caveat
+ *
+ * Rows arrive in the server's order (created-desc for the admin
+ * notifications API). Clicking a sortable column header sorts only the
+ * **currently-loaded** rows on the client — it does not re-query the
+ * server, so it does not produce a globally-sorted result across pages
+ * that have not been loaded. "Load more" appends the next cursor page (in
+ * server order) and the active client sort is then re-applied to the
+ * larger loaded set. This is acceptable for an admin triage view; it is
+ * intentionally not a global sort.
+ *
+ * @example
+ * ```tsx
+ * <DataTable
+ *   columns={columns}
+ *   data={rows}
+ *   hasMore={hasMore}
+ *   isLoadingMore={isLoadingMore}
+ *   onLoadMore={loadMore}
+ * />
+ * ```
+ */
+export function DataTable<TData, TValue = unknown>({
+  columns,
+  data,
+  initialSorting = [],
+  hasMore = false,
+  onLoadMore,
+  isLoadingMore = false,
+  loadMoreLabel = 'Load more',
+  emptyContent = 'No data to display.',
+  caption,
+  'aria-label': ariaLabel,
+  className,
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = React.useState<SortingState>(initialSorting);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  const rows = table.getRowModel().rows;
+  const columnCount = table.getAllLeafColumns().length || 1;
+  const showLoadMore = hasMore && typeof onLoadMore === 'function';
+
+  const wrapperClassName = [styles.wrapper, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={wrapperClassName}>
+      <table className={styles.table} aria-label={ariaLabel}>
+        {caption ? (
+          <caption className={styles.caption}>{caption}</caption>
+        ) : null}
+        <thead className={styles.head}>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id} className={styles.row}>
+              {headerGroup.headers.map((header) => {
+                const canSort = header.column.getCanSort();
+                const sortDirection = header.column.getIsSorted();
+                const ariaSort =
+                  sortDirection === 'asc'
+                    ? 'ascending'
+                    : sortDirection === 'desc'
+                      ? 'descending'
+                      : canSort
+                        ? 'none'
+                        : undefined;
+                const headerContent = header.isPlaceholder
+                  ? null
+                  : flexRender(
+                      header.column.columnDef.header,
+                      header.getContext()
+                    );
+
+                return (
+                  <th
+                    key={header.id}
+                    scope="col"
+                    aria-sort={ariaSort}
+                    className={styles.headerCell}
+                  >
+                    {canSort && !header.isPlaceholder ? (
+                      <button
+                        type="button"
+                        className={styles.sortButton}
+                        onClick={header.column.getToggleSortingHandler()}
+                      >
+                        <span className={styles.headerLabel}>
+                          {headerContent}
+                        </span>
+                        <SortIndicator direction={sortDirection} />
+                      </button>
+                    ) : (
+                      headerContent
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {rows.length === 0 ? (
+            <tr className={styles.row}>
+              <td className={styles.emptyCell} colSpan={columnCount}>
+                {emptyContent}
+              </td>
+            </tr>
+          ) : (
+            rows.map((row) => (
+              <tr key={row.id} className={styles.row}>
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className={styles.cell}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+
+      {showLoadMore ? (
+        <div className={styles.footer}>
+          <Button
+            appearance="outline"
+            tone="secondary"
+            size="sm"
+            onClick={onLoadMore}
+            loading={isLoadingMore}
+          >
+            {loadMoreLabel}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default DataTable;

--- a/packages/squared/src/components/DataTable/DataTable.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.tsx
@@ -49,7 +49,11 @@ export type DataTableProps<TData, TValue = unknown> = {
   emptyContent?: React.ReactNode;
   /** Optional visible caption describing the table. */
   caption?: React.ReactNode;
-  /** Accessible label for the table, used when there is no visible caption. */
+  /**
+   * Accessible label for the table. Used only when there is no visible
+   * `caption`; if a `caption` is provided it takes precedence and this is
+   * ignored.
+   */
   'aria-label'?: string;
   /** Additional class name applied to the wrapper element. */
   className?: string;
@@ -140,7 +144,10 @@ export function DataTable<TData, TValue = unknown>({
 
   return (
     <div className={wrapperClassName}>
-      <table className={styles.table} aria-label={ariaLabel}>
+      <table
+        className={styles.table}
+        aria-label={caption ? undefined : ariaLabel}
+      >
         {caption ? (
           <caption className={styles.caption}>{caption}</caption>
         ) : null}

--- a/packages/squared/src/components/DataTable/DataTable.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.tsx
@@ -19,10 +19,11 @@ export type DataTableProps<TData, TValue = unknown> = {
   /**
    * The currently-loaded rows.
    *
-   * Rows are expected in the server's order — for the admin notifications
-   * API that is most-recent-first (created-desc). Client-side sorting
-   * (below) reorders only these loaded rows, **not** the full server-side
-   * result set. See the caveat in the component description.
+   * Rows are expected in the server's order — for example an API that
+   * returns most-recent-first (created-desc), as the admin notifications
+   * UI does. Client-side sorting (below) reorders only these loaded rows,
+   * **not** the full server-side result set. See the caveat in the
+   * component description.
    */
   data: TData[];
   /** Sort state applied on first render. Defaults to unsorted (server order). */
@@ -90,14 +91,14 @@ function SortIndicator({ direction }: { direction: SortDirection }) {
  *
  * ## Sorting + cursor pagination caveat
  *
- * Rows arrive in the server's order (created-desc for the admin
- * notifications API). Clicking a sortable column header sorts only the
- * **currently-loaded** rows on the client — it does not re-query the
+ * Rows arrive in the server's order (for example created-desc, as in the
+ * admin notifications UI). Clicking a sortable column header sorts only
+ * the **currently-loaded** rows on the client — it does not re-query the
  * server, so it does not produce a globally-sorted result across pages
  * that have not been loaded. "Load more" appends the next cursor page (in
  * server order) and the active client sort is then re-applied to the
- * larger loaded set. This is acceptable for an admin triage view; it is
- * intentionally not a global sort.
+ * larger loaded set. This is acceptable for use cases like an admin triage
+ * view; it is intentionally not a global sort.
  *
  * @example
  * ```tsx

--- a/packages/squared/src/components/DataTable/DataTable.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.tsx
@@ -13,9 +13,17 @@ import React from 'react';
 import { Button } from '../Button';
 import styles from './DataTable.module.css';
 
-export type DataTableProps<TData, TValue = unknown> = {
-  /** Column definitions, as TanStack Table `ColumnDef`s. */
-  columns: ColumnDef<TData, TValue>[];
+export type DataTableProps<TData> = {
+  /**
+   * Column definitions, as TanStack Table `ColumnDef`s.
+   *
+   * The value type is `any` per column rather than one shared generic, so a
+   * heterogeneous set of columns — each with its own accessor value type —
+   * can be passed without widening them all to a single type. This is
+   * TanStack's idiomatic signature for table wrapper components.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: per-column value types; TanStack's idiomatic wrapper signature
+  columns: ColumnDef<TData, any>[];
   /**
    * The currently-loaded rows.
    *
@@ -111,7 +119,7 @@ function SortIndicator({ direction }: { direction: SortDirection }) {
  * />
  * ```
  */
-export function DataTable<TData, TValue = unknown>({
+export function DataTable<TData>({
   columns,
   data,
   initialSorting = [],
@@ -123,7 +131,7 @@ export function DataTable<TData, TValue = unknown>({
   caption,
   'aria-label': ariaLabel,
   className,
-}: DataTableProps<TData, TValue>) {
+}: DataTableProps<TData>) {
   const [sorting, setSorting] = React.useState<SortingState>(initialSorting);
 
   const table = useReactTable({

--- a/packages/squared/src/components/DataTable/index.ts
+++ b/packages/squared/src/components/DataTable/index.ts
@@ -1,0 +1,2 @@
+export * from './DataTable';
+export { default } from './DataTable';

--- a/packages/squared/src/index.ts
+++ b/packages/squared/src/index.ts
@@ -23,6 +23,8 @@ export type { CheckboxGroupProps } from './components/CheckboxGroup';
 export { CheckboxGroup } from './components/CheckboxGroup';
 export type { ClipboardButtonProps } from './components/ClipboardButton';
 export { default as ClipboardButton } from './components/ClipboardButton';
+export type { DataTableProps } from './components/DataTable';
+export { DataTable } from './components/DataTable';
 export type {
   DateTimePickerProps,
   TimeInputProps,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,6 +470,9 @@ importers:
       '@radix-ui/react-visually-hidden':
         specifier: ^1.2.4
         version: 1.2.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
@@ -3709,6 +3712,17 @@ packages:
     resolution: {integrity: sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -11880,6 +11894,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
+
+  '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary

- Add a generic, reusable `DataTable` to `@lsst-sqre/squared` (backed by `@tanstack/react-table`) so future admin/data screens can render tabular data consistently (PRD user stories 37–39).
- The table renders rows from `data` using `columns` (`ColumnDef[]`), supports client-side sorting of the currently-loaded rows via sortable column headers, and exposes a caller-owned "Load more" footer for cursor pagination.
- Because server order is most-recent-first (created-desc), client-side sorting reorders only the loaded rows rather than performing a global sort across unloaded pages — this caveat is documented on the component and in its stories.

## Validation steps

- Run `pnpm storybook --filter @lsst-sqre/squared` and open **Components / DataTable**; confirm the Default, With rendered cells, Sortable, Load more, Loading more, and Empty stories all render.
- In the **Sortable** story, click a column header and confirm the loaded rows reorder and the header exposes its sort direction (chevron + `aria-sort`).
- In the **Load more** story, click "Load more" and confirm additional rows append below the existing ones.
- In the **Loading more** story, confirm the "Load more" button shows its loading state and is disabled.

## References

- Closes #475
- PRD: #474
- Jira: https://rubinobs.atlassian.net/browse/DM-55246