### PR TITLE
DM-55290: Add controlled row selection to DataTable

### DIFF
--- a/.changeset/squared-data-table-row-selection.md
+++ b/.changeset/squared-data-table-row-selection.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/squared': minor
+---
+
+Add optional controlled row selection to `DataTable`. Providing the new `rowSelection` and `onRowSelectionChange` props opts the table into `@tanstack/react-table`'s row-selection model: a leading checkbox column renders with a select-all header checkbox (indeterminate when only some rows are selected), each row gets its own toggle, and the controlled state stays owned by the caller. Select-all toggles every loaded row. When either prop is omitted the table renders exactly as before, with no checkbox column and no behavior change.

--- a/.changeset/squared-data-table-row-selection.md
+++ b/.changeset/squared-data-table-row-selection.md
@@ -3,3 +3,5 @@
 ---
 
 Add optional controlled row selection to `DataTable`. Providing the new `rowSelection` and `onRowSelectionChange` props opts the table into `@tanstack/react-table`'s row-selection model: a leading checkbox column renders with a select-all header checkbox (indeterminate when only some rows are selected), each row gets its own toggle, and the controlled state stays owned by the caller. Select-all toggles every loaded row. When either prop is omitted the table renders exactly as before, with no checkbox column and no behavior change.
+
+An optional `getRowLabel` prop derives a per-row accessible label (`Select row: <identifier>`) so screen-reader users can tell the row checkboxes apart; without it the checkboxes keep the generic `Select row` label.

--- a/packages/squared/src/components/DataTable/DataTable.stories.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { ColumnDef } from '@tanstack/react-table';
+import type { ColumnDef, RowSelectionState } from '@tanstack/react-table';
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { Badge } from '../Badge';
@@ -211,6 +211,72 @@ function LoadMoreDemo() {
     />
   );
 }
+
+// A stateful host owning controlled row-selection state, mirroring how the
+// notifications inbox wires selection for its bulk "Mark read" action.
+function SelectableDemo() {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const selectedCount = Object.values(rowSelection).filter(Boolean).length;
+
+  return (
+    <div>
+      <p style={{ marginBottom: 'var(--sqo-space-sm)' }}>
+        {selectedCount} selected
+      </p>
+      <DataTable
+        columns={columns}
+        data={rows}
+        rowSelection={rowSelection}
+        onRowSelectionChange={setRowSelection}
+      />
+    </div>
+  );
+}
+
+// Interaction test: the leading checkbox column selects individual rows and
+// the header checkbox selects/clears all loaded rows.
+export const Selectable: Story = {
+  render: () => <SelectableDemo />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // No rows selected to start.
+    await expect(canvas.getByText('0 selected')).toBeInTheDocument();
+
+    // Toggling a single row updates the controlled selection.
+    const rowCheckboxes = canvas.getAllByRole('checkbox', {
+      name: /select row/i,
+    });
+    await userEvent.click(rowCheckboxes[0]);
+    await waitFor(async () => {
+      await expect(canvas.getByText('1 selected')).toBeInTheDocument();
+    });
+    await expect(rowCheckboxes[0]).toBeChecked();
+
+    // Select-all toggles every loaded row.
+    await userEvent.click(
+      canvas.getByRole('checkbox', { name: /select all/i })
+    );
+    await waitFor(async () => {
+      await expect(
+        canvas.getByText(`${rows.length} selected`)
+      ).toBeInTheDocument();
+    });
+    for (const checkbox of canvas.getAllByRole('checkbox', {
+      name: /select row/i,
+    })) {
+      await expect(checkbox).toBeChecked();
+    }
+
+    // Toggling select-all again clears the selection.
+    await userEvent.click(
+      canvas.getByRole('checkbox', { name: /select all/i })
+    );
+    await waitFor(async () => {
+      await expect(canvas.getByText('0 selected')).toBeInTheDocument();
+    });
+  },
+};
 
 // Interaction test: the "Load more" slot invokes the caller's handler,
 // which appends the next page of rows.

