### PR TITLE
DM-55246: Add admin notifications listing page

### DIFF
--- a/.changeset/semaphore-admin-notification-listing.md
+++ b/.changeset/semaphore-admin-notification-listing.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+Add the `/admin/notifications` listing page for admin user notifications. Reachable from the new "User notifications" admin sidebar entry (under the inherited `exec:admin` gate), it lists the most recent notifications in a `DataTable` — recipient, sender, created time, and a rendered-Markdown summary — with loading, empty, and error-with-retry states. Recipient, sender, and since/until date-range filters narrow and combine, a "clear all" resets them, and the active filters are captured in the URL query string (via the new `useAdminNotificationFilters` hook) so a filtered view can be bookmarked and reproduced. A caller-owned "Load more" control pages through older notifications with a shown-of-total count, and a "Compose" button links to the compose route. The presentational `NotificationFilters` and `NotificationsTableView` components are driven entirely by props and ship with Storybook stories (loading / loaded / empty / error) that run as interaction tests.

--- a/.changeset/squared-data-table-detail-row.md
+++ b/.changeset/squared-data-table-detail-row.md
@@ -1,0 +1,8 @@
+---
+'@lsst-sqre/squared': minor
+'squareone': patch
+---
+
+Add an optional `renderDetailRow` prop to `DataTable`. When provided, each data item renders as a two-row unit: the primary row of column cells, plus a full-width secondary row beneath it whose single cell spans every column. The detail `colSpan` tracks the leaf column count, leaving a clean path to a future expand-to-detail interaction with a dedicated expander column.
+
+The squareone admin notifications listing (`/admin/notifications`) uses this for a two-row layout: the sortable recipient, sender, and created columns now get the full table width (no more truncated headers), and the rendered-Markdown summary spans full-width beneath each row instead of competing for a column.

--- a/apps/squareone/src/app/admin/notifications/NotificationsPageClient.test.tsx
+++ b/apps/squareone/src/app/admin/notifications/NotificationsPageClient.test.tsx
@@ -79,6 +79,27 @@ describe('NotificationsPageClient', () => {
     expect(mockUseAdminNotifications).toHaveBeenCalledWith('', {});
   });
 
