### PR TITLE
DM-55291: Link to quotas docs from the quotas settings page

### DIFF
--- a/.changeset/quotas-docs-link.md
+++ b/.changeset/quotas-docs-link.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+Add a "Learn more about quotas" documentation link to the `/settings/quotas` Lede. The link is composed from the existing `docsBaseUrl` config value via the `getDocsUrl` helper, so it resolves to the environment-appropriate variant of the RSP docs (default `https://rsp.lsst.io/guides/life/quotas.html`, e.g. `https://rsp.lsst.io/v/usdfprod/guides/life/quotas.html` on USDF). It opens in the same tab, matching the homepage notebooks docs link, and needs no new config key or Phalanx change.

--- a/apps/squareone/src/app/settings/quotas/QuotasPageClient.test.tsx
+++ b/apps/squareone/src/app/settings/quotas/QuotasPageClient.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the hooks so the component renders without a ConfigProvider/Suspense
+// boundary or live service discovery.
+vi.mock('@lsst-sqre/gafaelfawr-client', () => ({
+  useUserInfo: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useRepertoireUrl', () => ({
+  useRepertoireUrl: vi.fn(() => undefined),
+}));
+
+vi.mock('../../../hooks/useStaticConfig', () => ({
+  useStaticConfig: vi.fn(),
+}));
+
+import type { UseUserInfoReturn } from '@lsst-sqre/gafaelfawr-client';
+// Import after mocking.
+import { useUserInfo } from '@lsst-sqre/gafaelfawr-client';
+
+import { useStaticConfig } from '../../../hooks/useStaticConfig';
+import type { AppConfig } from '../../../lib/config/loader';
+import QuotasPageClient from './QuotasPageClient';
+
+// Build a config object with only the fields the component reads, cast to the
+// full AppConfig shape.
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    docsBaseUrl: 'https://rsp.lsst.io',
+    ...overrides,
+  } as AppConfig;
+}
+
+// Helper to create a logged-in useUserInfo return value so AuthRequired renders
+// its children.
+function makeUserInfoReturn(): UseUserInfoReturn {
+  return {
+    userInfo: { username: 'testuser' },
+    query: null,
+    isLoggedIn: true,
+    isLoading: false,
+    isPending: false,
+    error: null,
+    refetch: vi.fn(),
+  };
+}
+
+describe('QuotasPageClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useUserInfo).mockReturnValue(makeUserInfoReturn());
+  });
+
+  test('composes the quotas docs link from a non-default docsBaseUrl', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(
+      makeConfig({ docsBaseUrl: 'https://rsp.lsst.io/v/usdfprod' })
+    );
+
+    render(<QuotasPageClient />);
+
+    const link = screen.getByRole('link', { name: 'Learn more about quotas' });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://rsp.lsst.io/v/usdfprod/guides/life/quotas.html'
+    );
+  });
+
+  test('renders the quotas docs link in the same tab', () => {
+    vi.mocked(useStaticConfig).mockReturnValue(makeConfig());
+
+    render(<QuotasPageClient />);
+
+    const link = screen.getByRole('link', { name: 'Learn more about quotas' });
+    expect(link).not.toHaveAttribute('target');
+  });
+});

--- a/apps/squareone/src/app/settings/quotas/QuotasPageClient.tsx
+++ b/apps/squareone/src/app/settings/quotas/QuotasPageClient.tsx
@@ -6,6 +6,8 @@ import AuthRequired from '../../../components/AuthRequired';
 import QuotasView from '../../../components/QuotasView';
 import { Lede } from '../../../components/Typography';
 import { useRepertoireUrl } from '../../../hooks/useRepertoireUrl';
+import { useStaticConfig } from '../../../hooks/useStaticConfig';
+import { getDocsUrl } from '../../../lib/utils/docsUrls';
 
 export default function QuotasPageClient() {
   return (
@@ -18,13 +20,17 @@ export default function QuotasPageClient() {
 function QuotasContent() {
   const repertoireUrl = useRepertoireUrl();
   const { userInfo } = useUserInfo(repertoireUrl);
+  const { docsBaseUrl } = useStaticConfig();
+  const quotasDocsUrl = getDocsUrl(docsBaseUrl, '/guides/life/quotas.html');
 
   return (
     <>
       <h1>Quotas</h1>
       <Lede>
         Information about limits to your current resource usage on the Rubin
-        Science Platform. These limits can change.
+        Science Platform. These limits can change.{' '}
+        <a href={quotasDocsUrl}>Learn more about quotas</a> in the
+        documentation.
       </Lede>
       {userInfo?.quota ? (
         <div style={{ marginTop: 'var(--sqo-space-lg-fixed)' }}>


### PR DESCRIPTION
## Summary

- Add a "Learn more about quotas" documentation link to the `/settings/quotas` Lede, appended after the existing copy.
- Compose the href from the existing `docsBaseUrl` config via the `getDocsUrl` helper so it resolves to the environment-appropriate RSP docs variant — no new config key or Phalanx change required.
- Render it as a plain same-tab `<a>` (no `target="_blank"`), matching the homepage notebooks docs link.

## Validation steps

- On `/settings/quotas`, confirm the Lede shows a "Learn more about quotas" link after the existing copy, pointing to `https://rsp.lsst.io/guides/life/quotas.html` in the default (public) environment.
- With `docsBaseUrl` set to a non-default variant (e.g. `https://rsp.lsst.io/v/usdfprod`), confirm the link resolves to that variant's `/guides/life/quotas.html`.
- Confirm the link opens in the same tab (no `target="_blank"`).

## References

- Closes #494
- PRD: #493
- Jira: https://rubinobs.atlassian.net/browse/DM-55291