--- a/packages/squared/src/components/DataTable/DataTable.test.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.test.tsx
@@ -1,6 +1,7 @@
-import type { ColumnDef } from '@tanstack/react-table';
+import type { ColumnDef, RowSelectionState } from '@tanstack/react-table';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { DataTable } from './DataTable';
 
@@ -203,5 +204,97 @@ describe('DataTable', () => {
     );
 
     expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});
+
+// A controlled host owning row-selection state, mirroring how a consumer
+// (the notifications inbox) wires the selection props.
+function SelectableTable({
+  onChange,
+}: {
+  onChange?: (selection: RowSelectionState) => void;
+}) {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
+  return (
+    <DataTable
+      columns={columns}
+      data={data}
+      rowSelection={rowSelection}
+      onRowSelectionChange={(updater) => {
+        setRowSelection((prev) => {
+          const next = typeof updater === 'function' ? updater(prev) : updater;
+          onChange?.(next);
+          return next;
+        });
+      }}
+    />
+  );
+}
+
+describe('DataTable row selection', () => {
+  it('renders no checkbox column when the selection props are omitted', () => {
+    render(<DataTable columns={columns} data={data} />);
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('renders a leading checkbox column with a select-all header checkbox when selection is enabled', () => {
+    render(<SelectableTable />);
+
+    // One select-all header checkbox plus one checkbox per loaded row.
+    expect(screen.getAllByRole('checkbox')).toHaveLength(data.length + 1);
+    expect(
+      screen.getByRole('checkbox', { name: /select all/i })
+    ).toBeInTheDocument();
+  });
+
+  it('select-all toggles every loaded row', async () => {
+    render(<SelectableTable />);
+
+    await userEvent.click(
+      screen.getByRole('checkbox', { name: /select all/i })
+    );
+
+    const rowCheckboxes = screen.getAllByRole('checkbox', {
+      name: /select row/i,
+    });
+    expect(rowCheckboxes).toHaveLength(data.length);
+    for (const checkbox of rowCheckboxes) {
+      expect(checkbox).toBeChecked();
+    }
+    expect(screen.getByRole('checkbox', { name: /select all/i })).toBeChecked();
+  });
+
+  it('toggling an individual row updates the controlled selection via the callback', async () => {
+    const onChange = vi.fn();
+    render(<SelectableTable onChange={onChange} />);
+
+    const rowCheckboxes = screen.getAllByRole('checkbox', {
+      name: /select row/i,
+    });
+    await userEvent.click(rowCheckboxes[0]);
+
+    expect(rowCheckboxes[0]).toBeChecked();
+    expect(rowCheckboxes[1]).not.toBeChecked();
+    expect(onChange).toHaveBeenCalled();
+
+    // The latest controlled selection has exactly one row selected.
+    const latest = onChange.mock.calls.at(-1)?.[0] as RowSelectionState;
+    expect(Object.values(latest).filter(Boolean)).toHaveLength(1);
+  });
+
+  it('clears the selection when select-all is toggled off', async () => {
+    render(<SelectableTable />);
+
+    const selectAll = screen.getByRole('checkbox', { name: /select all/i });
+    await userEvent.click(selectAll);
+    await userEvent.click(selectAll);
+
+    for (const checkbox of screen.getAllByRole('checkbox', {
+      name: /select row/i,
+    })) {
+      expect(checkbox).not.toBeChecked();
+    }
   });
 });

--- a/packages/squared/src/components/DataTable/DataTable.test.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.test.tsx
@@ -211,8 +211,10 @@ describe('DataTable', () => {
 // (the notifications inbox) wires the selection props.
 function SelectableTable({
   onChange,
+  getRowLabel,
 }: {
   onChange?: (selection: RowSelectionState) => void;
+  getRowLabel?: (row: Row) => string;
 }) {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
@@ -221,6 +223,7 @@ function SelectableTable({
       columns={columns}
       data={data}
       rowSelection={rowSelection}
+      getRowLabel={getRowLabel}
       onRowSelectionChange={(updater) => {
         setRowSelection((prev) => {
           const next = typeof updater === 'function' ? updater(prev) : updater;
@@ -296,5 +299,24 @@ describe('DataTable row selection', () => {
     })) {
       expect(checkbox).not.toBeChecked();
     }
+  });
+
+  it('gives each row checkbox a distinct accessible name when getRowLabel is provided', () => {
+    render(<SelectableTable getRowLabel={(row) => row.name} />);
+
+    // Each per-row checkbox gets a unique "Select row: <name>" label so a
+    // screen-reader user can tell the rows apart.
+    expect(
+      screen.getByRole('checkbox', { name: /select row: bravo/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: /select row: alpha/i })
+    ).toBeInTheDocument();
+
+    // The labelled checkboxes still match the generic /select row/i query, so
+    // backward compatibility with the default label holds.
+    expect(
+      screen.getAllByRole('checkbox', { name: /select row/i })
+    ).toHaveLength(data.length);
   });
 });

--- a/packages/squared/src/components/DataTable/DataTable.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.tsx
@@ -90,6 +90,15 @@ export type DataTableProps<TData> = {
    * alongside `rowSelection`, to enable selection.
    */
   onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  /**
+   * Optionally derive a per-row accessible label for that row's selection
+   * checkbox. Without it, every checkbox shares the generic `"Select row"`
+   * label, which screen-reader users cannot tell apart. Return a stable,
+   * human-readable identifier for the row (e.g. a name or title); it is
+   * rendered as `Select row: <identifier>`. Only used when row selection is
+   * enabled.
+   */
+  getRowLabel?: (row: TData) => string;
   /** Optional visible caption describing the table. */
   caption?: React.ReactNode;
   /**
@@ -110,7 +119,9 @@ type SortDirection = false | 'asc' | 'desc';
  * are selected) and each cell toggles its own row through TanStack's
  * row-selection model.
  */
-function createSelectionColumn<TData>(): ColumnDef<TData, unknown> {
+function createSelectionColumn<TData>(
+  getRowLabel?: (row: TData) => string
+): ColumnDef<TData, unknown> {
   return {
     id: 'select',
     enableSorting: false,
@@ -129,7 +140,11 @@ function createSelectionColumn<TData>(): ColumnDef<TData, unknown> {
     ),
     cell: ({ row }) => (
       <Checkbox
-        aria-label="Select row"
+        aria-label={
+          getRowLabel
+            ? `Select row: ${getRowLabel(row.original)}`
+            : 'Select row'
+        }
         checked={row.getIsSelected()}
         disabled={!row.getCanSelect()}
         onCheckedChange={(value) => row.toggleSelected(value === true)}
@@ -202,6 +217,7 @@ export function DataTable<TData>({
   renderDetailRow,
   rowSelection,
   onRowSelectionChange,
+  getRowLabel,
 }: DataTableProps<TData>) {
   const [sorting, setSorting] = React.useState<SortingState>(initialSorting);
 
@@ -212,8 +228,10 @@ export function DataTable<TData>({
 
   const tableColumns = React.useMemo(
     () =>
-      selectionEnabled ? [createSelectionColumn<TData>(), ...columns] : columns,
-    [selectionEnabled, columns]
+      selectionEnabled
+        ? [createSelectionColumn<TData>(getRowLabel), ...columns]
+        : columns,
+    [selectionEnabled, columns, getRowLabel]
   );
 
   const table = useReactTable({

--- a/packages/squared/src/components/DataTable/DataTable.tsx
+++ b/packages/squared/src/components/DataTable/DataTable.tsx
@@ -5,12 +5,15 @@ import {
   flexRender,
   getCoreRowModel,
   getSortedRowModel,
+  type OnChangeFn,
+  type RowSelectionState,
   type SortingState,
   useReactTable,
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react';
 import React from 'react';
 import { Button } from '../Button';
+import { Checkbox } from '../Checkbox';
 import styles from './DataTable.module.css';
 
 export type DataTableProps<TData> = {
@@ -73,6 +76,20 @@ export type DataTableProps<TData> = {
    * When omitted, each item renders as a single `<tr>` (backward compatible).
    */
   renderDetailRow?: (row: TData) => React.ReactNode;
+  /**
+   * Controlled row-selection state, keyed by TanStack row id. Providing this
+   * together with `onRowSelectionChange` opts the table into row selection: a
+   * leading checkbox column and a select-all header checkbox render and drive
+   * `@tanstack/react-table`'s row-selection model. When either prop is omitted
+   * the table renders exactly as before, with no checkbox column.
+   */
+  rowSelection?: RowSelectionState;
+  /**
+   * Invoked when the selection changes (per-row toggle or select-all). Receives
+   * TanStack's updater; the caller owns the `rowSelection` state. Required,
+   * alongside `rowSelection`, to enable selection.
+   */
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
   /** Optional visible caption describing the table. */
   caption?: React.ReactNode;
   /**
@@ -86,6 +103,40 @@ export type DataTableProps<TData> = {
 };
 
 type SortDirection = false | 'asc' | 'desc';
+
+/**
+ * The leading checkbox column prepended when row selection is enabled. Its
+ * header drives select-all (with an indeterminate state when only some rows
+ * are selected) and each cell toggles its own row through TanStack's
+ * row-selection model.
+ */
+function createSelectionColumn<TData>(): ColumnDef<TData, unknown> {
+  return {
+    id: 'select',
+    enableSorting: false,
+    header: ({ table }) => (
+      <Checkbox
+        aria-label="Select all rows"
+        checked={
+          table.getIsAllRowsSelected()
+            ? true
+            : table.getIsSomeRowsSelected()
+              ? 'indeterminate'
+              : false
+        }
+        onCheckedChange={(value) => table.toggleAllRowsSelected(value === true)}
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        aria-label="Select row"
+        checked={row.getIsSelected()}
+        disabled={!row.getCanSelect()}
+        onCheckedChange={(value) => row.toggleSelected(value === true)}
+      />
+    ),
+  };
+}
 
 function SortIndicator({ direction }: { direction: SortDirection }) {
   if (direction === 'asc') {
@@ -149,14 +200,33 @@ export function DataTable<TData>({
   'aria-label': ariaLabel,
   className,
   renderDetailRow,
+  rowSelection,
+  onRowSelectionChange,
 }: DataTableProps<TData>) {
   const [sorting, setSorting] = React.useState<SortingState>(initialSorting);
 
+  // Selection is opt-in: both the controlled state and its change handler must
+  // be supplied. When enabled, prepend the leading checkbox column.
+  const selectionEnabled =
+    rowSelection !== undefined && onRowSelectionChange !== undefined;
+
+  const tableColumns = React.useMemo(
+    () =>
+      selectionEnabled ? [createSelectionColumn<TData>(), ...columns] : columns,
+    [selectionEnabled, columns]
+  );
+
   const table = useReactTable({
     data,
-    columns,
-    state: { sorting },
+    columns: tableColumns,
+    state: {
+      sorting,
+      ...(selectionEnabled ? { rowSelection } : {}),
+    },
     onSortingChange: setSorting,
+    ...(selectionEnabled
+      ? { enableRowSelection: true, onRowSelectionChange }
+      : {}),
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });


### PR DESCRIPTION
## Summary

- Add opt-in controlled row selection to the squared `DataTable`: providing the new `rowSelection` and `onRowSelectionChange` props renders a leading checkbox column with a select-all header checkbox and per-row toggles, driving `@tanstack/react-table`'s row-selection model with the state owned by the caller.
- Selection is fully backward compatible — omitting the props renders the table exactly as before, with no checkbox column and no behavior change. This is the reusable squared primitive the upcoming notifications inbox needs for its bulk "Mark read" action.

## Validation steps

- In Storybook (`pnpm storybook --filter @lsst-sqre/squared`), open **Components/DataTable → Selectable**: toggling a row checkbox updates the "N selected" count and checks that row; the header checkbox selects all loaded rows, then clears them on a second click; the header shows an indeterminate state when only some rows are selected.
- Open any other DataTable story (Default, Sortable, With detail row) and confirm there is no checkbox column and sorting / load-more / detail-row behavior is unchanged.

## References

- Closes #497
- PRD: #495
- Jira: https://rubinobs.atlassian.net/browse/DM-55290