+  it('shows the loading state, not the empty state, while discovery is pending', () => {
+    // Discovery pending: the URL is undefined and the disabled query reports
+    // isLoading=false with no entries. The container should still surface a
+    // loading state rather than the misleading "no matches" empty state.
+    mockUseSemaphoreUrl.mockReturnValue(undefined);
+    mockUseAdminNotifications.mockReturnValue(
+      makeNotificationsReturn({
+        entries: undefined,
+        isLoading: false,
+        totalCount: null,
+      })
+    );
+
+    render(<NotificationsPageClient />);
+
+    expect(screen.getByText(/loading notifications/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/no notifications match/i)
+    ).not.toBeInTheDocument();
+  });
+
   it('renders the notifications table', () => {
     render(<NotificationsPageClient />);
 

--- a/apps/squareone/src/app/admin/notifications/NotificationsPageClient.test.tsx
+++ b/apps/squareone/src/app/admin/notifications/NotificationsPageClient.test.tsx
@@ -1,0 +1,166 @@
+import * as semaphoreClient from '@lsst-sqre/semaphore-client';
+import { mockAdminNotifications } from '@lsst-sqre/semaphore-client';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as useAdminNotificationFiltersModule from '../../../hooks/useAdminNotificationFilters';
+import * as useSemaphoreUrlModule from '../../../hooks/useSemaphoreUrl';
+import NotificationsPageClient from './NotificationsPageClient';
+
+vi.mock('@lsst-sqre/semaphore-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof semaphoreClient>();
+  return {
+    ...actual,
+    useAdminNotifications: vi.fn(),
+  };
+});
+vi.mock('../../../hooks/useSemaphoreUrl');
+vi.mock('../../../hooks/useAdminNotificationFilters');
+
+const mockUseAdminNotifications = vi.mocked(
+  semaphoreClient.useAdminNotifications
+);
+const mockUseSemaphoreUrl = vi.mocked(useSemaphoreUrlModule.useSemaphoreUrl);
+const mockUseAdminNotificationFilters = vi.mocked(
+  useAdminNotificationFiltersModule.default
+);
+
+function makeNotificationsReturn(
+  overrides: Partial<semaphoreClient.UseAdminNotificationsReturn> = {}
+): semaphoreClient.UseAdminNotificationsReturn {
+  return {
+    entries: mockAdminNotifications,
+    isLoading: false,
+    isFetching: false,
+    isLoadingMore: false,
+    error: null,
+    hasMore: false,
+    totalCount: mockAdminNotifications.length,
+    loadMore: vi.fn(),
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('NotificationsPageClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSemaphoreUrl.mockReturnValue('https://semaphore.example.com');
+    mockUseAdminNotificationFilters.mockReturnValue({
+      filters: {},
+      setFilter: vi.fn(),
+      clearAllFilters: vi.fn(),
+    });
+    mockUseAdminNotifications.mockReturnValue(makeNotificationsReturn());
+  });
+
+  it('fetches with the discovered Semaphore URL and the current filters', () => {
+    mockUseSemaphoreUrl.mockReturnValue('https://semaphore.example.com');
+    mockUseAdminNotificationFilters.mockReturnValue({
+      filters: { recipient: 'alice' },
+      setFilter: vi.fn(),
+      clearAllFilters: vi.fn(),
+    });
+
+    render(<NotificationsPageClient />);
+
+    expect(mockUseAdminNotifications).toHaveBeenCalledWith(
+      'https://semaphore.example.com',
+      { recipient: 'alice' }
+    );
+  });
+
+  it('passes an empty URL through so the query stays disabled before discovery', () => {
+    mockUseSemaphoreUrl.mockReturnValue(undefined);
+
+    render(<NotificationsPageClient />);
+
+    expect(mockUseAdminNotifications).toHaveBeenCalledWith('', {});
+  });
+
+  it('renders the notifications table', () => {
+    render(<NotificationsPageClient />);
+
+    expect(screen.getAllByText('alice').length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/showing 8 of 8 notifications/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders a loading state', () => {
+    mockUseAdminNotifications.mockReturnValue(
+      makeNotificationsReturn({ entries: undefined, isLoading: true })
+    );
+
+    render(<NotificationsPageClient />);
+
+    expect(screen.getByText(/loading notifications/i)).toBeInTheDocument();
+  });
+
+  it('routes a filter change through setFilter', async () => {
+    const user = userEvent.setup();
+    const setFilter = vi.fn();
+    mockUseAdminNotificationFilters.mockReturnValue({
+      filters: {},
+      setFilter,
+      clearAllFilters: vi.fn(),
+    });
+
+    render(<NotificationsPageClient />);
+
+    await user.type(screen.getByLabelText(/filter by recipient/i), 'a');
+
+    expect(setFilter).toHaveBeenCalledWith('recipient', 'a');
+  });
+
+  it('clears filters via clearAllFilters', async () => {
+    const user = userEvent.setup();
+    const clearAllFilters = vi.fn();
+    mockUseAdminNotificationFilters.mockReturnValue({
+      filters: { recipient: 'alice' },
+      setFilter: vi.fn(),
+      clearAllFilters,
+    });
+
+    render(<NotificationsPageClient />);
+
+    await user.click(
+      screen.getByRole('button', { name: /clear all filters/i })
+    );
+
+    expect(clearAllFilters).toHaveBeenCalled();
+  });
+
+  it('loads more pages', async () => {
+    const user = userEvent.setup();
+    const loadMore = vi.fn();
+    mockUseAdminNotifications.mockReturnValue(
+      makeNotificationsReturn({ hasMore: true, loadMore })
+    );
+
+    render(<NotificationsPageClient />);
+
+    await user.click(screen.getByRole('button', { name: /load more/i }));
+
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('retries via refetch on error', async () => {
+    const user = userEvent.setup();
+    const refetch = vi.fn();
+    mockUseAdminNotifications.mockReturnValue(
+      makeNotificationsReturn({
+        entries: undefined,
+        error: new Error('Boom'),
+        refetch,
+      })
+    );
+
+    render(<NotificationsPageClient />);
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(refetch).toHaveBeenCalled();
+  });
+});

--- a/apps/squareone/src/app/admin/notifications/NotificationsPageClient.tsx
+++ b/apps/squareone/src/app/admin/notifications/NotificationsPageClient.tsx
@@ -39,6 +39,17 @@ export default function NotificationsPageClient() {
     refetch,
   } = useAdminNotifications(semaphoreUrl ?? '', filters);
 
+  // While service discovery is pending the Semaphore URL is `undefined`, which
+  // keeps the underlying query disabled, so `isLoading` is `false` even though
+  // no data has arrived yet. Treat that pending window as loading so the table
+  // shows its loading state rather than the misleading "no matches" empty state.
+  const isDiscovering = semaphoreUrl === undefined;
+
+  // Each handler emitted by `NotificationFilters` carries exactly one key, so
+  // applying them one at a time is safe. If a future caller batches multiple
+  // keys into a single `partial`, route them through one URLSearchParams update
+  // instead: `setFilter` snapshots `searchParams`, so per-key calls here would
+  // clobber each other and only the last key would survive.
   const handleFilterChange = (partial: Partial<AdminNotificationFilters>) => {
     for (const [key, value] of Object.entries(partial)) {
       setFilter(
@@ -65,7 +76,7 @@ export default function NotificationsPageClient() {
 
       <NotificationsTableView
         notifications={entries}
-        isLoading={isLoading}
+        isLoading={isLoading || isDiscovering}
         error={error}
         hasMore={hasMore}
         isLoadingMore={isLoadingMore}

--- a/apps/squareone/src/app/admin/notifications/NotificationsPageClient.tsx
+++ b/apps/squareone/src/app/admin/notifications/NotificationsPageClient.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { AdminNotificationFilters } from '@lsst-sqre/semaphore-client';
+import { useAdminNotifications } from '@lsst-sqre/semaphore-client';
+
+import {
+  NotificationFilters,
+  NotificationsTableView,
+} from '../../../components/AdminNotifications';
+import useAdminNotificationFilters from '../../../hooks/useAdminNotificationFilters';
+import { useSemaphoreUrl } from '../../../hooks/useSemaphoreUrl';
+
+/**
+ * Client container for the `/admin/notifications` listing page.
+ *
+ * Resolves the Semaphore base URL from service discovery, reads the
+ * URL-captured filters, and fetches the notifications with cursor-based
+ * "Load more" pagination. The presentational work — the filter bar and the
+ * table with its loading/empty/error states — lives in
+ * {@link NotificationFilters} and {@link NotificationsTableView}; this
+ * component only wires data and callbacks together.
+ *
+ * The page sits behind the `exec:admin` gate inherited from the admin layout.
+ * While discovery is pending the Semaphore URL is `undefined`, which keeps the
+ * underlying query disabled (graceful degradation, as broadcasts already do).
+ */
+export default function NotificationsPageClient() {
+  const semaphoreUrl = useSemaphoreUrl();
+  const { filters, setFilter, clearAllFilters } = useAdminNotificationFilters();
+
+  const {
+    entries,
+    isLoading,
+    error,
+    hasMore,
+    isLoadingMore,
+    totalCount,
+    loadMore,
+    refetch,
+  } = useAdminNotifications(semaphoreUrl ?? '', filters);
+
+  const handleFilterChange = (partial: Partial<AdminNotificationFilters>) => {
+    for (const [key, value] of Object.entries(partial)) {
+      setFilter(
+        key as 'recipient' | 'sender' | 'since' | 'until',
+        value as string | Date | undefined
+      );
+    }
+  };
+
+  return (
+    <div>
+      <h1>User notifications</h1>
+      <p>
+        Recent notifications sent to Rubin Science Platform users, most recent
+        first. Filter by recipient, sender, or date range, or compose a new
+        notification.
+      </p>
+
+      <NotificationFilters
+        filters={filters}
+        onFilterChange={handleFilterChange}
+        onClearFilters={clearAllFilters}
+      />
+
+      <NotificationsTableView
+        notifications={entries}
+        isLoading={isLoading}
+        error={error}
+        hasMore={hasMore}
+        isLoadingMore={isLoadingMore}
+        totalCount={totalCount}
+        onLoadMore={loadMore}
+        onRetry={refetch}
+      />
+    </div>
+  );
+}

--- a/apps/squareone/src/app/admin/notifications/page.test.tsx
+++ b/apps/squareone/src/app/admin/notifications/page.test.tsx
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the RSC config loader so generateMetadata can run without the
+// filesystem-backed config.
+vi.mock('../../../lib/config/rsc', () => ({
+  getStaticConfig: vi.fn(),
+}));
+
+// Import after mocking.
+import type { AppConfig } from '../../../lib/config/loader';
+import { getStaticConfig } from '../../../lib/config/rsc';
+import { generateMetadata } from './page';
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    siteName: 'Rubin Science Platform',
+    ...overrides,
+  } as AppConfig;
+}
+
+describe('NotificationsPage generateMetadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('sets the page title from config.siteName', async () => {
+    vi.mocked(getStaticConfig).mockResolvedValue(makeConfig());
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.title).toBe('User notifications | Rubin Science Platform');
+  });
+
+  test('uses the configured siteName when it differs', async () => {
+    vi.mocked(getStaticConfig).mockResolvedValue(
+      makeConfig({ siteName: 'Telescope Ops' })
+    );
+
+    const metadata = await generateMetadata();
+
+    expect(metadata.title).toBe('User notifications | Telescope Ops');
+  });
+});

--- a/apps/squareone/src/app/admin/notifications/page.tsx
+++ b/apps/squareone/src/app/admin/notifications/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+
+import { getStaticConfig } from '../../../lib/config/rsc';
+import NotificationsPageClient from './NotificationsPageClient';
+
+const pageDescription =
+  'Browse and filter the user notifications sent via Semaphore';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const config = await getStaticConfig();
+  return {
+    title: `User notifications | ${config.siteName}`,
+    description: pageDescription,
+    openGraph: {
+      title: 'User notifications',
+      description: pageDescription,
+    },
+  };
+}
+
+/**
+ * Admin user-notifications listing page.
+ *
+ * Server component that mirrors the other admin pages: it derives the page
+ * metadata from the resolved app config and renders the client container that
+ * fetches and displays the notifications. The page sits inside the admin
+ * section, so it inherits the `AdminRequired` / `exec:admin` gate from the
+ * admin layout.
+ *
+ * The client container reads the filter state from the URL query string via
+ * `useSearchParams()` (through `useAdminNotificationFilters`), so it must sit
+ * under a `<Suspense>` boundary to satisfy the App Router's static-rendering
+ * requirement.
+ */
+export default function NotificationsPage() {
+  return (
+    <Suspense>
+      <NotificationsPageClient />
+    </Suspense>
+  );
+}

