### PR TITLE
DM-55246: Add semaphore-client admin notification support

### DIFF
--- a/.changeset/semaphore-admin-notification-create.md
+++ b/.changeset/semaphore-admin-notification-create.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/semaphore-client': minor
+---
+
+Add the Semaphore admin notifications **create** layer. A new Zod schema (`CreateUserNotificationSchema`) and inferred `CreateUserNotification` type model the `{ recipient, summary, body? }` create payload. The client function `createAdminNotification(semaphoreUrl, notification, csrfToken)` POSTs to `/v1/admin/notifications` with `credentials: 'include'` and the Gafaelfawr `x-csrf-token` header, returning the created `UserNotificationWithUrl`. A new `mutation-options` module ships `createAdminNotificationMutationOptions` (and the `CreateAdminNotificationVariables` type), whose `onSuccess` invalidates the admin-notifications list query, and the `useCreateAdminNotification(semaphoreUrl)` hook exposes the create mutation.

--- a/.changeset/semaphore-admin-notification-reads.md
+++ b/.changeset/semaphore-admin-notification-reads.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/semaphore-client': minor
+---
+
+Add the Semaphore admin notifications **read** layer. New Zod schemas (`UserNotificationSchema`, `UserNotificationWithUrlSchema`) and inferred types model the admin list/detail payloads, where `summary` and `body` are raw Markdown. New client functions `fetchAdminNotifications` (parses the RFC 5988 `Link` header for the next cursor and `X-Total-Count` for the total, and applies the `recipient`/`sender`/`since`/`until` filters) and `fetchAdminNotification` back two new TanStack Query option factories (`adminNotificationsInfiniteQueryOptions`, `adminNotificationQueryOptions`) and hooks (`useAdminNotifications` exposing `{ entries, hasMore, loadMore, isLoadingMore, totalCount }`, `useAdminNotification`). A new `mock-notifications` module ships a fixture dataset plus a pure filter+paginate helper for dev API routes and Storybook stories.

--- a/packages/semaphore-client/openapi.json
+++ b/packages/semaphore-client/openapi.json
@@ -1,9 +1,9 @@
 {
-  "openapi": "3.0.2",
+  "openapi": "3.1.0",
   "info": {
     "title": "Semaphore",
     "description": "Semaphore is the user message and notification system for the Rubin Science Platform.\n\nYou can find Semaphore's user and developer documentation at [https://semaphore.lsst.io](https://semaphore.lsst.io). Semaphore is developed at [https://github.com/lsst-sqre/semaphore](https://github.com/lsst-sqre/semaphore)",
-    "version": "0.5.0"
+    "version": "0.1.dev1+g482752235"
   },
   "paths": {
     "/": {
@@ -68,12 +68,339 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "title": "Response Get Broadcasts Semaphore V1 Broadcasts Get",
-                  "type": "array",
                   "items": {
                     "$ref": "#/components/schemas/BroadcastMessageModel"
-                  }
+                  },
+                  "type": "array",
+                  "title": "Response Get Broadcasts Semaphore V1 Broadcasts Get"
                 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/semaphore/v1/admin/notifications": {
+      "post": {
+        "tags": ["admin", "notifications"],
+        "summary": "Create admin notification",
+        "description": "Send an admin notification to a user.",
+        "operationId": "admin_create_notification_semaphore_v1_admin_notifications_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserNotification"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserNotificationWithUrl"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["admin", "notifications"],
+        "summary": "List admin notifications",
+        "description": "List all current admin notifications.",
+        "operationId": "admin_list_notifications_semaphore_v1_admin_notifications_get",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "string", "pattern": "^p?[0-9]+_[0-9]+$" },
+                { "type": "null" }
+              ],
+              "title": "Cursor",
+              "description": "Pagination cursor",
+              "examples": ["1614985055_4234"]
+            },
+            "description": "Pagination cursor"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "integer", "minimum": 1 },
+                { "type": "null" }
+              ],
+              "title": "Row limit",
+              "description": "Maximum number of notifications to return.",
+              "examples": [500]
+            },
+            "description": "Maximum number of notifications to return."
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/UtcDatetime" },
+                { "type": "null" }
+              ],
+              "title": "Not before",
+              "description": "Only show entries at or after this time.",
+              "examples": ["2021-03-05T14:59:52Z"]
+            },
+            "description": "Only show entries at or after this time."
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/UtcDatetime" },
+                { "type": "null" }
+              ],
+              "title": "Not after",
+              "description": "Only show entries before or at this time.",
+              "examples": ["2021-03-05T14:59:52Z"]
+            },
+            "description": "Only show entries before or at this time."
+          },
+          {
+            "name": "recipient",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "Recipient",
+              "description": "Limit notifications to this recipient.",
+              "examples": ["username"]
+            },
+            "description": "Limit notifications to this recipient."
+          },
+          {
+            "name": "sender",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "Sender",
+              "description": "Limit notifications to this sender.",
+              "examples": ["bot-quota"]
+            },
+            "description": "Limit notifications to this sender."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserNotificationWithUrl"
+                  },
+                  "title": "Response Admin List Notifications Semaphore V1 Admin Notifications Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/semaphore/v1/admin/notifications/{id}": {
+      "get": {
+        "tags": ["admin", "notifications"],
+        "summary": "Get admin notification",
+        "description": "Retrieve a specific admin notification.",
+        "operationId": "admin_get_notification_semaphore_v1_admin_notifications__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Id" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserNotification" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/semaphore/v1/notifications": {
+      "get": {
+        "tags": ["notifications"],
+        "summary": "List notifications",
+        "description": "List all current notifications for the authenticated user.",
+        "operationId": "list_notifications_semaphore_v1_notifications_get",
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "string", "pattern": "^p?[0-9]+_[0-9]+$" },
+                { "type": "null" }
+              ],
+              "title": "Cursor",
+              "description": "Pagination cursor",
+              "examples": ["1614985055_4234"]
+            },
+            "description": "Pagination cursor"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "integer", "minimum": 1 },
+                { "type": "null" }
+              ],
+              "title": "Row limit",
+              "description": "Maximum number of notifications to return.",
+              "examples": [500]
+            },
+            "description": "Maximum number of notifications to return."
+          },
+          {
+            "name": "unread",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "title": "Only unread",
+              "description": "Only show unread notifications.",
+              "default": false
+            },
+            "description": "Only show unread notifications."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserNotificationSummary"
+                  },
+                  "title": "Response List Notifications Semaphore V1 Notifications Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/semaphore/v1/notifications/{id}": {
+      "get": {
+        "tags": ["notifications"],
+        "summary": "Get admin notification",
+        "description": "Retrieve a specific admin notification.",
+        "operationId": "get_notification_semaphore_v1_notifications__id__get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Id" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserNotificationFormatted"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/semaphore/v1/notifications/read": {
+      "post": {
+        "tags": ["notifications"],
+        "summary": "Mark notifications read",
+        "description": "Mark a list of notifications read. Notifications that do not exist or that are already marked as read are silently ignored. Returning errors for nonexistent notifications is not useful since there may be race conditions with services revoking notifications.",
+        "operationId": "post_notification_read_semaphore_v1_notifications_read_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UserNotificationRead" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
               }
             }
           }
@@ -84,116 +411,451 @@
   "components": {
     "schemas": {
       "BroadcastCategory": {
-        "title": "BroadcastCategory",
-        "enum": ["outage", "info", "notice"],
         "type": "string",
+        "enum": ["outage", "info", "notice"],
+        "title": "BroadcastCategory",
         "description": "Broadcast message categories."
       },
       "BroadcastMessageModel": {
-        "title": "BroadcastMessageModel",
-        "required": ["id", "summary", "active", "enabled", "stale", "category"],
-        "type": "object",
         "properties": {
-          "id": { "title": "The message's identifier", "type": "string" },
+          "id": { "type": "string", "title": "The message's identifier" },
           "summary": {
-            "title": "The message summary",
-            "allOf": [{ "$ref": "#/components/schemas/FormattedText" }]
+            "$ref": "#/components/schemas/semaphore__handlers__v1__models__FormattedText",
+            "title": "The message summary"
           },
           "body": {
-            "title": "The body content (optional).",
-            "allOf": [{ "$ref": "#/components/schemas/FormattedText" }]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/semaphore__handlers__v1__models__FormattedText"
+              },
+              { "type": "null" }
+            ],
+            "title": "The body content (optional)."
           },
           "active": {
-            "title": "Whether the message should be displayed",
             "type": "boolean",
+            "title": "Whether the message should be displayed",
             "description": "True if the message should be broadcast based on its schedule and being enabled."
           },
           "enabled": {
-            "title": "Toggle for whether the message is enabled",
             "type": "boolean",
+            "title": "Toggle for whether the message is enabled",
             "description": "When false, the message isn't shown even if it is scheduled"
           },
           "stale": {
-            "title": "Flag indicated the message is stable",
             "type": "boolean",
+            "title": "Flag indicated the message is stable",
             "description": "True if the message has no future scheduled broadcast events."
           },
           "category": {
-            "title": "Category of the message.",
-            "allOf": [{ "$ref": "#/components/schemas/BroadcastCategory" }]
+            "$ref": "#/components/schemas/BroadcastCategory",
+            "title": "Category of the message."
           }
         },
+        "type": "object",
+        "required": [
+          "id",
+          "summary",
+          "body",
+          "active",
+          "enabled",
+          "stale",
+          "category"
+        ],
+        "title": "BroadcastMessageModel",
         "description": "A broadcast message."
       },
-      "FormattedText": {
-        "title": "FormattedText",
-        "required": ["gfm", "html"],
-        "type": "object",
+      "CreateUserNotification": {
         "properties": {
-          "gfm": {
-            "title": "The GitHub-flavored Markdown-formatted text.",
-            "type": "string"
+          "recipient": {
+            "type": "string",
+            "title": "Recipient",
+            "description": "Username to whom to send the notification.",
+            "examples": ["some-user"]
           },
-          "html": { "title": "The HTML-formatted text.", "type": "string" }
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "Short summary in Markdown format. This will be shown in the message list. This may only use inline formatting.",
+            "examples": ["You are approaching your disk space quota limit"]
+          },
+          "body": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Message body",
+            "description": "Optional message body. This can use full Markdown formatting including lists and headings.",
+            "examples": [
+              "You are using 448GiB of disk out of a quota of 500GiB."
+            ]
+          }
         },
-        "description": "Text that is formatted in both markdown and HTML."
+        "type": "object",
+        "required": ["recipient", "summary"],
+        "title": "CreateUserNotification",
+        "description": "Input for creating a new user notification."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": { "$ref": "#/components/schemas/ValidationError" },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
       },
       "Index": {
-        "title": "Index",
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/Metadata",
+            "title": "Package metadata"
+          },
+          "github_app_id": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Github App Id"
+          },
+          "github_app_enabled": {
+            "type": "boolean",
+            "title": "Github App Enabled"
+          },
+          "api_docs_path": { "type": "string", "title": "Api Docs Path" },
+          "openapi_path": { "type": "string", "title": "Openapi Path" }
+        },
+        "type": "object",
         "required": [
           "metadata",
+          "github_app_id",
           "github_app_enabled",
           "api_docs_path",
           "openapi_path"
         ],