--- a/apps/squareone/src/components/AdminLayout/adminNavigation.test.ts
+++ b/apps/squareone/src/components/AdminLayout/adminNavigation.test.ts
@@ -17,7 +17,7 @@ const baseConfig: AppConfigContextValue = {
   mdxDir: 'src/content/pages',
 };
 
-test('generates a single flat section with the Sentry and service-token items', () => {
+test('generates a single flat section with the Sentry, service-token, and notification items', () => {
   const navigation = getAdminNavigation(baseConfig);
 
   expect(navigation).toHaveLength(1);
@@ -25,6 +25,7 @@ test('generates a single flat section with the Sentry and service-token items', 
     items: [
       { href: '/admin/sentry', label: 'Sentry' },
       { href: '/admin/service-tokens', label: 'Service tokens' },
+      { href: '/admin/notifications', label: 'User notifications' },
     ],
   });
 });
@@ -36,6 +37,16 @@ test('includes the service-token admin item', () => {
   expect(items).toContainEqual({
     href: '/admin/service-tokens',
     label: 'Service tokens',
+  });
+});
+
+test('includes the user-notifications admin item', () => {
+  const navigation = getAdminNavigation(baseConfig);
+  const items = navigation.flatMap((section) => section.items);
+
+  expect(items).toContainEqual({
+    href: '/admin/notifications',
+    label: 'User notifications',
   });
 });
 

--- a/apps/squareone/src/components/AdminLayout/adminNavigation.ts
+++ b/apps/squareone/src/components/AdminLayout/adminNavigation.ts
@@ -18,6 +18,7 @@ export function getAdminNavigation(
       items: [
         { href: '/admin/sentry', label: 'Sentry' },
         { href: '/admin/service-tokens', label: 'Service tokens' },
+        { href: '/admin/notifications', label: 'User notifications' },
       ],
     },
   ];

--- a/apps/squareone/src/components/AdminNotifications/NotificationFilters.module.css
+++ b/apps/squareone/src/components/AdminNotifications/NotificationFilters.module.css
@@ -1,0 +1,28 @@
+/* NotificationFilters: filter controls for the admin notifications listing */
+
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sqo-space-md);
+  align-items: end;
+  margin-bottom: var(--sqo-space-md);
+}
+
+.filterGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sqo-space-xxs);
+}
+
+.filterLabel {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--rsd-color-gray-500);
+}
+
+/* Responsive layout: full width on mobile */
+@media (max-width: 768px) {
+  .filterGroup {
+    width: 100%;
+  }
+}

--- a/apps/squareone/src/components/AdminNotifications/NotificationFilters.test.tsx
+++ b/apps/squareone/src/components/AdminNotifications/NotificationFilters.test.tsx
@@ -1,0 +1,91 @@
+import type { AdminNotificationFilters } from '@lsst-sqre/semaphore-client';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import NotificationFilters from './NotificationFilters';
+
+function renderFilters(
+  overrides: Partial<{
+    filters: AdminNotificationFilters;
+    onFilterChange: (partial: Partial<AdminNotificationFilters>) => void;
+    onClearFilters: () => void;
+  }> = {}
+) {
+  const props = {
+    filters: {} as AdminNotificationFilters,
+    onFilterChange: vi.fn(),
+    onClearFilters: vi.fn(),
+    ...overrides,
+  };
+  render(
+    <NotificationFilters
+      filters={props.filters}
+      onFilterChange={props.onFilterChange}
+      onClearFilters={props.onClearFilters}
+    />
+  );
+  return props;
+}
+
+describe('NotificationFilters', () => {
+  it('renders recipient, sender, and date-range controls', () => {
+    renderFilters();
+
+    expect(screen.getByLabelText(/filter by recipient/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/filter by sender/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/filter by start date/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/filter by end date/i)).toBeInTheDocument();
+  });
+
+  it('seeds the recipient and sender inputs from the current filters', () => {
+    renderFilters({ filters: { recipient: 'alice', sender: 'ops-runbook' } });
+
+    expect(screen.getByLabelText(/filter by recipient/i)).toHaveValue('alice');
+    expect(screen.getByLabelText(/filter by sender/i)).toHaveValue(
+      'ops-runbook'
+    );
+  });
+
+  it('reports recipient input changes', async () => {
+    const user = userEvent.setup();
+    const { onFilterChange } = renderFilters();
+
+    await user.type(screen.getByLabelText(/filter by recipient/i), 'a');
+
+    expect(onFilterChange).toHaveBeenCalledWith({ recipient: 'a' });
+  });
+
+  it('reports sender input changes', async () => {
+    const user = userEvent.setup();
+    const { onFilterChange } = renderFilters();
+
+    await user.type(screen.getByLabelText(/filter by sender/i), 'b');
+
+    expect(onFilterChange).toHaveBeenCalledWith({ sender: 'b' });
+  });
+
+  it('clears the recipient filter when the input is emptied', async () => {
+    const user = userEvent.setup();
+    const { onFilterChange } = renderFilters({
+      filters: { recipient: 'alice' },
+    });
+
+    await user.clear(screen.getByLabelText(/filter by recipient/i));
+
+    expect(onFilterChange).toHaveBeenCalledWith({ recipient: undefined });
+  });
+
+  it('invokes the clear-all handler', async () => {
+    const user = userEvent.setup();
+    const { onClearFilters } = renderFilters({
+      filters: { recipient: 'alice' },
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: /clear all filters/i })
+    );
+
+    expect(onClearFilters).toHaveBeenCalled();
+  });
+});

--- a/apps/squareone/src/components/AdminNotifications/NotificationFilters.tsx
+++ b/apps/squareone/src/components/AdminNotifications/NotificationFilters.tsx
@@ -1,0 +1,126 @@
+import type { AdminNotificationFilters } from '@lsst-sqre/semaphore-client';
+import { Button, DateTimePicker, TextInput } from '@lsst-sqre/squared';
+import { X } from 'lucide-react';
+import type React from 'react';
+
+import styles from './NotificationFilters.module.css';
+
+export type NotificationFiltersProps = {
+  /** The current filter values, typically derived from the URL. */
+  filters: AdminNotificationFilters;
+  /** Called with the subset of filters that changed. */
+  onFilterChange: (filters: Partial<AdminNotificationFilters>) => void;
+  /** Called when the user clears every filter at once. */
+  onClearFilters: () => void;
+};
+
+/**
+ * Presentational filter bar for the admin notifications listing.
+ *
+ * Renders recipient/sender text inputs and since/until date-time pickers, plus
+ * a clear-all control. It owns no state: values are seeded from `filters` and
+ * every change is reported through `onFilterChange` (the container persists
+ * them to the URL). The date pickers are keyed by their current value so a
+ * change to `filters` from outside (e.g. loading a bookmarked URL) re-seeds
+ * the uncontrolled picker.
+ */
+export default function NotificationFilters({
+  filters,
+  onFilterChange,
+  onClearFilters,
+}: NotificationFiltersProps) {
+  const handleRecipientChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.trim();
+    onFilterChange({ recipient: value || undefined });
+  };
+
+  const handleSenderChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.trim();
+    onFilterChange({ sender: value || undefined });
+  };
+
+  const handleSinceChange = (iso: string) => {
+    onFilterChange({ since: iso ? new Date(iso) : undefined });
+  };
+
+  const handleUntilChange = (iso: string) => {
+    onFilterChange({ until: iso ? new Date(iso) : undefined });
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.filterGroup}>
+        <label htmlFor="filter-recipient" className={styles.filterLabel}>
+          Recipient
+        </label>
+        <TextInput
+          id="filter-recipient"
+          type="text"
+          value={filters.recipient || ''}
+          onChange={handleRecipientChange}
+          placeholder="Username"
+          size="sm"
+          aria-label="Filter by recipient"
+        />
+      </div>
+
+      <div className={styles.filterGroup}>
+        <label htmlFor="filter-sender" className={styles.filterLabel}>
+          Sender
+        </label>
+        <TextInput
+          id="filter-sender"
+          type="text"
+          value={filters.sender || ''}
+          onChange={handleSenderChange}
+          placeholder="Sender"
+          size="sm"
+          aria-label="Filter by sender"
+        />
+      </div>
+
+      <div className={styles.filterGroup}>
+        <label htmlFor="filter-since" className={styles.filterLabel}>
+          Since
+        </label>
+        <DateTimePicker
+          key={`since-${filters.since?.toISOString() ?? 'none'}`}
+          defaultValue={filters.since?.toISOString() || ''}
+          onChange={handleSinceChange}
+          defaultTimezone="local"
+          showTimezone={true}
+          placeholder="Start date"
+          size="sm"
+          aria-label="Filter by start date"
+        />
+      </div>
+
+      <div className={styles.filterGroup}>
+        <label htmlFor="filter-until" className={styles.filterLabel}>
+          Until
+        </label>
+        <DateTimePicker
+          key={`until-${filters.until?.toISOString() ?? 'none'}`}
+          defaultValue={filters.until?.toISOString() || ''}
+          onChange={handleUntilChange}
+          defaultTimezone="local"
+          showTimezone={true}
+          placeholder="End date"
+          size="sm"
+          aria-label="Filter by end date"
+        />
+      </div>
+
+      <Button
+        appearance="outline"
+        tone="secondary"
+        size="sm"
+        leadingIcon={X}
+        onClick={onClearFilters}
+        aria-label="Clear all filters"
+      >
+        Clear filters
+      </Button>
+    </div>
+  );
+}

--- a/apps/squareone/src/components/AdminNotifications/NotificationsTableView.module.css
+++ b/apps/squareone/src/components/AdminNotifications/NotificationsTableView.module.css
@@ -40,7 +40,14 @@
   color: var(--rsd-color-gray-500);
 }
 
-/* Collapse the rendered-Markdown summary so it sits inline within the table
+/* The rendered-Markdown summary now sits in a full-width detail row beneath
+ * its primary row; mute it slightly so the primary recipient/sender/created
+ * row stays the visual anchor. */
+.summary {
+  color: var(--rsd-color-gray-600);
+}
+
+/* Collapse the rendered-Markdown summary so it sits inline within the detail
  * cell rather than introducing paragraph block spacing. */
 .summary :global(p) {
   margin: 0;

--- a/apps/squareone/src/components/AdminNotifications/NotificationsTableView.module.css
+++ b/apps/squareone/src/components/AdminNotifications/NotificationsTableView.module.css
@@ -1,0 +1,47 @@
+/* NotificationsTableView: admin notifications listing table + states */
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sqo-space-md);
+  width: 100%;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.loadingState,
+.errorState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sqo-space-xs);
+  padding: var(--sqo-space-xl);
+  text-align: center;
+  color: var(--rsd-color-gray-500);
+}
+
+.errorState {
+  color: var(--rsd-color-red-500);
+}
+
+.errorMessage {
+  font-size: 0.875rem;
+  color: var(--rsd-color-gray-600);
+}
+
+.count {
+  padding-top: var(--sqo-space-sm);
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--rsd-color-gray-500);
+}
+
+/* Collapse the rendered-Markdown summary so it sits inline within the table
+ * cell rather than introducing paragraph block spacing. */
+.summary :global(p) {
+  margin: 0;
+}