-        "type": "object",
-        "properties": {
-          "metadata": {
-            "title": "Package metadata",
-            "allOf": [{ "$ref": "#/components/schemas/Metadata" }]
-          },
-          "github_app_id": { "title": "Github App Id", "type": "string" },
-          "github_app_enabled": {
-            "title": "Github App Enabled",
-            "type": "boolean"
-          },
-          "api_docs_path": { "title": "Api Docs Path", "type": "string" },
-          "openapi_path": { "title": "Openapi Path", "type": "string" }
-        },
+        "title": "Index",
         "description": "The application's root response, including metadata and information\nabout the APIs."
       },
       "Metadata": {
-        "title": "Metadata",
-        "required": ["name", "version"],
-        "type": "object",
         "properties": {
           "name": {
-            "title": "Application name",
             "type": "string",
-            "example": "myapp"
+            "title": "Application name",
+            "examples": ["myapp"]
           },
           "version": {
-            "title": "Version",
             "type": "string",
-            "example": "1.0.0"
+            "title": "Version",
+            "examples": ["1.0.0"]
           },
           "description": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Description",
-            "type": "string",
-            "example": "string"
+            "examples": ["Some package description"]
           },
           "repository_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Repository URL",
-            "type": "string",
-            "example": "https://example.com/"
+            "examples": ["https://example.com/"]
           },
           "documentation_url": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
             "title": "Documentation URL",
-            "type": "string",
-            "example": "https://example.com/"
+            "examples": ["https://example.com/"]
           }
         },
+        "type": "object",
+        "required": ["name", "version"],
+        "title": "Metadata",
         "description": "Metadata about a package."
+      },
+      "UserNotification": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Message ID",
+            "description": "Unique message ID for this message. Clients should not make any assumptions about the structure of this ID and should treat it as an opaque string.",
+            "examples": ["4561-a7513"]
+          },
+          "created": {
+            "$ref": "#/components/schemas/UtcDatetime",
+            "title": "Created date",
+            "description": "When the message was sent.",
+            "examples": ["2026-06-12T17:10:32-00:00"]
+          },
+          "read": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/UtcDatetime" },
+              { "type": "null" }
+            ],
+            "title": "Read date",
+            "description": "When the notification was read by its recipient, or null if the notification has not been read.",
+            "examples": ["2026-06-13T14:45:12-00:00"]
+          },
+          "sender": {
+            "type": "string",
+            "title": "Sender",
+            "description": "Username of the agent that sent the notification.",
+            "examples": ["bot-quota-notifier"]
+          },
+          "recipient": {
+            "type": "string",
+            "title": "Recipient",
+            "description": "Username to whom the notiication was sent.",
+            "examples": ["some-user"]
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "Short summary in Markdown format.",
+            "examples": ["You are approaching your disk space quota limit"]
+          },
+          "body": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Message body",
+            "description": "Optional body, or null if there is no body.",
+            "examples": [
+              "You are using 448GiB of disk out of a quota of 500GiB."
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "created",
+          "read",
+          "sender",
+          "recipient",
+          "summary",
+          "body"
+        ],
+        "title": "UserNotification",
+        "description": "Model for a created but not formatted user notification."
+      },
+      "UserNotificationFormatted": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Message ID",
+            "description": "Unique message ID for this message. Clients should not make any assumptions about the structure of this ID and should treat it as an opaque string.",
+            "examples": ["4561-a7513"]
+          },
+          "created": {
+            "$ref": "#/components/schemas/UtcDatetime",
+            "title": "Created date",
+            "description": "When the message was sent.",
+            "examples": ["2026-06-12T17:10:32-00:00"]
+          },
+          "read": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/UtcDatetime" },
+              { "type": "null" }
+            ],
+            "title": "Read date",
+            "description": "When the notification was read by its recipient, or null if the notification has not been read.",
+            "examples": ["2026-06-13T14:45:12-00:00"]
+          },
+          "summary": {
+            "$ref": "#/components/schemas/semaphore__models__notification__FormattedText",
+            "title": "Summary",
+            "description": "Will be formatted for inline context."
+          },
+          "body": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/semaphore__models__notification__FormattedText"
+              },
+              { "type": "null" }
+            ],
+            "title": "Message body",
+            "description": "Will be formatted for block context."
+          }
+        },
+        "type": "object",
+        "required": ["id", "created", "read", "summary", "body"],
+        "title": "UserNotificationFormatted",
+        "description": "The full formatted user notification for user-facing UIs."
+      },
+      "UserNotificationRead": {
+        "properties": {
+          "ids": {
+            "items": { "type": "string" },
+            "type": "array",
+            "uniqueItems": true,
+            "title": "Notification IDs",
+            "description": "These notifications will be marked as read at the current time if they are not already marked as read."
+          }
+        },
+        "type": "object",
+        "required": ["ids"],
+        "title": "UserNotificationRead",
+        "description": "Notification IDs to mark as read."
+      },
+      "UserNotificationSummary": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Message ID",
+            "description": "Unique message ID for this message. Clients should not make any assumptions about the structure of this ID and should treat it as an opaque string.",
+            "examples": ["4561-a7513"]
+          },
+          "created": {
+            "$ref": "#/components/schemas/UtcDatetime",
+            "title": "Created date",
+            "description": "When the message was sent.",
+            "examples": ["2026-06-12T17:10:32-00:00"]
+          },
+          "read": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/UtcDatetime" },
+              { "type": "null" }
+            ],
+            "title": "Read date",
+            "description": "When the notification was read by its recipient, or null if the notification has not been read.",
+            "examples": ["2026-06-13T14:45:12-00:00"]
+          },
+          "summary": {
+            "$ref": "#/components/schemas/semaphore__models__notification__FormattedText",
+            "title": "Summary",
+            "description": "Will be formatted for inline context."
+          },
+          "url": {
+            "type": "string",
+            "maxLength": 2083,
+            "minLength": 1,
+            "format": "uri",
+            "title": "URL",
+            "description": "URL to the sent notification.",
+            "examples": [
+              "https://data.example.com/semaphore/v1/admin/notifications/4561-a7513"
+            ]
+          }
+        },
+        "type": "object",
+        "required": ["id", "created", "read", "summary", "url"],
+        "title": "UserNotificationSummary",
+        "description": "User notification with a formatted summary but no body.\n\nReturned in lists of notifications to display to a user. Includes a URL\nfrom which the full notification including the formatted body can be\nreturned."
+      },
+      "UserNotificationWithUrl": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Message ID",
+            "description": "Unique message ID for this message. Clients should not make any assumptions about the structure of this ID and should treat it as an opaque string.",
+            "examples": ["4561-a7513"]
+          },
+          "created": {
+            "$ref": "#/components/schemas/UtcDatetime",
+            "title": "Created date",
+            "description": "When the message was sent.",
+            "examples": ["2026-06-12T17:10:32-00:00"]
+          },
+          "read": {
+            "anyOf": [
+              { "$ref": "#/components/schemas/UtcDatetime" },
+              { "type": "null" }
+            ],
+            "title": "Read date",
+            "description": "When the notification was read by its recipient, or null if the notification has not been read.",
+            "examples": ["2026-06-13T14:45:12-00:00"]
+          },
+          "sender": {
+            "type": "string",
+            "title": "Sender",
+            "description": "Username of the agent that sent the notification.",
+            "examples": ["bot-quota-notifier"]
+          },
+          "recipient": {
+            "type": "string",
+            "title": "Recipient",
+            "description": "Username to whom the notiication was sent.",
+            "examples": ["some-user"]
+          },
+          "summary": {
+            "type": "string",
+            "title": "Summary",
+            "description": "Short summary in Markdown format.",
+            "examples": ["You are approaching your disk space quota limit"]
+          },
+          "body": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "title": "Message body",
+            "description": "Optional body, or null if there is no body.",
+            "examples": [
+              "You are using 448GiB of disk out of a quota of 500GiB."
+            ]
+          },
+          "url": {
+            "type": "string",
+            "maxLength": 2083,
+            "minLength": 1,
+            "format": "uri",
+            "title": "URL",
+            "description": "URL to the sent notification.",
+            "examples": [
+              "https://data.example.com/semaphore/v1/admin/notifications/4561-a7513"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "created",
+          "read",
+          "sender",
+          "recipient",
+          "summary",
+          "body",
+          "url"
+        ],
+        "title": "UserNotificationWithUrl",
+        "description": "User notification with URL.\n\nReturned in lists of user notifications so that each notification in the\nlist has a URL to retrieve or manipulate the notification."
+      },
+      "UtcDatetime": { "type": "string", "format": "date-time" },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": { "anyOf": [{ "type": "string" }, { "type": "integer" }] },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": { "type": "string", "title": "Message" },
+          "type": { "type": "string", "title": "Error Type" },
+          "input": { "title": "Input" },
+          "ctx": { "type": "object", "title": "Context" }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      },
+      "semaphore__handlers__v1__models__FormattedText": {
+        "properties": {
+          "gfm": {
+            "type": "string",
+            "title": "The GitHub-flavored Markdown-formatted text."
+          },
+          "html": { "type": "string", "title": "The HTML-formatted text." }
+        },
+        "type": "object",
+        "required": ["gfm", "html"],
+        "title": "FormattedText",
+        "description": "Text that is formatted in both markdown and HTML."
+      },
+      "semaphore__models__notification__FormattedText": {
+        "properties": {
+          "gfm": {
+            "type": "string",
+            "title": "Markdown text",
+            "description": "The GitHub Flavored Markdown-formatted text.",
+            "examples": ["Some *Markdown* text."]
+          },
+          "html": {
+            "type": "string",
+            "title": "HTML text",
+            "description": "The HTML-formatted text.",
+            "examples": ["Some <em>HTML</em> text."]
+          }
+        },
+        "type": "object",
+        "required": ["gfm", "html"],
+        "title": "FormattedText",
+        "description": "Text that is formatted in both Markdown and HTML."
       }
     }
   }

--- a/packages/semaphore-client/src/client.notifications.test.ts
+++ b/packages/semaphore-client/src/client.notifications.test.ts
@@ -219,6 +219,32 @@ describe('createAdminNotification', () => {
     expect(body).not.toHaveProperty('body');
   });
 