--- a/apps/squareone/src/components/AdminNotifications/NotificationsTableView.stories.tsx
+++ b/apps/squareone/src/components/AdminNotifications/NotificationsTableView.stories.tsx
@@ -1,0 +1,121 @@
+import { mockAdminNotifications } from '@lsst-sqre/semaphore-client';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import NotificationsTableView from './NotificationsTableView';
+
+const meta: Meta<typeof NotificationsTableView> = {
+  title: 'Components/AdminNotifications/NotificationsTableView',
+  component: NotificationsTableView,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The default loaded view: a table of notifications with a shown-of-total
+ * count and a Compose button.
+ */
+export const Loaded: Story = {
+  args: {
+    notifications: mockAdminNotifications,
+    totalCount: mockAdminNotifications.length,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Recipient and sender of the fixtures render in the table (recipients
+    // recur across rows, so there is more than one "alice").
+    await expect(canvas.getAllByText('alice').length).toBeGreaterThan(0);
+    await expect(
+      canvas.getAllByText('bot-quota-notifier').length
+    ).toBeGreaterThan(0);
+
+    // The summary Markdown renders to HTML (the `**quota**` emphasis).
+    const emphasized = canvas.getByText('quota');
+    await expect(emphasized.tagName).toBe('STRONG');
+
+    // The shown-of-total count and Compose button are present.
+    await expect(
+      canvas.getByText(/showing 8 of 8 notifications/i)
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('link', { name: /compose/i })
+    ).toHaveAttribute('href', '/admin/notifications/new');
+  },
+};
+
+/**
+ * "Load more" is shown when more pages are available; loading is owned by the
+ * caller and reflected on the button.
+ */
+export const WithLoadMore: Story = {
+  name: 'With load more',
+  args: {
+    notifications: mockAdminNotifications.slice(0, 5),
+    totalCount: mockAdminNotifications.length,
+    hasMore: true,
+    onLoadMore: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const loadMore = canvas.getByRole('button', { name: /load more/i });
+    await userEvent.click(loadMore);
+    await expect(args.onLoadMore).toHaveBeenCalled();
+  },
+};
+
+/** The initial loading state, before the first page resolves. */
+export const Loading: Story = {
+  args: {
+    notifications: undefined,
+    isLoading: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/loading notifications/i)
+    ).toBeInTheDocument();
+  },
+};
+
+/** The empty state, when the query succeeds but matches nothing. */
+export const Empty: Story = {
+  args: {
+    notifications: [],
+    totalCount: 0,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText(/no notifications match your filters/i)
+    ).toBeInTheDocument();
+  },
+};
+
+/** The error state, with a retry affordance that calls back to the caller. */
+export const ErrorState: Story = {
+  name: 'Error',
+  args: {
+    notifications: undefined,
+    error: new Error('Semaphore is unavailable'),
+    onRetry: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByText(/failed to load notifications/i)
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByText('Semaphore is unavailable')
+    ).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: /retry/i }));
+    await expect(args.onRetry).toHaveBeenCalled();
+  },
+};