+  it('strips stray keys from the payload before sending', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ ...detailPayload, url: listPayload[0].url }),
+        {
+          status: 200,
+        }
+      )
+    );
+
+    await createAdminNotification(
+      'https://example.com/semaphore',
+      {
+        recipient: 'some-user',
+        summary: 'Heads up',
+        // @ts-expect-error - exercising runtime stripping of unknown keys
+        extra: 'should not be sent',
+      },
+      'csrf-token-abc'
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+    expect(body).toEqual({ recipient: 'some-user', summary: 'Heads up' });
+    expect(body).not.toHaveProperty('extra');
+  });
+
   it('returns the created notification parsed from the response', async () => {
     const created = {
       ...detailPayload,

--- a/packages/semaphore-client/src/client.notifications.test.ts
+++ b/packages/semaphore-client/src/client.notifications.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchAdminNotification,
+  fetchAdminNotifications,
+  SemaphoreError,
+} from './client';
+
+const listPayload = [
+  {
+    id: '4561-a7513',
+    created: '2026-06-12T17:10:32+00:00',
+    read: null,
+    sender: 'bot-quota-notifier',
+    recipient: 'some-user',
+    summary: 'You are approaching your disk space quota limit',
+    body: 'You are using 448GiB of disk out of a quota of 500GiB.',
+    url: 'https://example.com/semaphore/v1/admin/notifications/4561-a7513',
+  },
+];
+
+const detailPayload = {
+  id: '4561-a7513',
+  created: '2026-06-12T17:10:32+00:00',
+  read: null,
+  sender: 'bot-quota-notifier',
+  recipient: 'some-user',
+  summary: 'You are approaching your disk space quota limit',
+  body: 'You are using 448GiB of disk out of a quota of 500GiB.',
+};
+
+describe('fetchAdminNotifications', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('parses entries and maps Link header to nextCursor and X-Total-Count to totalCount', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(listPayload), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          Link: '<https://example.com/semaphore/v1/admin/notifications?cursor=1614985055_4234>; rel="next"',
+          'X-Total-Count': '42',
+        },
+      })
+    );
+
+    const page = await fetchAdminNotifications('https://example.com/semaphore');
+
+    expect(page.entries).toEqual(listPayload);
+    expect(page.nextCursor).toBe('1614985055_4234');
+    expect(page.totalCount).toBe(42);
+  });
+
+  it('returns null nextCursor and totalCount when headers are absent', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(listPayload), { status: 200 })
+    );
+
+    const page = await fetchAdminNotifications('https://example.com/semaphore');
+
+    expect(page.nextCursor).toBeNull();
+    expect(page.totalCount).toBeNull();
+  });
+
+  it('applies recipient, sender, since, until, limit, and cursor query params', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }));
+
+    await fetchAdminNotifications(
+      'https://example.com/semaphore',
+      {
+        recipient: 'some-user',
+        sender: 'bot-quota',
+        since: new Date('2026-01-01T00:00:00Z'),
+        until: new Date('2026-02-01T00:00:00Z'),
+        limit: 25,
+      },
+      'p123_4'
+    );
+
+    const calledUrl = new URL(mockFetch.mock.calls[0][0] as string);
+    expect(calledUrl.pathname).toBe('/semaphore/v1/admin/notifications');
+    expect(calledUrl.searchParams.get('recipient')).toBe('some-user');
+    expect(calledUrl.searchParams.get('sender')).toBe('bot-quota');
+    expect(calledUrl.searchParams.get('since')).toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
+    expect(calledUrl.searchParams.get('until')).toBe(
+      '2026-02-01T00:00:00.000Z'
+    );
+    expect(calledUrl.searchParams.get('limit')).toBe('25');
+    expect(calledUrl.searchParams.get('cursor')).toBe('p123_4');
+  });
+
+  it('omits query params that are not provided', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }));
+
+    await fetchAdminNotifications('https://example.com/semaphore');
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toBe(
+      'https://example.com/semaphore/v1/admin/notifications'
+    );
+  });
+
+  it('throws SemaphoreError on HTTP error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Forbidden', { status: 403, statusText: 'Forbidden' })
+    );
+
+    await expect(
+      fetchAdminNotifications('https://example.com/semaphore')
+    ).rejects.toThrow(SemaphoreError);
+  });
+});
+
+describe('fetchAdminNotification', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches a single notification by id', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(detailPayload), { status: 200 })
+      );
+
+    const result = await fetchAdminNotification(
+      'https://example.com/semaphore',
+      '4561-a7513'
+    );
+
+    expect(result).toEqual(detailPayload);
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      'https://example.com/semaphore/v1/admin/notifications/4561-a7513'
+    );
+  });
+
+  it('throws SemaphoreError when the notification is not found', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Not Found', { status: 404, statusText: 'Not Found' })
+    );
+
+    await expect(
+      fetchAdminNotification('https://example.com/semaphore', 'missing')
+    ).rejects.toThrow(SemaphoreError);
+  });
+});

--- a/packages/semaphore-client/src/client.notifications.test.ts
+++ b/packages/semaphore-client/src/client.notifications.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  createAdminNotification,
   fetchAdminNotification,
   fetchAdminNotifications,
   SemaphoreError,
@@ -148,6 +149,105 @@ describe('fetchAdminNotification', () => {
 
     await expect(
       fetchAdminNotification('https://example.com/semaphore', 'missing')
+    ).rejects.toThrow(SemaphoreError);
+  });
+});
+
+describe('createAdminNotification', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs the payload with credentials, the CSRF header, and a JSON body', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ ...detailPayload, url: listPayload[0].url }),
+        {
+          status: 200,
+        }
+      )
+    );
+
+    await createAdminNotification(
+      'https://example.com/semaphore',
+      {
+        recipient: 'some-user',
+        summary: 'You are approaching your disk space quota limit',
+        body: 'You are using 448GiB of disk out of a quota of 500GiB.',
+      },
+      'csrf-token-abc'
+    );
+
+    const [calledUrl, init] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe(
+      'https://example.com/semaphore/v1/admin/notifications'
+    );
+    expect(init?.method).toBe('POST');
+    expect(init?.credentials).toBe('include');
+
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['x-csrf-token']).toBe('csrf-token-abc');
+    expect(headers['Content-Type']).toBe('application/json');
+
+    expect(JSON.parse(init?.body as string)).toEqual({
+      recipient: 'some-user',
+      summary: 'You are approaching your disk space quota limit',
+      body: 'You are using 448GiB of disk out of a quota of 500GiB.',
+    });
+  });
+
+  it('omits the body field when it is not provided', async () => {
+    const mockFetch = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ...detailPayload,
+          body: null,
+          url: listPayload[0].url,
+        }),
+        { status: 200 }
+      )
+    );
+
+    await createAdminNotification(
+      'https://example.com/semaphore',
+      { recipient: 'some-user', summary: 'Heads up' },
+      'csrf-token-abc'
+    );
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+    expect(body).toEqual({ recipient: 'some-user', summary: 'Heads up' });
+    expect(body).not.toHaveProperty('body');
+  });
+
+  it('returns the created notification parsed from the response', async () => {
+    const created = {
+      ...detailPayload,
+      url: 'https://example.com/semaphore/v1/admin/notifications/4561-a7513',
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(created), { status: 200 })
+    );
+
+    const result = await createAdminNotification(
+      'https://example.com/semaphore',
+      { recipient: 'some-user', summary: 'Heads up' },
+      'csrf-token-abc'
+    );
+
+    expect(result).toEqual(created);
+  });
+
+  it('throws SemaphoreError on HTTP error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Forbidden', { status: 403, statusText: 'Forbidden' })
+    );
+
+    await expect(
+      createAdminNotification(
+        'https://example.com/semaphore',
+        { recipient: 'some-user', summary: 'Heads up' },
+        'csrf-token-abc'
+      )
     ).rejects.toThrow(SemaphoreError);
   });
 });

--- a/packages/semaphore-client/src/client.ts
+++ b/packages/semaphore-client/src/client.ts
@@ -3,6 +3,7 @@ import {
   type BroadcastsResponse,
   BroadcastsResponseSchema,
   type CreateUserNotification,
+  CreateUserNotificationSchema,
   type UserNotification,
   UserNotificationSchema,
   type UserNotificationWithUrl,
@@ -276,6 +277,10 @@ export async function createAdminNotification(
   const baseUrl = normalizeUrl(semaphoreUrl);
   const url = `${baseUrl}/v1/admin/notifications`;
 
+  // Validate and normalize the payload at the boundary: this strips any stray
+  // keys and drops an undefined `body` so it is omitted from the request.
+  const payload = CreateUserNotificationSchema.parse(notification);
+
   const response = await fetch(url, {
     method: 'POST',
     credentials: 'include',
@@ -283,7 +288,7 @@ export async function createAdminNotification(
       'Content-Type': 'application/json',
       'x-csrf-token': csrfToken,
     },
-    body: JSON.stringify(notification),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {

--- a/packages/semaphore-client/src/client.ts
+++ b/packages/semaphore-client/src/client.ts
@@ -33,6 +33,17 @@ export class SemaphoreError extends Error {
   }
 }
 
+/**
+ * Normalize a Semaphore base URL by stripping trailing slashes.
+ */
+function normalizeUrl(url: string): string {
+  let normalized = url;
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
 // Module-level cache for deduplication (applies to both server and client contexts)
 let cachedBroadcasts: BroadcastsResponse | null = null;
 let cacheTimestamp = 0;
@@ -84,11 +95,7 @@ export async function fetchBroadcasts(
   }
 
   // Remove trailing slashes, then append /v1/broadcasts
-  let baseUrl = semaphoreUrl;
-  while (baseUrl.endsWith('/')) {
-    baseUrl = baseUrl.slice(0, -1);
-  }
-  const broadcastsUrl = `${baseUrl}/v1/broadcasts`;
+  const broadcastsUrl = `${normalizeUrl(semaphoreUrl)}/v1/broadcasts`;
 
   const startTime = Date.now();
   log.debug({ requestId, broadcastsUrl }, 'Starting network fetch');
@@ -129,17 +136,6 @@ export function getEmptyBroadcasts(): BroadcastsResponse {
 // =============================================================================
 // Admin notifications
 // =============================================================================
-
-/**
- * Normalize a Semaphore base URL by stripping trailing slashes.
- */
-function normalizeUrl(url: string): string {
-  let normalized = url;
-  while (normalized.endsWith('/')) {
-    normalized = normalized.slice(0, -1);
-  }
-  return normalized;
-}
 
 /**
  * Parse the next-page cursor from an RFC 5988 `Link` header.

--- a/packages/semaphore-client/src/client.ts
+++ b/packages/semaphore-client/src/client.ts
@@ -1,4 +1,12 @@
-import { type BroadcastsResponse, BroadcastsResponseSchema } from './schemas';
+import { z } from 'zod';
+import {
+  type BroadcastsResponse,
+  BroadcastsResponseSchema,
+  type UserNotification,
+  UserNotificationSchema,
+  UserNotificationWithUrlSchema,
+} from './schemas';
+import type { AdminNotificationFilters, AdminNotificationsPage } from './types';
 
 /**
  * Minimal logger interface compatible with pino's calling convention.
@@ -116,4 +124,131 @@ export async function fetchBroadcasts(
  */
 export function getEmptyBroadcasts(): BroadcastsResponse {
   return [];
+}
+
+// =============================================================================
+// Admin notifications
+// =============================================================================
+
+/**
+ * Normalize a Semaphore base URL by stripping trailing slashes.
+ */
+function normalizeUrl(url: string): string {
+  let normalized = url;
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+/**
+ * Parse the next-page cursor from an RFC 5988 `Link` header.
+ *
+ * Mirrors the cursor-parsing approach in
+ * `packages/gafaelfawr-client/src/client.ts`.
+ *
+ * @param linkHeader - Value of the `Link` response header
+ * @returns The `cursor` query parameter of the `rel="next"` link, or null
+ */
+function parseCursorFromLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+
+  const nextMatch = linkHeader.match(
+    /<[^>]*[?&]cursor=([^>&]+)[^>]*>;\s*rel="next"/
+  );
+  if (nextMatch) {
+    return decodeURIComponent(nextMatch[1]);
+  }
+
+  return null;
+}
+
+/**
+ * Fetch a page of admin notifications from the Semaphore admin API.
+ *
+ * Applies the `recipient` / `sender` / `since` / `until` / `limit` filters
+ * as query parameters, parses the next-page cursor from the RFC 5988 `Link`
+ * header, and reads the total count from the `X-Total-Count` header.
+ *
+ * @endpoint GET /v1/admin/notifications
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param filters - Recipient/sender/date-range/limit filters
+ * @param cursor - Opaque pagination cursor for the requested page
+ * @returns A page of notifications with `nextCursor` and `totalCount`
+ * @throws SemaphoreError if the request fails
+ */
+export async function fetchAdminNotifications(
+  semaphoreUrl: string,
+  filters: AdminNotificationFilters = {},
+  cursor?: string | null
+): Promise<AdminNotificationsPage> {
+  const baseUrl = normalizeUrl(semaphoreUrl);
+
+  const params = new URLSearchParams();
+  if (filters.recipient) params.set('recipient', filters.recipient);
+  if (filters.sender) params.set('sender', filters.sender);
+  if (filters.since) params.set('since', filters.since.toISOString());
+  if (filters.until) params.set('until', filters.until.toISOString());
+  if (filters.limit) params.set('limit', String(filters.limit));
+  if (cursor) params.set('cursor', cursor);
+
+  const queryString = params.toString();
+  const url = `${baseUrl}/v1/admin/notifications${queryString ? `?${queryString}` : ''}`;
+
+  const response = await fetch(url, {
+    credentials: 'include',
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new SemaphoreError(
+      `Semaphore API error: ${response.status} ${response.statusText}`,
+      response.status
+    );
+  }
+
+  const data = await response.json();
+  const entries = z.array(UserNotificationWithUrlSchema).parse(data);
+
+  const nextCursor = parseCursorFromLink(response.headers.get('Link'));
+  const totalCountHeader = response.headers.get('X-Total-Count');
+  const totalCount = totalCountHeader
+    ? Number.parseInt(totalCountHeader, 10)
+    : null;
+
+  return { entries, nextCursor, totalCount };
+}
+
+/**
+ * Fetch a single admin notification by id.
+ *
+ * @endpoint GET /v1/admin/notifications/{id}
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param id - Opaque notification id
+ * @returns The notification record
+ * @throws SemaphoreError if the request fails or the id is not found
+ */
+export async function fetchAdminNotification(
+  semaphoreUrl: string,
+  id: string
+): Promise<UserNotification> {
+  const baseUrl = normalizeUrl(semaphoreUrl);
+  const url = `${baseUrl}/v1/admin/notifications/${encodeURIComponent(id)}`;
+
+  const response = await fetch(url, {
+    credentials: 'include',
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new SemaphoreError(
+      `Semaphore API error: ${response.status} ${response.statusText}`,
+      response.status
+    );
+  }
+
+  const data = await response.json();
+  return UserNotificationSchema.parse(data);
 }

--- a/packages/semaphore-client/src/client.ts
+++ b/packages/semaphore-client/src/client.ts
@@ -2,8 +2,10 @@ import { z } from 'zod';
 import {
   type BroadcastsResponse,
   BroadcastsResponseSchema,
+  type CreateUserNotification,
   type UserNotification,
   UserNotificationSchema,
+  type UserNotificationWithUrl,
   UserNotificationWithUrlSchema,
 } from './schemas';
 import type { AdminNotificationFilters, AdminNotificationsPage } from './types';
@@ -247,4 +249,50 @@ export async function fetchAdminNotification(
 
   const data = await response.json();
   return UserNotificationSchema.parse(data);
+}
+
+/**
+ * Create a user notification via the Semaphore admin API.
+ *
+ * POSTs the `{ recipient, summary, body? }` payload with `credentials:
+ * 'include'` and the Gafaelfawr `x-csrf-token` header — the same mutation
+ * pattern used by `@lsst-sqre/gafaelfawr-client`. The CSRF token is sourced by
+ * the caller from Gafaelfawr login info. The endpoint echoes back the created
+ * notification (including its `url`).
+ *
+ * @endpoint POST /v1/admin/notifications
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param notification - The `{ recipient, summary, body? }` payload to create
+ * @param csrfToken - CSRF token from Gafaelfawr login info
+ * @returns The created notification, including its resource URL
+ * @throws SemaphoreError if the request fails
+ */
+export async function createAdminNotification(
+  semaphoreUrl: string,
+  notification: CreateUserNotification,
+  csrfToken: string
+): Promise<UserNotificationWithUrl> {
+  const baseUrl = normalizeUrl(semaphoreUrl);
+  const url = `${baseUrl}/v1/admin/notifications`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-csrf-token': csrfToken,
+    },
+    body: JSON.stringify(notification),
+  });
+
+  if (!response.ok) {
+    throw new SemaphoreError(
+      `Semaphore API error: ${response.status} ${response.statusText}`,
+      response.status
+    );
+  }
+
+  const data = await response.json();
+  return UserNotificationWithUrlSchema.parse(data);
 }

--- a/packages/semaphore-client/src/hooks/index.ts
+++ b/packages/semaphore-client/src/hooks/index.ts
@@ -7,3 +7,4 @@ export {
   useAdminNotifications,
 } from './useAdminNotifications';
 export { useBroadcasts } from './useBroadcasts';
+export { useCreateAdminNotification } from './useCreateAdminNotification';

--- a/packages/semaphore-client/src/hooks/index.ts
+++ b/packages/semaphore-client/src/hooks/index.ts
@@ -1,1 +1,9 @@
+export {
+  type UseAdminNotificationReturn,
+  useAdminNotification,
+} from './useAdminNotification';
+export {
+  type UseAdminNotificationsReturn,
+  useAdminNotifications,
+} from './useAdminNotifications';
 export { useBroadcasts } from './useBroadcasts';

--- a/packages/semaphore-client/src/hooks/useAdminNotification.test.tsx
+++ b/packages/semaphore-client/src/hooks/useAdminNotification.test.tsx
@@ -54,6 +54,18 @@ describe('useAdminNotification', () => {
     expect(result.current.isError).toBe(false);
   });
 
+  it('does not report loading when the query is disabled (empty id)', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { result } = renderHook(() => useAdminNotification(url, ''), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.notification).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('exposes an error state when the fetch fails', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('Not Found', { status: 404, statusText: 'Not Found' })

--- a/packages/semaphore-client/src/hooks/useAdminNotification.test.tsx
+++ b/packages/semaphore-client/src/hooks/useAdminNotification.test.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAdminNotification } from './useAdminNotification';
+
+const url = 'https://example.com/semaphore';
+
+const detail = {
+  id: '4561-a7513',
+  created: '2026-06-12T17:10:32+00:00',
+  read: null,
+  sender: 'bot-quota',
+  recipient: 'alice',
+  summary: 'A summary',
+  body: 'A body',
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useAdminNotification', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns a single notification on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(detail), { status: 200 })
+    );
+
+    const { result } = renderHook(
+      () => useAdminNotification(url, '4561-a7513'),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.notification).toEqual(detail);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('exposes an error state when the fetch fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Not Found', { status: 404, statusText: 'Not Found' })
+    );
+
+    const { result } = renderHook(() => useAdminNotification(url, 'missing'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.notification).toBeUndefined();
+  });
+});

--- a/packages/semaphore-client/src/hooks/useAdminNotification.ts
+++ b/packages/semaphore-client/src/hooks/useAdminNotification.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { adminNotificationQueryOptions } from '../query-options';
+import type { UserNotification } from '../schemas';
+
+/**
+ * Return type for the {@link useAdminNotification} hook.
+ */
+export type UseAdminNotificationReturn = {
+  /** The notification, or undefined while loading or on error */
+  notification: UserNotification | undefined;
+  /** Whether the query is loading */
+  isLoading: boolean;
+  /** Whether the query errored (e.g. unknown id) */
+  isError: boolean;
+  /** Error if the query failed */
+  error: Error | null;
+  /** Refetch the notification */
+  refetch: () => void;
+};
+
+/**
+ * Fetch a single admin notification by id.
+ *
+ * Unlike the list hook, errors are surfaced (not swallowed) so the detail
+ * page can render a graceful not-found state.
+ *
+ * @endpoint GET /v1/admin/notifications/{id}
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service. The query is
+ *   disabled when empty.
+ * @param id - Opaque notification id. The query is disabled when empty.
+ */
+export function useAdminNotification(
+  semaphoreUrl: string,
+  id: string
+): UseAdminNotificationReturn {
+  const { data, isPending, isError, error, refetch } = useQuery(
+    adminNotificationQueryOptions(semaphoreUrl, id)
+  );
+
+  return {
+    notification: data,
+    isLoading: isPending,
+    isError,
+    error: error ?? null,
+    refetch,
+  };
+}

--- a/packages/semaphore-client/src/hooks/useAdminNotification.ts
+++ b/packages/semaphore-client/src/hooks/useAdminNotification.ts
@@ -42,7 +42,11 @@ export function useAdminNotification(
 
   return {
     notification: data,
-    isLoading: isPending,
+    // Guard against the disabled state: when the query is disabled (empty
+    // url or id) it stays `pending` indefinitely, so report `false` rather
+    // than a perpetual loading state. Mirrors `useTokenDetails` in
+    // `@lsst-sqre/gafaelfawr-client`.
+    isLoading: isPending && !!semaphoreUrl && !!id,
     isError,
     error: error ?? null,
     refetch,

--- a/packages/semaphore-client/src/hooks/useAdminNotifications.test.tsx
+++ b/packages/semaphore-client/src/hooks/useAdminNotifications.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAdminNotifications } from './useAdminNotifications';
@@ -72,6 +72,18 @@ describe('useAdminNotifications', () => {
     expect(result.current.hasMore).toBe(true);
   });
 
+  it('does not report loading and does not fetch when disabled (empty url)', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    const { result } = renderHook(() => useAdminNotifications(''), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.entries).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('reports hasMore false when there is no next cursor', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify([n1]), { status: 200 })
@@ -116,7 +128,9 @@ describe('useAdminNotifications', () => {
       expect(result.current.entries).toEqual([n1]);
     });
 
-    result.current.loadMore();
+    act(() => {
+      result.current.loadMore();
+    });
 
     await waitFor(() => {
       expect(result.current.entries).toEqual([n1, n2]);

--- a/packages/semaphore-client/src/hooks/useAdminNotifications.test.tsx
+++ b/packages/semaphore-client/src/hooks/useAdminNotifications.test.tsx
@@ -1,0 +1,127 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAdminNotifications } from './useAdminNotifications';
+
+const url = 'https://example.com/semaphore';
+
+const n1 = {
+  id: 'n1',
+  created: '2026-06-12T17:10:32+00:00',
+  read: null,
+  sender: 'bot-quota',
+  recipient: 'alice',
+  summary: 'First',
+  body: null,
+  url: 'https://example.com/semaphore/v1/admin/notifications/n1',
+};
+
+const n2 = {
+  id: 'n2',
+  created: '2026-06-11T17:10:32+00:00',
+  read: null,
+  sender: 'bot-quota',
+  recipient: 'bob',
+  summary: 'Second',
+  body: null,
+  url: 'https://example.com/semaphore/v1/admin/notifications/n2',
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useAdminNotifications', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes entries, totalCount, and hasMore from the first page', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify([n1]), {
+        status: 200,
+        headers: {
+          Link: '<https://example.com/semaphore/v1/admin/notifications?cursor=c2>; rel="next"',
+          'X-Total-Count': '2',
+        },
+      })
+    );
+
+    const { result } = renderHook(() => useAdminNotifications(url), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.entries).toEqual([n1]);
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it('reports hasMore false when there is no next cursor', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify([n1]), { status: 200 })
+    );
+
+    const { result } = renderHook(() => useAdminNotifications(url), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.totalCount).toBeNull();
+  });
+
+  it('appends the next page to entries when loadMore is called', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const requested = String(input);
+      if (requested.includes('cursor=c2')) {
+        return Promise.resolve(
+          new Response(JSON.stringify([n2]), { status: 200 })
+        );
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify([n1]), {
+          status: 200,
+          headers: {
+            Link: '<https://example.com/semaphore/v1/admin/notifications?cursor=c2>; rel="next"',
+            'X-Total-Count': '2',
+          },
+        })
+      );
+    });
+
+    const { result } = renderHook(() => useAdminNotifications(url), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries).toEqual([n1]);
+    });
+
+    result.current.loadMore();
+
+    await waitFor(() => {
+      expect(result.current.entries).toEqual([n1, n2]);
+    });
+
+    expect(result.current.hasMore).toBe(false);
+  });
+});