--- a/apps/squareone/src/components/AdminNotifications/NotificationsTableView.test.tsx
+++ b/apps/squareone/src/components/AdminNotifications/NotificationsTableView.test.tsx
@@ -1,0 +1,92 @@
+import { mockAdminNotifications } from '@lsst-sqre/semaphore-client';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import NotificationsTableView from './NotificationsTableView';
+
+describe('NotificationsTableView', () => {
+  it('renders a loading state', () => {
+    render(<NotificationsTableView notifications={undefined} isLoading />);
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it('renders an error state with a retry control', async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(
+      <NotificationsTableView
+        notifications={undefined}
+        error={new Error('Boom')}
+        onRetry={onRetry}
+      />
+    );
+
+    expect(
+      screen.getByText(/failed to load notifications/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Boom')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalled();
+  });
+
+  it('renders recipient, sender, and a rendered Markdown summary', () => {
+    render(
+      <NotificationsTableView
+        notifications={mockAdminNotifications.slice(0, 1)}
+        totalCount={1}
+      />
+    );
+
+    // recipient + sender of the first fixture
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bot-quota-notifier')).toBeInTheDocument();
+    // The summary Markdown (`**quota**`) is rendered to a <strong> element.
+    const emphasized = screen.getByText('quota');
+    expect(emphasized.tagName).toBe('STRONG');
+  });
+
+  it('renders an empty state when there are no notifications', () => {
+    render(<NotificationsTableView notifications={[]} totalCount={0} />);
+
+    expect(screen.getByText(/no notifications match/i)).toBeInTheDocument();
+  });
+
+  it('shows a shown-of-total count', () => {
+    render(
+      <NotificationsTableView
+        notifications={mockAdminNotifications.slice(0, 3)}
+        totalCount={8}
+      />
+    );
+
+    expect(screen.getByText(/showing 3 of 8/i)).toBeInTheDocument();
+  });
+
+  it('exposes a Load more control that invokes the handler', async () => {
+    const user = userEvent.setup();
+    const onLoadMore = vi.fn();
+    render(
+      <NotificationsTableView
+        notifications={mockAdminNotifications.slice(0, 3)}
+        totalCount={8}
+        hasMore
+        onLoadMore={onLoadMore}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /load more/i }));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('links the Compose button to the compose route', () => {
+    render(<NotificationsTableView notifications={[]} />);
+
+    expect(screen.getByRole('link', { name: /compose/i })).toHaveAttribute(
+      'href',
+      '/admin/notifications/new'
+    );
+  });
+});

--- a/apps/squareone/src/components/AdminNotifications/NotificationsTableView.test.tsx
+++ b/apps/squareone/src/components/AdminNotifications/NotificationsTableView.test.tsx
@@ -46,6 +46,12 @@ describe('NotificationsTableView', () => {
     // The summary Markdown (`**quota**`) is rendered to a <strong> element.
     const emphasized = screen.getByText('quota');
     expect(emphasized.tagName).toBe('STRONG');
+
+    // The summary now lives in a full-width detail row, not a column, so
+    // there is no "Summary" column header.
+    expect(
+      screen.queryByRole('columnheader', { name: /Summary/ })
+    ).not.toBeInTheDocument();
   });
 
   it('renders an empty state when there are no notifications', () => {

--- a/apps/squareone/src/components/AdminNotifications/NotificationsTableView.tsx
+++ b/apps/squareone/src/components/AdminNotifications/NotificationsTableView.tsx
@@ -1,0 +1,147 @@
+import type { UserNotificationWithUrl } from '@lsst-sqre/semaphore-client';
+import { Button, DataTable, type DataTableProps } from '@lsst-sqre/squared';
+import { PlusCircle } from 'lucide-react';
+import Link from 'next/link';
+
+import RenderedMarkdown from '../RenderedMarkdown';
+import styles from './NotificationsTableView.module.css';
+
+/** Where the "Compose" button links by default. */
+const DEFAULT_COMPOSE_HREF = '/admin/notifications/new';
+
+export type NotificationsTableViewProps = {
+  /** The currently-loaded notifications (server order, most-recent first). */
+  notifications: UserNotificationWithUrl[] | undefined;
+  /** Whether the initial page is loading. */
+  isLoading?: boolean;
+  /** Set when the listing failed to load. */
+  error?: Error | null;
+  /** Whether more pages are available from the server. */
+  hasMore?: boolean;
+  /** Whether the next page is currently loading. */
+  isLoadingMore?: boolean;
+  /** Total number of notifications in the (filtered) result set. */
+  totalCount?: number | null;
+  /** Fetch the next page of older notifications. */
+  onLoadMore?: () => void;
+  /** Retry the listing query after an error. */
+  onRetry?: () => void;
+  /** Override the "Compose" button target (defaults to the compose route). */
+  composeHref?: string;
+};
+
+/**
+ * Format an ISO 8601 timestamp as a stable, timezone-independent `YYYY-MM-DD
+ * HH:MM UTC` string for the Created column.
+ */
+function formatCreated(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return iso;
+  }
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  return `${year}-${month}-${day} ${hours}:${minutes} UTC`;
+}
+
+const columns: DataTableProps<UserNotificationWithUrl>['columns'] = [
+  { accessorKey: 'recipient', header: 'Recipient' },
+  { accessorKey: 'sender', header: 'Sender' },
+  {
+    accessorKey: 'created',
+    header: 'Created',
+    cell: (info) => formatCreated(info.getValue<string>()),
+  },
+  {
+    accessorKey: 'summary',
+    header: 'Summary',
+    enableSorting: false,
+    cell: (info) => (
+      <RenderedMarkdown
+        className={styles.summary}
+        markdown={info.getValue<string>()}
+      />
+    ),
+  },
+];
+
+/**
+ * Presentational view of the admin notifications listing.
+ *
+ * Renders a "Compose" button plus the notifications {@link DataTable}
+ * (recipient / sender / created / rendered-Markdown summary), a caller-owned
+ * "Load more" control, a shown-of-total count, and the loading, empty, and
+ * error-with-retry states. It is fully driven by props so it can be exercised
+ * from Storybook with fixtures; data fetching lives in the container.
+ */
+export default function NotificationsTableView({
+  notifications,
+  isLoading = false,
+  error = null,
+  hasMore = false,
+  isLoadingMore = false,
+  totalCount = null,
+  onLoadMore,
+  onRetry,
+  composeHref = DEFAULT_COMPOSE_HREF,
+}: NotificationsTableViewProps) {
+  const entries = notifications ?? [];
+  const shownCount = entries.length;
+
+  let body: React.ReactNode;
+  if (isLoading) {
+    body = <div className={styles.loadingState}>Loading notifications…</div>;
+  } else if (error) {
+    body = (
+      <div className={styles.errorState}>
+        <p>Failed to load notifications</p>
+        <p className={styles.errorMessage}>{error.message}</p>
+        <Button
+          appearance="outline"
+          tone="secondary"
+          size="sm"
+          onClick={onRetry}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  } else {
+    body = (
+      <>
+        <DataTable
+          columns={columns}
+          data={entries}
+          hasMore={hasMore}
+          isLoadingMore={isLoadingMore}
+          onLoadMore={onLoadMore}
+          aria-label="User notifications"
+          emptyContent="No notifications match your filters."
+        />
+        {shownCount > 0 && (
+          <div className={styles.count}>
+            Showing {shownCount}
+            {totalCount !== null && totalCount !== undefined
+              ? ` of ${totalCount}`
+              : ''}{' '}
+            notifications
+          </div>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.toolbar}>
+        <Button as={Link} href={composeHref} leadingIcon={PlusCircle} size="sm">
+          Compose
+        </Button>
+      </div>
+      {body}
+    </div>
+  );
+}

--- a/apps/squareone/src/components/AdminNotifications/NotificationsTableView.tsx
+++ b/apps/squareone/src/components/AdminNotifications/NotificationsTableView.tsx
@@ -55,27 +55,18 @@ const columns: DataTableProps<UserNotificationWithUrl>['columns'] = [
     header: 'Created',
     cell: (info) => formatCreated(info.getValue<string>()),
   },
-  {
-    accessorKey: 'summary',
-    header: 'Summary',
-    enableSorting: false,
-    cell: (info) => (
-      <RenderedMarkdown
-        className={styles.summary}
-        markdown={info.getValue<string>()}
-      />
-    ),
-  },
 ];
 
 /**
  * Presentational view of the admin notifications listing.
  *
- * Renders a "Compose" button plus the notifications {@link DataTable}
- * (recipient / sender / created / rendered-Markdown summary), a caller-owned
- * "Load more" control, a shown-of-total count, and the loading, empty, and
- * error-with-retry states. It is fully driven by props so it can be exercised
- * from Storybook with fixtures; data fetching lives in the container.
+ * Renders a "Compose" button plus the notifications {@link DataTable}. Each
+ * notification is a two-row unit: a primary row with the sortable recipient,
+ * sender, and created columns, and a full-width secondary row beneath it
+ * holding the rendered-Markdown summary (no column header). The view also
+ * owns a "Load more" control, a shown-of-total count, and the loading, empty,
+ * and error-with-retry states. It is fully driven by props so it can be
+ * exercised from Storybook with fixtures; data fetching lives in the container.
  */
 export default function NotificationsTableView({
   notifications,
@@ -120,6 +111,9 @@ export default function NotificationsTableView({
           onLoadMore={onLoadMore}
           aria-label="User notifications"
           emptyContent="No notifications match your filters."
+          renderDetailRow={(n) => (
+            <RenderedMarkdown className={styles.summary} markdown={n.summary} />
+          )}
         />
         {shownCount > 0 && (
           <div className={styles.count}>

--- a/apps/squareone/src/components/AdminNotifications/index.ts
+++ b/apps/squareone/src/components/AdminNotifications/index.ts
@@ -1,0 +1,4 @@
+export type { NotificationFiltersProps } from './NotificationFilters';
+export { default as NotificationFilters } from './NotificationFilters';
+export type { NotificationsTableViewProps } from './NotificationsTableView';
+export { default as NotificationsTableView } from './NotificationsTableView';

--- a/apps/squareone/src/hooks/useAdminNotificationFilters.test.tsx
+++ b/apps/squareone/src/hooks/useAdminNotificationFilters.test.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import useAdminNotificationFilters from './useAdminNotificationFilters';
+
+// Mock Next.js App Router navigation hooks
+const mockPush = vi.fn();
+const mockPathname = '/admin/notifications';
+let mockSearchParams = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  usePathname: () => mockPathname,
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe('useAdminNotificationFilters', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it('parses recipient, sender, and date filters from the URL', () => {
+    mockSearchParams = new URLSearchParams({
+      recipient: 'alice',
+      sender: 'ops-runbook',
+      since: '2026-06-01T00:00:00.000Z',
+      until: '2026-06-30T23:59:59.000Z',
+    });
+
+    const { result } = renderHook(() => useAdminNotificationFilters());
+
+    expect(result.current.filters.recipient).toBe('alice');
+    expect(result.current.filters.sender).toBe('ops-runbook');
+    expect(result.current.filters.since).toEqual(
+      new Date('2026-06-01T00:00:00.000Z')
+    );
+    expect(result.current.filters.until).toEqual(
+      new Date('2026-06-30T23:59:59.000Z')
+    );
+  });
+
+  it('returns empty filters when there are no query parameters', () => {
+    mockSearchParams = new URLSearchParams();
+
+    const { result } = renderHook(() => useAdminNotificationFilters());
+
+    expect(result.current.filters.recipient).toBeUndefined();
+    expect(result.current.filters.sender).toBeUndefined();
+    expect(result.current.filters.since).toBeUndefined();
+    expect(result.current.filters.until).toBeUndefined();
+  });
+
+  it('serializes a recipient filter into the URL', () => {
+    const { result } = renderHook(() => useAdminNotificationFilters());
+
+    act(() => {
+      result.current.setFilter('recipient', 'alice');
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/admin/notifications?recipient=alice'
+    );
+  });
+
+  it('serializes a sender filter into the URL', () => {
+    const { result } = renderHook(() => useAdminNotificationFilters());
+
+    act(() => {
+      result.current.setFilter('sender', 'ops-runbook');
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/admin/notifications?sender=ops-runbook'
+    );
+  });
+
+  it('serializes a date filter as an ISO string', () => {
+    const { result } = renderHook(() => useAdminNotificationFilters());
+    const testDate = new Date('2026-06-01T00:00:00.000Z');
+
+    act(() => {
+      result.current.setFilter('since', testDate);
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/admin/notifications?since=2026-06-01T00%3A00%3A00.000Z'
+    );
+  });
+
+  it('preserves existing filters when setting a new one (filters combine)', () => {
+    mockSearchParams = new URLSearchParams({ recipient: 'alice' });
+
+    const { result } = renderHook(() => useAdminNotificationFilters());
+
+    act(() => {
+      result.current.setFilter('sender', 'ops-runbook');
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/admin/notifications?recipient=alice&sender=ops-runbook'
+    );
+  });
+
+  it('removes a filter when set to undefined', () => {
+    mockSearchParams = new URLSearchParams({ recipient: 'alice' });
+
+    const { result } = renderHook(() => useAdminNotificationFilters());
+
+    act(() => {
+      result.current.setFilter('recipient', undefined);
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/admin/notifications');
+  });
+
+  it('clears all filters', () => {
+    mockSearchParams = new URLSearchParams({
+      recipient: 'alice',
+      sender: 'ops-runbook',
+      since: '2026-06-01T00:00:00.000Z',
+    });
+
+    const { result } = renderHook(() => useAdminNotificationFilters());
+
+    act(() => {
+      result.current.clearAllFilters();
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/admin/notifications');
+  });
+
+  it('ignores invalid date strings in the URL', () => {
+    mockSearchParams = new URLSearchParams({
+      since: 'not-a-date',
+      until: 'also-invalid',
+    });
+
+    const { result } = renderHook(() => useAdminNotificationFilters());
+
+    expect(result.current.filters.since).toBeUndefined();
+    expect(result.current.filters.until).toBeUndefined();
+  });
+});

--- a/apps/squareone/src/hooks/useAdminNotificationFilters.ts
+++ b/apps/squareone/src/hooks/useAdminNotificationFilters.ts
@@ -1,0 +1,93 @@
+import type { AdminNotificationFilters } from '@lsst-sqre/semaphore-client';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useMemo } from 'react';
+
+/**
+ * Filter keys this hook serializes to and from the URL query string.
+ *
+ * `limit` (part of {@link AdminNotificationFilters}) is intentionally excluded:
+ * page size is owned by the listing container, not the bookmarkable URL.
+ */
+type UrlFilterKey = 'recipient' | 'sender' | 'since' | 'until';
+
+type UseAdminNotificationFiltersReturn = {
+  filters: AdminNotificationFilters;
+  setFilter: <K extends UrlFilterKey>(
+    key: K,
+    value: AdminNotificationFilters[K]
+  ) => void;
+  clearAllFilters: () => void;
+};
+
+/**
+ * Parse a date from an ISO string in a URL parameter.
+ */
+function parseDate(value: string | null): Date | undefined {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+/**
+ * Parse a string from a URL parameter.
+ */
+function parseString(value: string | null): string | undefined {
+  return value || undefined;
+}
+
+/**
+ * Manage admin notification filter state via the URL query string.
+ *
+ * Modeled on {@link useTokenHistoryFilters}: the URL is the single source of
+ * truth for the `recipient`, `sender`, `since`, and `until` filters, so a
+ * filtered view can be bookmarked or shared and is reproduced exactly when the
+ * URL is loaded. Dates are serialized as ISO 8601 strings. Filters combine —
+ * setting one preserves the others.
+ *
+ * Uses the Next.js App Router navigation hooks (`useRouter`, `usePathname`,
+ * `useSearchParams`).
+ *
+ * @returns The current `filters`, a `setFilter` updater, and `clearAllFilters`.
+ */
+export default function useAdminNotificationFilters(): UseAdminNotificationFiltersReturn {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Parse the current filters from the URL search params. Each filter key maps
+  // directly to a query parameter of the same name (matching the Semaphore
+  // admin list endpoint's query parameters).
+  const filters = useMemo<AdminNotificationFilters>(
+    () => ({
+      recipient: parseString(searchParams.get('recipient')),
+      sender: parseString(searchParams.get('sender')),
+      since: parseDate(searchParams.get('since')),
+      until: parseDate(searchParams.get('until')),
+    }),
+    [searchParams]
+  );
+
+  const setFilter = useCallback(
+    <K extends UrlFilterKey>(key: K, value: AdminNotificationFilters[K]) => {
+      const params = new URLSearchParams(searchParams.toString());
+
+      if (value === undefined || value === null) {
+        params.delete(key);
+      } else if (value instanceof Date) {
+        params.set(key, value.toISOString());
+      } else {
+        params.set(key, String(value));
+      }
+
+      const queryString = params.toString();
+      router.push(queryString ? `${pathname}?${queryString}` : pathname);
+    },
+    [router, pathname, searchParams]
+  );
+
+  const clearAllFilters = useCallback(() => {
+    router.push(pathname);
+  }, [router, pathname]);
+
+  return { filters, setFilter, clearAllFilters };
+}

--- a/packages/squared/src/components/DataTable/DataTable.module.css
+++ b/packages/squared/src/components/DataTable/DataTable.module.css
@@ -87,8 +87,32 @@
   border-bottom: 1px solid var(--rsd-color-gray-100);
 }
 
+/* When a detail row is present, the separator lives on the <tbody> group so
+ * the primary row and its detail row read as a single unit. */
+.rowGroup {
+  border-bottom: 1px solid var(--rsd-color-gray-100);
+}
+
+/* The primary row of a detail-row pair carries no separator of its own; the
+ * .rowGroup draws the divider beneath the pair. */
+.primaryRow {
+  border-bottom: none;
+}
+
 .cell {
   padding: var(--sqo-space-xs) var(--sqo-space-sm);
+  text-align: left;
+  vertical-align: top;
+}
+
+/* The full-width secondary row hugs its primary row: reduced top padding and
+ * no separator of its own (the .rowGroup carries the separator). */
+.detailRow {
+  border-bottom: none;
+}
+
+.detailCell {
+  padding: 0 var(--sqo-space-sm) var(--sqo-space-sm) var(--sqo-space-sm);
   text-align: left;
   vertical-align: top;
 }

--- a/packages/squared/src/components/DataTable/DataTable.stories.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.stories.tsx
@@ -88,6 +88,40 @@ export const WithRenderedCells: Story = {
   },
 };
 
+// `renderDetailRow` renders a full-width secondary row beneath each primary
+// row. The sortable columns get the full table width while the wide content
+// (here a summary) spans every column below — a two-row layout per item.
+export const WithDetailRow: Story = {
+  name: 'With detail row',
+  render: () => {
+    const primaryColumns: ColumnDef<NotificationRow>[] = [
+      { accessorKey: 'recipient', header: 'Recipient' },
+      { accessorKey: 'sender', header: 'Sender' },
+      { accessorKey: 'created', header: 'Created' },
+    ];
+    return (
+      <DataTable
+        columns={primaryColumns}
+        data={rows}
+        renderDetailRow={(row) => row.summary}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The summary content appears full-width beneath its primary row.
+    await expect(
+      canvas.getByText('Your notebook finished executing.')
+    ).toBeInTheDocument();
+
+    // There is no "Summary" column header; the detail row carries it instead.
+    await expect(
+      canvas.queryByRole('columnheader', { name: /Summary/ })
+    ).not.toBeInTheDocument();
+  },
+};
+
 export const Empty: Story = {
   render: () => (
     <DataTable

--- a/packages/squared/src/components/DataTable/DataTable.test.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.test.tsx
@@ -163,6 +163,40 @@ describe('DataTable', () => {
     expect(sortedCells[0]).toHaveTextContent('Alpha');
   });
 
+  it('renders a detail row per data item with a full-width cell when renderDetailRow is provided', () => {
+    const { container } = render(
+      <DataTable
+        columns={columns}
+        data={data}
+        renderDetailRow={(row) => <span>detail: {row.name}</span>}
+      />
+    );
+
+    // One detail row per data item, each holding a single cell that spans
+    // every column.
+    const detailCells = Array.from(
+      container.querySelectorAll('td[colspan]')
+    ).filter((cell) => cell.getAttribute('colspan') === String(columns.length));
+    expect(detailCells).toHaveLength(data.length);
+
+    // The detail content is rendered for each item.
+    expect(screen.getByText('detail: Alpha')).toBeInTheDocument();
+    expect(screen.getByText('detail: Bravo')).toBeInTheDocument();
+  });
+
+  it('still renders the primary cell values alongside detail rows', () => {
+    render(
+      <DataTable
+        columns={columns}
+        data={data}
+        renderDetailRow={(row) => <span>detail: {row.name}</span>}
+      />
+    );
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Bravo')).toBeInTheDocument();
+  });
+
   it('applies a custom className to the table wrapper', () => {
     const { container } = render(
       <DataTable columns={columns} data={data} className="custom-class" />

--- a/packages/squared/src/components/DataTable/DataTable.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.tsx
@@ -56,6 +56,23 @@ export type DataTableProps<TData> = {
   loadMoreLabel?: string;
   /** Content rendered in the table body when there are no rows. */
   emptyContent?: React.ReactNode;
+  /**
+   * Optionally render a full-width secondary row beneath each primary row.
+   *
+   * When provided, every data item renders as a pair of `<tr>`s inside its
+   * own `<tbody>`: the primary row of column cells, followed by a secondary
+   * row whose single cell spans all columns (`colSpan`) and holds whatever
+   * this returns. The notifications listing uses this to place a rendered
+   * Markdown summary full-width beneath its recipient/sender/created row.
+   *
+   * The detail `colSpan` tracks the leaf column count, so this is
+   * forward-compatible with adding a leading expander column for a future
+   * expand-to-detail interaction: the secondary slot can swap its content on
+   * the row's expanded state without changing this signature's shape.
+   *
+   * When omitted, each item renders as a single `<tr>` (backward compatible).
+   */
+  renderDetailRow?: (row: TData) => React.ReactNode;
   /** Optional visible caption describing the table. */
   caption?: React.ReactNode;
   /**
@@ -131,6 +148,7 @@ export function DataTable<TData>({
   caption,
   'aria-label': ariaLabel,
   className,
+  renderDetailRow,
 }: DataTableProps<TData>) {
   const [sorting, setSorting] = React.useState<SortingState>(initialSorting);
 
@@ -208,15 +226,37 @@ export function DataTable<TData>({
             </tr>
           ))}
         </thead>
-        <tbody>
-          {rows.length === 0 ? (
+        {rows.length === 0 ? (
+          <tbody>
             <tr className={styles.row}>
               <td className={styles.emptyCell} colSpan={columnCount}>
                 {emptyContent}
               </td>
             </tr>
-          ) : (
-            rows.map((row) => (
+          </tbody>
+        ) : renderDetailRow ? (
+          // Each item is its own <tbody> (multiple tbodies are valid HTML)
+          // holding a primary row of cells plus a full-width detail row, so
+          // the pair reads as one unit.
+          rows.map((row) => (
+            <tbody key={row.id} className={styles.rowGroup}>
+              <tr className={styles.primaryRow}>
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className={styles.cell}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+              <tr className={styles.detailRow}>
+                <td className={styles.detailCell} colSpan={columnCount}>
+                  {renderDetailRow(row.original)}
+                </td>
+              </tr>
+            </tbody>
+          ))
+        ) : (
+          <tbody>
+            {rows.map((row) => (
               <tr key={row.id} className={styles.row}>
                 {row.getVisibleCells().map((cell) => (
                   <td key={cell.id} className={styles.cell}>
@@ -224,9 +264,9 @@ export function DataTable<TData>({
                   </td>
                 ))}
               </tr>
-            ))
-          )}
-        </tbody>
+            ))}
+          </tbody>
+        )}
       </table>
 
       {showLoadMore ? (


### PR DESCRIPTION
## Summary

- Add the `/admin/notifications` listing page (reachable from the new "User notifications" admin sidebar entry, under the inherited `exec:admin` gate): a `DataTable` of recent notifications showing recipient, sender, created time, and a rendered-Markdown summary, with loading / empty / error-with-retry states.
- Filter the listing by recipient, sender, and a since/until date range; filters combine, "clear all" resets, and the active filters are captured in the URL query string so a filtered view can be bookmarked and reproduced.
- Page through older notifications with a caller-owned "Load more" control and a shown-of-total count, and jump to the compose form via a "Compose" button.

## Validation steps

- Run `pnpm dev --filter squareone`, sign in as the Admin dev persona, and open the admin area: confirm "User notifications" appears in the sidebar and links to `/admin/notifications`.
- On `/admin/notifications`, confirm the most recent notifications load into a table (recipient, sender, created, rendered-Markdown summary) with a brief loading state first.
- Filter by recipient, by sender, and by a since/until range; confirm each narrows the results, that they combine, and that "clear filters" returns to the default recent view.
- Confirm the active filters appear in the URL query string, and that opening a bookmarked filtered URL reproduces that exact view.
- Confirm "Load more" fetches the next page of older notifications and the shown-of-total count updates.
- Clear the dev store / filter to an empty result and confirm the empty state renders; simulate a failed load and confirm the error state with a working "Retry" renders.
- Confirm the "Compose" button links to `/admin/notifications/new`.

## References

- Closes #479
- PRD: #474
- Jira: https://rubinobs.atlassian.net/browse/DM-55246