--- a/packages/semaphore-client/src/hooks/useAdminNotifications.ts
+++ b/packages/semaphore-client/src/hooks/useAdminNotifications.ts
@@ -75,7 +75,11 @@ export function useAdminNotifications(
 
   return {
     entries,
-    isLoading: isLoading && !!semaphoreUrl,
+    // `isLoading` (isPending && isFetching) is already false when the query is
+    // disabled (empty url), since a disabled query never enters the fetching
+    // state — no extra guard needed here. (Contrast `useAdminNotification`,
+    // which derives loading from `isPending` and must guard it explicitly.)
+    isLoading,
     isFetching,
     isLoadingMore: isFetchingNextPage,
     error: error ?? null,

--- a/packages/semaphore-client/src/hooks/useAdminNotifications.ts
+++ b/packages/semaphore-client/src/hooks/useAdminNotifications.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { adminNotificationsInfiniteQueryOptions } from '../query-options';
+import type { UserNotificationWithUrl } from '../schemas';
+import type { AdminNotificationFilters } from '../types';
+
+/**
+ * Return type for the {@link useAdminNotifications} hook.
+ *
+ * Matches the shape exposed by `useTokenChangeHistory` in
+ * `@lsst-sqre/gafaelfawr-client`.
+ */
+export type UseAdminNotificationsReturn = {
+  /** Flattened array of all loaded notifications across pages */
+  entries: UserNotificationWithUrl[] | undefined;
+  /** Whether the initial page is loading */
+  isLoading: boolean;
+  /** Whether any page is currently fetching */
+  isFetching: boolean;
+  /** Whether the next page is currently loading */
+  isLoadingMore: boolean;
+  /** Error if the query failed */
+  error: Error | null;
+  /** Whether there are more pages to load */
+  hasMore: boolean;
+  /** Total count of notifications (from X-Total-Count header, may be null) */
+  totalCount: number | null;
+  /** Load the next page of older notifications */
+  loadMore: () => void;
+  /** Refetch all loaded pages */
+  refetch: () => void;
+};
+
+/**
+ * Fetch admin notifications with cursor-based "Load more" pagination.
+ *
+ * Pages are flattened into a single `entries` array. Results are most-recent
+ * first (server order); see {@link adminNotificationsInfiniteQueryOptions}.
+ *
+ * @endpoint GET /v1/admin/notifications
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service. The query is
+ *   disabled when empty.
+ * @param filters - Recipient/sender/date-range/limit filters
+ */
+export function useAdminNotifications(
+  semaphoreUrl: string,
+  filters: AdminNotificationFilters = {}
+): UseAdminNotificationsReturn {
+  const {
+    data,
+    error,
+    isLoading,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    refetch,
+  } = useInfiniteQuery(
+    adminNotificationsInfiniteQueryOptions(semaphoreUrl, filters)
+  );
+
+  // Flatten all pages into a single entries array.
+  const entries = data?.pages.flatMap((page) => page.entries);
+
+  // All pages report the same total; read it from the first page.
+  const totalCount = data?.pages[0]?.totalCount ?? null;
+
+  const loadMore = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  return {
+    entries,
+    isLoading: isLoading && !!semaphoreUrl,
+    isFetching,
+    isLoadingMore: isFetchingNextPage,
+    error: error ?? null,
+    hasMore: hasNextPage ?? false,
+    totalCount,
+    loadMore,
+    refetch,
+  };
+}

--- a/packages/semaphore-client/src/hooks/useCreateAdminNotification.test.tsx
+++ b/packages/semaphore-client/src/hooks/useCreateAdminNotification.test.tsx
@@ -1,0 +1,106 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCreateAdminNotification } from './useCreateAdminNotification';
+
+const url = 'https://example.com/semaphore';
+
+const created = {
+  id: '4561-a7513',
+  created: '2026-06-12T17:10:32+00:00',
+  read: null,
+  sender: 'some-admin',
+  recipient: 'some-user',
+  summary: 'Heads up',
+  body: null,
+  url: 'https://example.com/semaphore/v1/admin/notifications/4561-a7513',
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
+}
+
+describe('useCreateAdminNotification', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes a create mutation', () => {
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateAdminNotification(url), {
+      wrapper: Wrapper,
+    });
+
+    expect(typeof result.current.mutate).toBe('function');
+    expect(typeof result.current.mutateAsync).toBe('function');
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('POSTs with the CSRF header, credentials, and the notification body', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify(created), { status: 200 })
+      );
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateAdminNotification(url), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        notification: { recipient: 'some-user', summary: 'Heads up' },
+        csrfToken: 'csrf-token-abc',
+      });
+    });
+
+    const [calledUrl, init] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe(
+      'https://example.com/semaphore/v1/admin/notifications'
+    );
+    expect(init?.method).toBe('POST');
+    expect(init?.credentials).toBe('include');
+    expect((init?.headers as Record<string, string>)['x-csrf-token']).toBe(
+      'csrf-token-abc'
+    );
+    expect(JSON.parse(init?.body as string)).toEqual({
+      recipient: 'some-user',
+      summary: 'Heads up',
+    });
+  });
+
+  it('invalidates the admin-notifications list query on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(created), { status: 200 })
+    );
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateAdminNotification(url), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        notification: { recipient: 'some-user', summary: 'Heads up' },
+        csrfToken: 'csrf-token-abc',
+      });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['admin-notifications', url],
+      });
+    });
+  });
+});

--- a/packages/semaphore-client/src/hooks/useCreateAdminNotification.ts
+++ b/packages/semaphore-client/src/hooks/useCreateAdminNotification.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createAdminNotificationMutationOptions } from '../mutation-options';
+
+/**
+ * Create an admin notification via a TanStack Query mutation.
+ *
+ * Wraps {@link createAdminNotificationMutationOptions}, wiring in the
+ * `QueryClient` so a successful create invalidates the admin-notifications
+ * list query. The returned mutation's `mutate`/`mutateAsync` take
+ * `{ notification, csrfToken }`; the caller sources the CSRF token from
+ * Gafaelfawr login info.
+ *
+ * @endpoint POST /v1/admin/notifications
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ */
+export function useCreateAdminNotification(semaphoreUrl: string) {
+  const queryClient = useQueryClient();
+  return useMutation(
+    createAdminNotificationMutationOptions(semaphoreUrl, queryClient)
+  );
+}

--- a/packages/semaphore-client/src/index.ts
+++ b/packages/semaphore-client/src/index.ts
@@ -3,6 +3,7 @@
 export type { Logger } from './client';
 export {
   clearBroadcastsCache,
+  createAdminNotification,
   fetchAdminNotification,
   fetchAdminNotifications,
   fetchBroadcasts,
@@ -18,6 +19,7 @@ export {
   useAdminNotification,
   useAdminNotifications,
   useBroadcasts,
+  useCreateAdminNotification,
 } from './hooks';
 // Mock data for development
 export {
@@ -32,6 +34,9 @@ export {
   mockAdminNotification,
   mockAdminNotifications,
 } from './mock-notifications';
+// TanStack Query mutations
+export type { CreateAdminNotificationVariables } from './mutation-options';
+export { createAdminNotificationMutationOptions } from './mutation-options';
 export type { BroadcastsQueryConfig } from './query-options';
 // TanStack Query integration
 export {
@@ -44,6 +49,7 @@ export type {
   Broadcast,
   BroadcastCategory,
   BroadcastsResponse,
+  CreateUserNotification,
   FormattedText,
   UserNotification,
   UserNotificationWithUrl,
@@ -52,6 +58,7 @@ export {
   BroadcastCategorySchema,
   BroadcastSchema,
   BroadcastsResponseSchema,
+  CreateUserNotificationSchema,
   FormattedTextSchema,
   UserNotificationSchema,
   UserNotificationWithUrlSchema,

--- a/packages/semaphore-client/src/index.ts
+++ b/packages/semaphore-client/src/index.ts
@@ -3,12 +3,22 @@
 export type { Logger } from './client';
 export {
   clearBroadcastsCache,
+  fetchAdminNotification,
+  fetchAdminNotifications,
   fetchBroadcasts,
   getEmptyBroadcasts,
   SemaphoreError,
 } from './client';
 // React hooks
-export { useBroadcasts } from './hooks/useBroadcasts';
+export type {
+  UseAdminNotificationReturn,
+  UseAdminNotificationsReturn,
+} from './hooks';
+export {
+  useAdminNotification,
+  useAdminNotifications,
+  useBroadcasts,
+} from './hooks';
 // Mock data for development
 export {
   allCategoryBroadcasts,
@@ -16,19 +26,37 @@ export {
   mockBroadcasts,
   mockOutageBroadcast,
 } from './mock-broadcasts';
+export type { FilterPaginateParams } from './mock-notifications';
+export {
+  filterAndPaginateNotifications,
+  mockAdminNotification,
+  mockAdminNotifications,
+} from './mock-notifications';
 export type { BroadcastsQueryConfig } from './query-options';
 // TanStack Query integration
-export { broadcastsQueryOptions } from './query-options';
+export {
+  adminNotificationQueryOptions,
+  adminNotificationsInfiniteQueryOptions,
+  broadcastsQueryOptions,
+} from './query-options';
 // Schemas and types
 export type {
   Broadcast,
   BroadcastCategory,
   BroadcastsResponse,
   FormattedText,
+  UserNotification,
+  UserNotificationWithUrl,
 } from './schemas';
 export {
   BroadcastCategorySchema,
   BroadcastSchema,
   BroadcastsResponseSchema,
   FormattedTextSchema,
+  UserNotificationSchema,
+  UserNotificationWithUrlSchema,
 } from './schemas';
+export type {
+  AdminNotificationFilters,
+  AdminNotificationsPage,
+} from './types';

--- a/packages/semaphore-client/src/mock-notifications.test.ts
+++ b/packages/semaphore-client/src/mock-notifications.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  filterAndPaginateNotifications,
+  mockAdminNotifications,
+} from './mock-notifications';
+
+describe('mockAdminNotifications fixture', () => {
+  it('is sorted most-recent first', () => {
+    const times = mockAdminNotifications.map((n) =>
+      new Date(n.created).getTime()
+    );
+    const sorted = [...times].sort((a, b) => b - a);
+    expect(times).toEqual(sorted);
+  });
+});
+
+describe('filterAndPaginateNotifications', () => {
+  it('returns all entries with no filters or limit', () => {
+    const page = filterAndPaginateNotifications(mockAdminNotifications, {});
+    expect(page.entries).toEqual(mockAdminNotifications);
+    expect(page.totalCount).toBe(mockAdminNotifications.length);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('filters by recipient', () => {
+    const page = filterAndPaginateNotifications(mockAdminNotifications, {
+      recipient: 'alice',
+    });
+    expect(page.entries.every((n) => n.recipient === 'alice')).toBe(true);
+    expect(page.totalCount).toBe(4);
+  });
+
+  it('filters by sender', () => {
+    const page = filterAndPaginateNotifications(mockAdminNotifications, {
+      sender: 'ops-runbook',
+    });
+    expect(page.entries.every((n) => n.sender === 'ops-runbook')).toBe(true);
+    expect(page.totalCount).toBe(3);
+  });
+
+  it('filters by since (inclusive) using a Date', () => {
+    const page = filterAndPaginateNotifications(mockAdminNotifications, {
+      since: new Date('2026-06-10T00:00:00Z'),
+    });
+    expect(page.totalCount).toBe(3);
+    expect(
+      page.entries.every(
+        (n) =>
+          new Date(n.created).getTime() >=
+          new Date('2026-06-10T00:00:00Z').getTime()
+      )
+    ).toBe(true);
+  });
+
+  it('filters by until (inclusive) using an ISO string', () => {
+    const page = filterAndPaginateNotifications(mockAdminNotifications, {
+      until: '2026-06-08T23:59:59Z',
+    });
+    expect(page.totalCount).toBe(4);
+    expect(
+      page.entries.every(
+        (n) =>
+          new Date(n.created).getTime() <=
+          new Date('2026-06-08T23:59:59Z').getTime()
+      )
+    ).toBe(true);
+  });
+
+  it('paginates with limit and an opaque cursor', () => {
+    const page1 = filterAndPaginateNotifications(mockAdminNotifications, {
+      limit: 3,
+    });
+    expect(page1.entries).toHaveLength(3);
+    expect(page1.totalCount).toBe(8);
+    expect(page1.nextCursor).not.toBeNull();
+
+    const page2 = filterAndPaginateNotifications(mockAdminNotifications, {
+      limit: 3,
+      cursor: page1.nextCursor,
+    });
+    expect(page2.entries).toHaveLength(3);
+    expect(page2.totalCount).toBe(8);
+    expect(page2.nextCursor).not.toBeNull();
+
+    const page3 = filterAndPaginateNotifications(mockAdminNotifications, {
+      limit: 3,
+      cursor: page2.nextCursor,
+    });
+    expect(page3.entries).toHaveLength(2);
+    expect(page3.nextCursor).toBeNull();
+
+    // The three pages together reconstruct the full filtered set in order.
+    expect([...page1.entries, ...page2.entries, ...page3.entries]).toEqual(
+      mockAdminNotifications
+    );
+  });
+
+  it('combines a filter with pagination, keeping totalCount of the filtered set', () => {
+    const page = filterAndPaginateNotifications(mockAdminNotifications, {
+      recipient: 'alice',
+      limit: 2,
+    });
+    expect(page.entries).toHaveLength(2);
+    expect(page.entries.every((n) => n.recipient === 'alice')).toBe(true);
+    expect(page.totalCount).toBe(4);
+    expect(page.nextCursor).not.toBeNull();
+  });
+});

--- a/packages/semaphore-client/src/mock-notifications.ts
+++ b/packages/semaphore-client/src/mock-notifications.ts
@@ -1,0 +1,176 @@
+/**
+ * Fixture data and a pure filter+paginate helper for admin notifications.
+ *
+ * The fixtures and helper are shared by the squareone dev API routes (which
+ * serve them and emit a `Link` header) and by Storybook stories (which pass
+ * them through props). Keeping the filter/paginate logic here means dev and
+ * Storybook stay in lock-step with one implementation.
+ */
+import type { UserNotification, UserNotificationWithUrl } from './schemas';
+import type { AdminNotificationsPage } from './types';
+
+const MOCK_URL_BASE =
+  'https://data.example.com/semaphore/v1/admin/notifications';
+
+function withUrl(notification: UserNotification): UserNotificationWithUrl {
+  return { ...notification, url: `${MOCK_URL_BASE}/${notification.id}` };
+}
+
+/**
+ * A realistic set of admin notifications, ordered most-recent first (the same
+ * order the Semaphore admin list endpoint returns). Covers a mix of
+ * recipients, senders, read/unread status, and present/absent bodies so that
+ * filtering and rendering can be exercised.
+ */
+export const mockAdminNotifications: UserNotificationWithUrl[] = [
+  withUrl({
+    id: 'ntf-001',
+    created: '2026-06-12T17:10:32+00:00',
+    read: null,
+    sender: 'bot-quota-notifier',
+    recipient: 'alice',
+    summary: 'You are approaching your disk space **quota** limit',
+    body: 'You are using 448GiB of disk out of a quota of 500GiB. Consider cleaning up old scratch files.',
+  }),
+  withUrl({
+    id: 'ntf-002',
+    created: '2026-06-11T09:00:00+00:00',
+    read: '2026-06-11T10:00:00+00:00',
+    sender: 'bot-quota-notifier',
+    recipient: 'bob',
+    summary: 'Your notebook server was culled after 24h idle',
+    body: null,
+  }),
+  withUrl({
+    id: 'ntf-003',
+    created: '2026-06-10T12:30:00+00:00',
+    read: null,
+    sender: 'ops-runbook',
+    recipient: 'alice',
+    summary: 'Scheduled maintenance window this weekend',
+    body: 'The RSP will be unavailable on **Saturday 06:00–10:00 UTC** for database upgrades.',
+  }),
+  withUrl({
+    id: 'ntf-004',
+    created: '2026-06-09T08:15:00+00:00',
+    read: null,
+    sender: 'bot-quota-notifier',
+    recipient: 'carol',
+    summary: 'Your TAP query results are ready',
+    body: null,
+  }),
+  withUrl({
+    id: 'ntf-005',
+    created: '2026-06-08T22:45:00+00:00',
+    read: '2026-06-09T00:00:00+00:00',
+    sender: 'ops-runbook',
+    recipient: 'alice',
+    summary:
+      'Please review the updated [data rights policy](https://example.com/policy)',
+    body: 'All users must acknowledge the updated policy before **July 1**.',
+  }),
+  withUrl({
+    id: 'ntf-006',
+    created: '2026-06-07T14:00:00+00:00',
+    read: null,
+    sender: 'bot-quota-notifier',
+    recipient: 'bob',
+    summary: 'A new image release is available in the spawner',
+    body: null,
+  }),
+  withUrl({
+    id: 'ntf-007',
+    created: '2026-06-06T06:00:00+00:00',
+    read: null,
+    sender: 'ops-runbook',
+    recipient: 'dave',
+    summary: 'Welcome to the Rubin Science Platform',
+    body: 'Get started with the [documentation](https://rsp.lsst.io) and tutorial notebooks.',
+  }),
+  withUrl({
+    id: 'ntf-008',
+    created: '2026-06-05T18:20:00+00:00',
+    read: null,
+    sender: 'bot-quota-notifier',
+    recipient: 'alice',
+    summary: 'Your batch job has completed',
+    body: null,
+  }),
+];
+
+/**
+ * A single admin notification fixture (detail-shaped, without a `url`),
+ * convenient for detail-page and detail-view stories.
+ */
+export const mockAdminNotification: UserNotification = (() => {
+  const { url: _url, ...detail } = mockAdminNotifications[0];
+  return detail;
+})();
+
+/**
+ * Parameters accepted by {@link filterAndPaginateNotifications}.
+ *
+ * `since`/`until` accept either a `Date` or an ISO 8601 string so that dev
+ * API routes can pass raw query-string values straight through.
+ */
+export type FilterPaginateParams = {
+  recipient?: string;
+  sender?: string;
+  since?: Date | string;
+  until?: Date | string;
+  /** Opaque pagination cursor returned as a previous page's `nextCursor`. */
+  cursor?: string | null;
+  /** Page size. When omitted, all matching notifications are returned. */
+  limit?: number;
+};
+
+function toMillis(value: Date | string): number {
+  return value instanceof Date ? value.getTime() : new Date(value).getTime();
+}
+
+/**
+ * Filter and paginate a list of notifications, mirroring the behavior of the
+ * Semaphore admin list endpoint.
+ *
+ * Filtering matches `recipient`/`sender` exactly and applies an inclusive
+ * `since`/`until` window on the `created` timestamp. Pagination is expressed
+ * with an **opaque numeric-offset cursor** (an implementation detail of this
+ * mock; the real API uses Safir cursors). `totalCount` always reflects the
+ * full filtered set, independent of the page slice.
+ *
+ * @param notifications - The full (most-recent-first) dataset
+ * @param params - Filter and pagination parameters
+ * @returns A page shaped like {@link AdminNotificationsPage}
+ */
+export function filterAndPaginateNotifications(
+  notifications: UserNotificationWithUrl[],
+  params: FilterPaginateParams
+): AdminNotificationsPage {
+  const { recipient, sender, since, until, cursor, limit } = params;
+
+  const sinceMs = since !== undefined ? toMillis(since) : null;
+  const untilMs = until !== undefined ? toMillis(until) : null;
+
+  const filtered = notifications.filter((n) => {
+    if (recipient && n.recipient !== recipient) return false;
+    if (sender && n.sender !== sender) return false;
+    const createdMs = new Date(n.created).getTime();
+    if (sinceMs !== null && createdMs < sinceMs) return false;
+    if (untilMs !== null && createdMs > untilMs) return false;
+    return true;
+  });
+
+  const totalCount = filtered.length;
+
+  if (!limit) {
+    return { entries: filtered, nextCursor: null, totalCount };
+  }
+
+  const offset = cursor ? Number.parseInt(cursor, 10) : 0;
+  const start = Number.isNaN(offset) ? 0 : offset;
+  const end = start + limit;
+  const entries = filtered.slice(start, end);
+  const nextCursor = end < totalCount ? String(end) : null;
+
+  return { entries, nextCursor, totalCount };
+}

--- a/packages/semaphore-client/src/mutation-options.test.ts
+++ b/packages/semaphore-client/src/mutation-options.test.ts
@@ -1,0 +1,78 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type CreateAdminNotificationVariables,
+  createAdminNotificationMutationOptions,
+} from './mutation-options';
+import type { UserNotificationWithUrl } from './schemas';
+
+const url = 'https://example.com/semaphore';
+
+const variables: CreateAdminNotificationVariables = {
+  notification: { recipient: 'some-user', summary: 'Heads up' },
+  csrfToken: 'csrf-token-abc',
+};
+
+const created: UserNotificationWithUrl = {
+  id: '4561-a7513',
+  created: '2026-06-12T17:10:32+00:00',
+  read: null,
+  sender: 'some-admin',
+  recipient: 'some-user',
+  summary: 'Heads up',
+  body: null,
+  url: 'https://example.com/semaphore/v1/admin/notifications/4561-a7513',
+};
+
+describe('createAdminNotificationMutationOptions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('posts the notification via createAdminNotification', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(created), { status: 200 })
+      );
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    } as unknown as QueryClient;
+
+    const opts = createAdminNotificationMutationOptions(url, queryClient);
+    // Invoke the mutationFn directly. It's cast to its single-variable call
+    // shape so the test doesn't couple to TanStack's internal context arg.
+    const mutationFn = opts.mutationFn as (
+      v: CreateAdminNotificationVariables
+    ) => Promise<UserNotificationWithUrl>;
+    const result = await mutationFn(variables);
+
+    expect(result).toEqual(created);
+    const [calledUrl, init] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe(
+      'https://example.com/semaphore/v1/admin/notifications'
+    );
+    expect(init?.method).toBe('POST');
+    expect((init?.headers as Record<string, string>)['x-csrf-token']).toBe(
+      'csrf-token-abc'
+    );
+  });
+
+  it('invalidates the admin-notifications list query on success', () => {
+    const invalidateQueries = vi.fn();
+    const queryClient = { invalidateQueries } as unknown as QueryClient;
+
+    const opts = createAdminNotificationMutationOptions(url, queryClient);
+    // Cast away the lifecycle-callback arity so the test only exercises the
+    // invalidation behavior, not TanStack's exact onSuccess signature.
+    const onSuccess = opts.onSuccess as (
+      data: UserNotificationWithUrl,
+      variables: CreateAdminNotificationVariables
+    ) => void;
+    onSuccess(created, variables);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['admin-notifications', url],
+    });
+  });
+});

--- a/packages/semaphore-client/src/mutation-options.ts
+++ b/packages/semaphore-client/src/mutation-options.ts
@@ -1,0 +1,45 @@
+import { mutationOptions, type QueryClient } from '@tanstack/react-query';
+import { createAdminNotification } from './client';
+import type {
+  CreateUserNotification,
+  UserNotificationWithUrl,
+} from './schemas';
+
+/**
+ * Variables for the create-admin-notification mutation.
+ */
+export type CreateAdminNotificationVariables = {
+  /** The `{ recipient, summary, body? }` payload to create. */
+  notification: CreateUserNotification;
+  /** CSRF token sourced by the caller from Gafaelfawr login info. */
+  csrfToken: string;
+};
+
+/**
+ * TanStack Query mutation options for creating an admin notification.
+ *
+ * On success, invalidates the admin-notifications list query so the listing
+ * reflects the newly created notification. The invalidation key is the
+ * `['admin-notifications', semaphoreUrl]` prefix of the list query key defined
+ * in `adminNotificationsInfiniteQueryOptions`, so every filter variant of the
+ * list is invalidated.
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param queryClient - Query client used to invalidate the list on success
+ */
+export const createAdminNotificationMutationOptions = (
+  semaphoreUrl: string,
+  queryClient: QueryClient
+) =>
+  mutationOptions({
+    mutationFn: ({
+      notification,
+      csrfToken,
+    }: CreateAdminNotificationVariables): Promise<UserNotificationWithUrl> =>
+      createAdminNotification(semaphoreUrl, notification, csrfToken),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['admin-notifications', semaphoreUrl],
+      });
+    },
+  });

--- a/packages/semaphore-client/src/query-options.notifications.test.ts
+++ b/packages/semaphore-client/src/query-options.notifications.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adminNotificationQueryOptions,
+  adminNotificationsInfiniteQueryOptions,
+} from './query-options';
+import type { AdminNotificationsPage } from './types';
+
+const url = 'https://example.com/semaphore';
+
+describe('adminNotificationsInfiniteQueryOptions', () => {
+  it('includes the URL and serialized filters in the query key', () => {
+    const since = new Date('2026-01-01T00:00:00Z');
+    const opts = adminNotificationsInfiniteQueryOptions(url, {
+      recipient: 'some-user',
+      since,
+    });
+
+    expect(opts.queryKey).toEqual([
+      'admin-notifications',
+      url,
+      { recipient: 'some-user', since: since.toISOString() },
+    ]);
+  });
+
+  it('uses a null initial page param', () => {
+    const opts = adminNotificationsInfiniteQueryOptions(url);
+    expect(opts.initialPageParam).toBeNull();
+  });
+
+  it('derives the next page param from the last page nextCursor', () => {
+    const opts = adminNotificationsInfiniteQueryOptions(url);
+    const page: AdminNotificationsPage = {
+      entries: [],
+      nextCursor: '1614985055_4234',
+      totalCount: 10,
+    };
+    expect(opts.getNextPageParam(page, [page], null, [null])).toBe(
+      '1614985055_4234'
+    );
+  });
+
+  it('returns null next page param when there is no next cursor', () => {
+    const opts = adminNotificationsInfiniteQueryOptions(url);
+    const page: AdminNotificationsPage = {
+      entries: [],
+      nextCursor: null,
+      totalCount: 10,
+    };
+    expect(opts.getNextPageParam(page, [page], null, [null])).toBeNull();
+  });
+
+  it('is disabled when the URL is empty', () => {
+    const opts = adminNotificationsInfiniteQueryOptions('');
+    expect(opts.enabled).toBe(false);
+  });
+});
+
+describe('adminNotificationQueryOptions', () => {
+  it('produces a query key scoped to the URL and id', () => {
+    const opts = adminNotificationQueryOptions(url, '4561-a7513');
+    expect(opts.queryKey).toEqual(['admin-notification', url, '4561-a7513']);
+  });
+
+  it('is disabled when the id is empty', () => {
+    const opts = adminNotificationQueryOptions(url, '');
+    expect(opts.enabled).toBe(false);
+  });
+});

--- a/packages/semaphore-client/src/query-options.ts
+++ b/packages/semaphore-client/src/query-options.ts
@@ -1,6 +1,13 @@
-import { queryOptions } from '@tanstack/react-query';
-import { fetchBroadcasts, getEmptyBroadcasts, type Logger } from './client';
+import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
+import {
+  fetchAdminNotification,
+  fetchAdminNotifications,
+  fetchBroadcasts,
+  getEmptyBroadcasts,
+  type Logger,
+} from './client';
 import type { BroadcastsResponse } from './schemas';
+import type { AdminNotificationFilters, AdminNotificationsPage } from './types';
 
 export type BroadcastsQueryConfig = {
   staleTime?: number;
@@ -60,3 +67,75 @@ export const broadcastsQueryOptions = (
     refetchOnReconnect,
   });
 };
+
+// =============================================================================
+// Admin notifications
+// =============================================================================
+
+/**
+ * Serialize admin notification filters into a stable, plain object for use in
+ * a query key. `Date` filters are normalized to ISO strings so that distinct
+ * filter combinations cache separately.
+ */
+function filtersToKeyObject(
+  filters: AdminNotificationFilters
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  if (filters.recipient) result.recipient = filters.recipient;
+  if (filters.sender) result.sender = filters.sender;
+  if (filters.since) result.since = filters.since.toISOString();
+  if (filters.until) result.until = filters.until.toISOString();
+  if (filters.limit) result.limit = filters.limit;
+  return result;
+}
+
+/**
+ * Infinite query options for the admin notifications list.
+ *
+ * Uses cursor-based pagination conveyed via the `Link` header; the cursor is
+ * threaded through `pageParam` and `getNextPageParam` reads it from the last
+ * page's `nextCursor`.
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param filters - Recipient/sender/date-range/limit filters
+ */
+export const adminNotificationsInfiniteQueryOptions = (
+  semaphoreUrl: string,
+  filters: AdminNotificationFilters = {}
+) =>
+  infiniteQueryOptions({
+    queryKey: [
+      'admin-notifications',
+      semaphoreUrl,
+      filtersToKeyObject(filters),
+    ] as const,
+    queryFn: ({ pageParam }): Promise<AdminNotificationsPage> =>
+      fetchAdminNotifications(semaphoreUrl, filters, pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage: AdminNotificationsPage) => lastPage.nextCursor,
+    enabled: !!semaphoreUrl,
+    staleTime: 10_000, // 10 seconds
+    gcTime: 5 * 60_000, // 5 minutes
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+  });
+
+/**
+ * Query options for a single admin notification by id.
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param id - Opaque notification id
+ */
+export const adminNotificationQueryOptions = (
+  semaphoreUrl: string,
+  id: string
+) =>
+  queryOptions({
+    queryKey: ['admin-notification', semaphoreUrl, id] as const,
+    queryFn: () => fetchAdminNotification(semaphoreUrl, id),
+    enabled: !!semaphoreUrl && !!id,
+    staleTime: 10_000, // 10 seconds
+    gcTime: 5 * 60_000, // 5 minutes
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+  });

--- a/packages/semaphore-client/src/schemas.notifications.test.ts
+++ b/packages/semaphore-client/src/schemas.notifications.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  UserNotificationSchema,
+  UserNotificationWithUrlSchema,
+} from './schemas';
+
+describe('UserNotificationWithUrlSchema', () => {
+  it('parses a representative admin list payload with raw-Markdown text', () => {
+    const payload = {
+      id: '4561-a7513',
+      created: '2026-06-12T17:10:32+00:00',
+      read: '2026-06-13T14:45:12+00:00',
+      sender: 'bot-quota-notifier',
+      recipient: 'some-user',
+      summary: 'You are approaching your disk space **quota** limit',
+      body: 'You are using 448GiB of disk out of a quota of 500GiB.',
+      url: 'https://data.example.com/semaphore/v1/admin/notifications/4561-a7513',
+    };
+
+    const parsed = UserNotificationWithUrlSchema.parse(payload);
+    expect(parsed).toEqual(payload);
+  });
+
+  it('allows a null read date and a null body', () => {
+    const payload = {
+      id: 'abc',
+      created: '2026-06-12T17:10:32+00:00',
+      read: null,
+      sender: 'bot',
+      recipient: 'user',
+      summary: 'Heads up',
+      body: null,
+      url: 'https://data.example.com/semaphore/v1/admin/notifications/abc',
+    };
+
+    expect(() => UserNotificationWithUrlSchema.parse(payload)).not.toThrow();
+  });
+
+  it('rejects a payload missing the url field', () => {
+    const payload = {
+      id: 'abc',
+      created: '2026-06-12T17:10:32+00:00',
+      read: null,
+      sender: 'bot',
+      recipient: 'user',
+      summary: 'Heads up',
+      body: null,
+    };
+
+    expect(() => UserNotificationWithUrlSchema.parse(payload)).toThrow();
+  });
+});
+
+describe('UserNotificationSchema', () => {
+  it('parses a representative admin detail payload (no url)', () => {
+    const payload = {
+      id: '4561-a7513',
+      created: '2026-06-12T17:10:32+00:00',
+      read: null,
+      sender: 'bot-quota-notifier',
+      recipient: 'some-user',
+      summary: 'You are approaching your disk space quota limit',
+      body: 'You are using 448GiB of disk out of a quota of 500GiB.',
+    };
+
+    const parsed = UserNotificationSchema.parse(payload);
+    expect(parsed).toEqual(payload);
+  });
+});

--- a/packages/semaphore-client/src/schemas.notifications.test.ts
+++ b/packages/semaphore-client/src/schemas.notifications.test.ts
@@ -66,4 +66,18 @@ describe('UserNotificationSchema', () => {
     const parsed = UserNotificationSchema.parse(payload);
     expect(parsed).toEqual(payload);
   });
+
+  it('rejects a non-ISO-8601 created date', () => {
+    const payload = {
+      id: '4561-a7513',
+      created: 'not-a-date',
+      read: null,
+      sender: 'bot-quota-notifier',
+      recipient: 'some-user',
+      summary: 'A summary',
+      body: null,
+    };
+
+    expect(() => UserNotificationSchema.parse(payload)).toThrow();
+  });
 });

--- a/packages/semaphore-client/src/schemas.notifications.test.ts
+++ b/packages/semaphore-client/src/schemas.notifications.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CreateUserNotificationSchema,
   UserNotificationSchema,
   UserNotificationWithUrlSchema,
 } from './schemas';
@@ -79,5 +80,38 @@ describe('UserNotificationSchema', () => {
     };
 
     expect(() => UserNotificationSchema.parse(payload)).toThrow();
+  });
+});
+
+describe('CreateUserNotificationSchema', () => {
+  it('parses a representative create payload with recipient, summary, and body', () => {
+    const payload = {
+      recipient: 'some-user',
+      summary: 'You are approaching your disk space **quota** limit',
+      body: 'You are using 448GiB of disk out of a quota of 500GiB.',
+    };
+
+    const parsed = CreateUserNotificationSchema.parse(payload);
+    expect(parsed).toEqual(payload);
+  });
+
+  it('parses a payload with only the required recipient and summary fields', () => {
+    const payload = { recipient: 'some-user', summary: 'Heads up' };
+
+    const parsed = CreateUserNotificationSchema.parse(payload);
+    expect(parsed).toEqual(payload);
+    expect(parsed.body).toBeUndefined();
+  });
+
+  it('rejects a payload missing the recipient', () => {
+    expect(() =>
+      CreateUserNotificationSchema.parse({ summary: 'Heads up' })
+    ).toThrow();
+  });
+
+  it('rejects a payload missing the summary', () => {
+    expect(() =>
+      CreateUserNotificationSchema.parse({ recipient: 'some-user' })
+    ).toThrow();
   });
 });

--- a/packages/semaphore-client/src/schemas.ts
+++ b/packages/semaphore-client/src/schemas.ts
@@ -31,8 +31,41 @@ export const BroadcastSchema = z.object({
  */
 export const BroadcastsResponseSchema = z.array(BroadcastSchema);
 
+/**
+ * A user notification from the Semaphore admin API.
+ *
+ * Returned by the admin detail endpoint
+ * (`GET /v1/admin/notifications/{id}`). Unlike the user-facing endpoint,
+ * the admin endpoints return `summary` and `body` as **raw Markdown**
+ * strings (not pre-rendered gfm/html), so admin UIs render Markdown
+ * client-side. `created` and `read` are ISO 8601 date-time strings; `read`
+ * is null when the recipient has not read the notification.
+ */
+export const UserNotificationSchema = z.object({
+  id: z.string(),
+  created: z.string(),
+  read: z.string().nullable(),
+  sender: z.string(),
+  recipient: z.string(),
+  summary: z.string(),
+  body: z.string().nullable(),
+});
+
+/**
+ * A user notification including a URL to the notification resource.
+ *
+ * Returned by the admin list endpoint (`GET /v1/admin/notifications`).
+ */
+export const UserNotificationWithUrlSchema = UserNotificationSchema.extend({
+  url: z.string(),
+});
+
 // Infer types from schemas
 export type FormattedText = z.infer<typeof FormattedTextSchema>;
 export type BroadcastCategory = z.infer<typeof BroadcastCategorySchema>;
 export type Broadcast = z.infer<typeof BroadcastSchema>;
 export type BroadcastsResponse = z.infer<typeof BroadcastsResponseSchema>;
+export type UserNotification = z.infer<typeof UserNotificationSchema>;
+export type UserNotificationWithUrl = z.infer<
+  typeof UserNotificationWithUrlSchema
+>;

--- a/packages/semaphore-client/src/schemas.ts
+++ b/packages/semaphore-client/src/schemas.ts
@@ -38,13 +38,14 @@ export const BroadcastsResponseSchema = z.array(BroadcastSchema);
  * (`GET /v1/admin/notifications/{id}`). Unlike the user-facing endpoint,
  * the admin endpoints return `summary` and `body` as **raw Markdown**
  * strings (not pre-rendered gfm/html), so admin UIs render Markdown
- * client-side. `created` and `read` are ISO 8601 date-time strings; `read`
- * is null when the recipient has not read the notification.
+ * client-side. `created` and `read` are validated as ISO 8601 date-time
+ * strings (offsets allowed, e.g. `2026-06-12T17:10:32+00:00`); `read` is
+ * null when the recipient has not read the notification.
  */
 export const UserNotificationSchema = z.object({
   id: z.string(),
-  created: z.string(),
-  read: z.string().nullable(),
+  created: z.string().datetime({ offset: true }),
+  read: z.string().datetime({ offset: true }).nullable(),
   sender: z.string(),
   recipient: z.string(),
   summary: z.string(),

--- a/packages/semaphore-client/src/schemas.ts
+++ b/packages/semaphore-client/src/schemas.ts
@@ -61,6 +61,19 @@ export const UserNotificationWithUrlSchema = UserNotificationSchema.extend({
   url: z.string(),
 });
 
+/**
+ * Payload for creating a user notification via the admin API.
+ *
+ * Sent to `POST /v1/admin/notifications`. `recipient` and `summary` are
+ * required; `summary` may use inline Markdown only, while the optional `body`
+ * supports full Markdown.
+ */
+export const CreateUserNotificationSchema = z.object({
+  recipient: z.string(),
+  summary: z.string(),
+  body: z.string().optional(),
+});
+
 // Infer types from schemas
 export type FormattedText = z.infer<typeof FormattedTextSchema>;
 export type BroadcastCategory = z.infer<typeof BroadcastCategorySchema>;
@@ -69,4 +82,7 @@ export type BroadcastsResponse = z.infer<typeof BroadcastsResponseSchema>;
 export type UserNotification = z.infer<typeof UserNotificationSchema>;
 export type UserNotificationWithUrl = z.infer<
   typeof UserNotificationWithUrlSchema
+>;
+export type CreateUserNotification = z.infer<
+  typeof CreateUserNotificationSchema
 >;

--- a/packages/semaphore-client/src/types.ts
+++ b/packages/semaphore-client/src/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared types for the Semaphore admin notifications client.
+ */
+import type { UserNotificationWithUrl } from './schemas';
+
+/**
+ * Filter options for the admin notifications list query.
+ *
+ * Mirrors the query parameters accepted by
+ * `GET /v1/admin/notifications`. The cursor is handled separately by the
+ * pagination layer and is therefore not part of the filters.
+ */
+export type AdminNotificationFilters = {
+  /** Limit notifications to this recipient. */
+  recipient?: string;
+  /** Limit notifications to this sender. */
+  sender?: string;
+  /** Only show notifications created at or after this time. */
+  since?: Date;
+  /** Only show notifications created before or at this time. */
+  until?: Date;
+  /** Maximum number of notifications to return per page. */
+  limit?: number;
+};
+
+/**
+ * A single page of admin notifications.
+ *
+ * `nextCursor` is parsed from the RFC 5988 `Link` header (null when there
+ * are no more pages); `totalCount` is read from the `X-Total-Count` header
+ * (null when the header is absent).
+ */
+export type AdminNotificationsPage = {
+  entries: UserNotificationWithUrl[];
+  nextCursor: string | null;
+  totalCount: number | null;
+};


### PR DESCRIPTION
## Summary

- Add the Semaphore admin notifications **read** data layer to `@lsst-sqre/semaphore-client`: Zod schemas (`UserNotificationSchema`, `UserNotificationWithUrlSchema`) + inferred types for the list/detail payloads (raw-Markdown `summary`/`body`, ISO date-time `created`/`read`), `fetchAdminNotifications` (RFC 5988 `Link`-header cursor + `X-Total-Count` + `recipient`/`sender`/`since`/`until` filters) and `fetchAdminNotification`, the `adminNotificationsInfiniteQueryOptions`/`adminNotificationQueryOptions` query options, and the `useAdminNotifications`/`useAdminNotification` hooks, plus a `mock-notifications` fixture dataset and pure filter+paginate helper.
- Add the Semaphore admin notifications **create** data layer: `CreateUserNotificationSchema` (`recipient`, `summary`, `body?`) + type, `createAdminNotification` (POSTs to `/v1/admin/notifications` with `credentials: 'include'` and the Gafaelfawr `x-csrf-token` header, returning the created `UserNotificationWithUrl`), `createAdminNotificationMutationOptions` whose `onSuccess` invalidates the admin-notifications list query, and the `useCreateAdminNotification(semaphoreUrl)` hook.
- Export all new read/create symbols from `@lsst-sqre/semaphore-client`'s entry point so the upcoming admin UI (DataTable, listing/detail/compose pages) can consume them.

## Validation steps

- In a Node REPL or scratch component, import the new symbols from `@lsst-sqre/semaphore-client` and confirm they resolve: `fetchAdminNotifications`, `fetchAdminNotification`, `createAdminNotification`, `adminNotificationsInfiniteQueryOptions`, `adminNotificationQueryOptions`, `createAdminNotificationMutationOptions`, `useAdminNotifications`, `useAdminNotification`, `useCreateAdminNotification`, `CreateUserNotificationSchema`, `mockAdminNotifications`, `filterAndPaginateNotifications`.
- Spot-check the mock helper: `filterAndPaginateNotifications(mockAdminNotifications, { recipient: 'alice', limit: 2 })` returns 2 entries (all `recipient === 'alice'`), `totalCount` 4, and a non-null `nextCursor`; passing that cursor back returns the next page.
- Spot-check the create path against a stubbed `fetch`: `createAdminNotification(url, { recipient: 'some-user', summary: 'Heads up' }, 'csrf-abc')` issues a `POST` to `<url>/v1/admin/notifications` with `credentials: 'include'`, an `x-csrf-token: csrf-abc` header, and a JSON body of exactly `{ recipient, summary }` (no `body` key when omitted).

## References

- Closes #476
- Closes #477
- PRD: #474
- Jira: https://rubinobs.atlassian.net/browse/DM-55246