### PR TITLE
DM-55290: Add squared DropdownMenu component

### DIFF
--- a/.changeset/squared-dropdown-menu.md
+++ b/.changeset/squared-dropdown-menu.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/squared': minor
+---
+
+Add a `DropdownMenu` component wrapping `@radix-ui/react-dropdown-menu`. It follows the existing Radix-wrapper conventions (CSS Modules with design tokens, `forwardRef`, compound `Object.assign` sub-components, `displayName`) and provides `DropdownMenu` plus `Trigger`, `Content`, `Item`, `Label`, and `Separator` sub-components. The default trigger renders a styled button with a chevron affordance and supports `asChild` for composing a custom trigger (for example the squared `Button`). It is suited to bulk-actions menus and supports both click and keyboard interaction.

--- a/packages/squared/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/packages/squared/src/components/DropdownMenu/DropdownMenu.module.css
@@ -1,0 +1,162 @@
+/**
+ * DropdownMenu styles
+ *
+ * Styling conventions mirror the Select component: design-token-driven
+ * colors/spacing, a button-like trigger, and a portaled content surface.
+ */
+
+/* Trigger (default button) styles */
+.trigger {
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sqo-space-xs);
+
+  padding: var(--sqo-space-xxxs) var(--sqo-space-xs);
+  min-height: 44px;
+
+  border: 1px solid var(--rsd-color-gray-100);
+  border-radius: var(--sqo-border-radius-1);
+  background: var(--rsd-component-page-background-color);
+  color: var(--rsd-component-text-color);
+  font-size: 1rem;
+
+  cursor: pointer;
+  outline: none;
+  transition: var(--sqo-transition-basic);
+}
+
+.trigger:focus-visible {
+  outline: 2px solid var(--rsd-color-primary-600);
+  outline-offset: 2px;
+  border-color: var(--rsd-color-primary-600);
+}
+
+.trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background-color: var(--rsd-color-gray-50);
+}
+
+.trigger[data-state="open"] {
+  border-color: var(--rsd-color-primary-600);
+}
+
+/* Trigger chevron */
+.triggerIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--rsd-color-gray-500);
+  transition: var(--sqo-transition-basic);
+  flex-shrink: 0;
+}
+
+.trigger[data-state="open"] .triggerIcon {
+  transform: rotate(180deg);
+}
+
+.triggerIcon svg {
+  width: 1em;
+  height: 1em;
+}
+
+/* Content (menu) styles */
+.content {
+  min-width: 12rem;
+  background: var(--rsd-component-page-background-color);
+  border: 1px solid var(--rsd-color-gray-200);
+  border-radius: var(--sqo-border-radius-2);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  z-index: 50;
+  padding: var(--sqo-space-xxxs);
+  overflow: hidden;
+
+  /* Animation */
+  animation-duration: 0.2s;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.content[data-state="open"] {
+  animation-name: contentShow;
+}
+
+.content[data-state="closed"] {
+  animation-name: contentHide;
+}
+
+@keyframes contentShow {
+  from {
+    opacity: 0;
+    transform: scale(0.95) translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+@keyframes contentHide {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.95) translateY(-2px);
+  }
+}
+
+/* Item styles */
+.item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--sqo-space-xs);
+  padding: var(--sqo-space-xs) var(--sqo-space-sm);
+  border-radius: var(--sqo-border-radius-1);
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+  transition: var(--sqo-transition-basic);
+
+  /* Typography */
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: var(--rsd-component-text-color);
+}
+
+.item:hover {
+  background: var(--rsd-color-gray-50);
+}
+
+.item[data-highlighted] {
+  background: var(--rsd-color-primary-50);
+  color: var(--rsd-color-primary-900);
+}
+
+.item[data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* Label styles */
+.label {
+  padding: var(--sqo-space-xs) var(--sqo-space-sm);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--rsd-color-gray-500);
+}
+
+/* Separator styles */
+.separator {
+  height: 1px;
+  background: var(--rsd-color-gray-200);
+  margin: var(--sqo-space-xxxs) var(--sqo-space-xs);
+}

--- a/packages/squared/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/squared/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -7,14 +7,49 @@ import { DropdownMenu } from './DropdownMenu';
 const meta: Meta<typeof DropdownMenu> = {
   title: 'Components/DropdownMenu',
   component: DropdownMenu,
-  parameters: { layout: 'centered' },
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '`DropdownMenu` presents a list of actions in a popover anchored to ' +
+          'a trigger button. Reach for it for action menus — bulk actions on ' +
+          'a selection, per-row "…" overflow menus, or any compact set of ' +
+          'commands that would otherwise crowd a toolbar. It is built on ' +
+          'Radix UI primitives, so keyboard navigation, focus management, ' +
+          'typeahead, and ARIA menu roles work out of the box.\n\n' +
+          'It is **not** a form control: items fire actions via `onSelect` ' +
+          'rather than binding a value. When the user needs to pick a value ' +
+          'from a list, use `Select` instead.\n\n' +
+          '**Anatomy** — compose these subcomponents:\n\n' +
+          '- `DropdownMenu` (root) — owns the open state. Uncontrolled by ' +
+          'default; pass `open` + `onOpenChange` to control it, or ' +
+          '`defaultOpen` to set the initial state. `modal` (default `true`) ' +
+          'traps focus and blocks outside interaction while the menu is ' +
+          'open.\n' +
+          '- `DropdownMenu.Trigger` — the button that opens the menu. ' +
+          'Renders a styled button with a chevron affordance by default; set ' +
+          '`showChevron={false}` to hide it, or `asChild` to use your own ' +
+          'element (for example a squared `Button`) as the trigger.\n' +
+          '- `DropdownMenu.Content` — the popover, rendered in a portal so it ' +
+          'escapes overflow clipping. Tune placement with `align` (`start` ' +
+          'by default) and `sideOffset` (`6` by default).\n' +
+          '- `DropdownMenu.Item` — a selectable action. Use `onSelect` for ' +
+          'its handler and `disabled` to make it inert.\n' +
+          '- `DropdownMenu.Label` and `DropdownMenu.Separator` — ' +
+          'non-interactive helpers for titling and visually grouping items.' +
+          '\n\nThe stories below demonstrate the common variants.',
+      },
+    },
+  },
   tags: ['autodocs'],
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// Basic bulk-actions menu
+// The default trigger renders a styled button with a chevron affordance and
+// opens a simple list of actions.
 export const Default: Story = {
   render: () => (
     <DropdownMenu>
@@ -47,7 +82,8 @@ export const Default: Story = {
   },
 };
 
-// Bulk-actions menu with a label and separator, like a selection toolbar
+// `DropdownMenu.Label` and `DropdownMenu.Separator` add a non-interactive
+// heading and a divider — useful for captioning a selection toolbar.
 export const WithLabelAndSeparator: Story = {
   render: () => (
     <DropdownMenu>
@@ -70,7 +106,8 @@ export const WithLabelAndSeparator: Story = {
   },
 };
 
-// Selecting an item fires its handler
+// Each `DropdownMenu.Item` fires its `onSelect` handler when chosen, and the
+// menu closes automatically afterward.
 export const ItemSelection: Story = {
   render: () => {
     const [lastAction, setLastAction] = useState<string>('none');
@@ -150,7 +187,8 @@ export const KeyboardInteraction: Story = {
   },
 };
 
-// Disabled item is not selectable
+// A `disabled` item is skipped by pointer and keyboard navigation and cannot
+// be selected.
 export const DisabledItem: Story = {
   render: () => (
     <DropdownMenu>
@@ -174,7 +212,9 @@ export const DisabledItem: Story = {
   },
 };
 
-// Custom trigger via asChild, composing the squared Button
+// `asChild` lets you supply your own trigger element — here a squared
+// `Button` — instead of the default styled button. The chevron is omitted so
+// the trigger's own styling is preserved.
 export const CustomTrigger: Story = {
   render: () => (
     <DropdownMenu>

--- a/packages/squared/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/squared/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,0 +1,203 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { Button } from '../Button';
+import { DropdownMenu } from './DropdownMenu';
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'Components/DropdownMenu',
+  component: DropdownMenu,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Basic bulk-actions menu
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+        <DropdownMenu.Item>Mark all read</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Actions' });
+
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // Menu content is portaled, so search the whole document.
+    await waitFor(() => {
+      expect(
+        within(document.body).getByRole('menuitem', { name: 'Mark read' })
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(document.body).getByRole('menuitem', { name: 'Mark all read' })
+    ).toBeInTheDocument();
+  },
+};
+
+// Bulk-actions menu with a label and separator, like a selection toolbar
+export const WithLabelAndSeparator: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger>Bulk actions</DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Label>2 selected</DropdownMenu.Label>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Bulk actions' }));
+
+    await waitFor(() => {
+      expect(within(document.body).getByText('2 selected')).toBeInTheDocument();
+    });
+    expect(within(document.body).getByRole('separator')).toBeInTheDocument();
+  },
+};
+
+// Selecting an item fires its handler
+export const ItemSelection: Story = {
+  render: () => {
+    const [lastAction, setLastAction] = useState<string>('none');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item onSelect={() => setLastAction('Marked read')}>
+              Mark read
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              onSelect={() => setLastAction('Marked all read')}
+            >
+              Mark all read
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+        <div>Last action: {lastAction}</div>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Actions' });
+
+    expect(canvas.getByText('Last action: none')).toBeInTheDocument();
+
+    await userEvent.click(trigger);
+    const item = await waitFor(() =>
+      within(document.body).getByRole('menuitem', { name: 'Mark read' })
+    );
+    await userEvent.click(item);
+
+    await waitFor(() => {
+      expect(canvas.getByText('Last action: Marked read')).toBeInTheDocument();
+    });
+    // The menu closes after a selection.
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  },
+};
+
+// Keyboard interaction: open and select with the keyboard
+export const KeyboardInteraction: Story = {
+  render: () => {
+    const [lastAction, setLastAction] = useState<string>('none');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item onSelect={() => setLastAction('Marked read')}>
+              Mark read
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+        <div>Last action: {lastAction}</div>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Actions' });
+
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(canvas.getByText('Last action: Marked read')).toBeInTheDocument();
+    });
+  },
+};
+
+// Disabled item is not selectable
+export const DisabledItem: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+        <DropdownMenu.Item disabled>Delete (coming soon)</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Actions' }));
+
+    const disabledItem = await waitFor(() =>
+      within(document.body).getByRole('menuitem', {
+        name: 'Delete (coming soon)',
+      })
+    );
+    expect(disabledItem).toHaveAttribute('data-disabled');
+  },
+};
+
+// Custom trigger via asChild, composing the squared Button
+export const CustomTrigger: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button size="sm">Actions</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+        <DropdownMenu.Item>Mark all read</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Actions' });
+
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(
+        within(document.body).getByRole('menuitem', { name: 'Mark read' })
+      ).toBeInTheDocument();
+    });
+  },
+};

--- a/packages/squared/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/squared/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,0 +1,257 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import DropdownMenu from './DropdownMenu';
+
+describe('DropdownMenu', () => {
+  describe('Basic rendering', () => {
+    it('renders the trigger', () => {
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      expect(trigger).toBeInTheDocument();
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('does not render the menu until opened', () => {
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Opening and selecting', () => {
+    it('opens the menu when the trigger is clicked', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+            <DropdownMenu.Item>Mark all read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      await user.click(trigger);
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitem', { name: 'Mark read' })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitem', { name: 'Mark all read' })
+      ).toBeInTheDocument();
+    });
+
+    it('fires the item handler and closes the menu on click', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item onSelect={onSelect}>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      await user.click(trigger);
+
+      const item = screen.getByRole('menuitem', { name: 'Mark read' });
+      await user.click(item);
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('Keyboard interaction', () => {
+    it('opens with the Enter key', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      trigger.focus();
+      await user.keyboard('{Enter}');
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+
+    it('selects a focused item with the Enter key', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item onSelect={onSelect}>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      await user.click(trigger);
+
+      // Focus the first item, then activate it.
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{Enter}');
+
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes with the Escape key', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByRole('button', { name: 'Actions' });
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      await user.keyboard('{Escape}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  describe('Label and separator', () => {
+    it('renders a label and a separator', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Label>Bulk actions</DropdownMenu.Label>
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+
+      expect(screen.getByText('Bulk actions')).toBeInTheDocument();
+      expect(screen.getByRole('separator')).toBeInTheDocument();
+    });
+  });
+
+  describe('Disabled items', () => {
+    it('does not fire the handler for a disabled item', async () => {
+      const user = userEvent.setup();
+      const onSelect = vi.fn();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item disabled onSelect={onSelect}>
+              Mark read
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+
+      const item = screen.getByRole('menuitem', { name: 'Mark read' });
+      expect(item).toHaveAttribute('data-disabled');
+
+      await user.click(item);
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Composition', () => {
+    it('forwards the trigger ref', () => {
+      const ref = vi.fn();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger ref={ref}>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      expect(ref).toHaveBeenCalled();
+      expect(ref.mock.calls[0][0]).toBeInstanceOf(HTMLButtonElement);
+    });
+
+    it('renders a custom trigger element with asChild', () => {
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger asChild>
+            <button type="button" data-testid="custom-trigger">
+              Custom
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item>Mark read</DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      const trigger = screen.getByTestId('custom-trigger');
+      expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    });
+
+    it('applies a custom className to an item', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <DropdownMenu>
+          <DropdownMenu.Trigger>Actions</DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item className="custom-item">
+              Mark read
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Actions' }));
+      expect(screen.getByRole('menuitem', { name: 'Mark read' })).toHaveClass(
+        'custom-item'
+      );
+    });
+  });
+});

--- a/packages/squared/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/squared/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,172 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { ChevronDown } from 'lucide-react';
+import React, { forwardRef } from 'react';
+import styles from './DropdownMenu.module.css';
+
+// Main DropdownMenu component (Root)
+export type DropdownMenuProps = {
+  children: React.ReactNode;
+
+  // Radix DropdownMenu Root props (explicitly typed to avoid exposing
+  // internal Radix types)
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?(open: boolean): void;
+  modal?: boolean;
+  dir?: 'ltr' | 'rtl';
+};
+
+const DropdownMenuRoot = ({ children, ...props }: DropdownMenuProps) => {
+  return (
+    <DropdownMenuPrimitive.Root {...props}>
+      {children}
+    </DropdownMenuPrimitive.Root>
+  );
+};
+
+DropdownMenuRoot.displayName = 'DropdownMenu';
+
+// DropdownMenu.Trigger component
+export type DropdownMenuTriggerProps = {
+  children: React.ReactNode;
+  /** Render the child element as the trigger instead of the default button. */
+  asChild?: boolean;
+  /** Show the chevron affordance on the default button trigger. */
+  showChevron?: boolean;
+} & React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>;
+
+const DropdownMenuTrigger = forwardRef<
+  HTMLButtonElement,
+  DropdownMenuTriggerProps
+>(({ children, asChild, showChevron = true, className, ...props }, ref) => {
+  // When asChild is set the caller supplies the trigger element, so we pass
+  // through without imposing the default button styling or chevron.
+  if (asChild) {
+    return (
+      <DropdownMenuPrimitive.Trigger
+        ref={ref}
+        asChild
+        className={className}
+        {...props}
+      >
+        {children}
+      </DropdownMenuPrimitive.Trigger>
+    );
+  }
+
+  return (
+    <DropdownMenuPrimitive.Trigger
+      ref={ref}
+      className={[styles.trigger, className].filter(Boolean).join(' ')}
+      {...props}
+    >
+      {children}
+      {showChevron && (
+        <span className={styles.triggerIcon} aria-hidden="true">
+          <ChevronDown />
+        </span>
+      )}
+    </DropdownMenuPrimitive.Trigger>
+  );
+});
+
+DropdownMenuTrigger.displayName = 'DropdownMenu.Trigger';
+
+// DropdownMenu.Content component (portaled)
+export type DropdownMenuContentProps = {
+  children: React.ReactNode;
+} & React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>;
+
+const DropdownMenuContent = forwardRef<
+  HTMLDivElement,
+  DropdownMenuContentProps
+>(({ children, className, sideOffset = 6, align = 'start', ...props }, ref) => {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        className={[styles.content, className].filter(Boolean).join(' ')}
+        sideOffset={sideOffset}
+        align={align}
+        {...props}
+      >
+        {children}
+      </DropdownMenuPrimitive.Content>
+    </DropdownMenuPrimitive.Portal>
+  );
+});
+
+DropdownMenuContent.displayName = 'DropdownMenu.Content';
+
+// DropdownMenu.Item component
+export type DropdownMenuItemProps = {
+  children: React.ReactNode;
+} & React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>;
+
+const DropdownMenuItem = forwardRef<HTMLDivElement, DropdownMenuItemProps>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <DropdownMenuPrimitive.Item
+        ref={ref}
+        className={[styles.item, className].filter(Boolean).join(' ')}
+        {...props}
+      >
+        {children}
+      </DropdownMenuPrimitive.Item>
+    );
+  }
+);
+
+DropdownMenuItem.displayName = 'DropdownMenu.Item';
+
+// DropdownMenu.Label component
+export type DropdownMenuLabelProps = {
+  children: React.ReactNode;
+} & React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>;
+
+const DropdownMenuLabel = forwardRef<HTMLDivElement, DropdownMenuLabelProps>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <DropdownMenuPrimitive.Label
+        ref={ref}
+        className={[styles.label, className].filter(Boolean).join(' ')}
+        {...props}
+      >
+        {children}
+      </DropdownMenuPrimitive.Label>
+    );
+  }
+);
+
+DropdownMenuLabel.displayName = 'DropdownMenu.Label';
+
+// DropdownMenu.Separator component
+export type DropdownMenuSeparatorProps = React.ComponentPropsWithoutRef<
+  typeof DropdownMenuPrimitive.Separator
+>;
+
+const DropdownMenuSeparator = forwardRef<
+  HTMLDivElement,
+  DropdownMenuSeparatorProps
+>(({ className, ...props }, ref) => {
+  return (
+    <DropdownMenuPrimitive.Separator
+      ref={ref}
+      className={[styles.separator, className].filter(Boolean).join(' ')}
+      {...props}
+    />
+  );
+});
+
+DropdownMenuSeparator.displayName = 'DropdownMenu.Separator';
+
+// Export as compound component
+export const DropdownMenu = Object.assign(DropdownMenuRoot, {
+  Trigger: DropdownMenuTrigger,
+  Content: DropdownMenuContent,
+  Item: DropdownMenuItem,
+  Label: DropdownMenuLabel,
+  Separator: DropdownMenuSeparator,
+});
+
+export default DropdownMenu;

--- a/packages/squared/src/components/DropdownMenu/index.ts
+++ b/packages/squared/src/components/DropdownMenu/index.ts
@@ -1,0 +1,9 @@
+export type {
+  DropdownMenuContentProps,
+  DropdownMenuItemProps,
+  DropdownMenuLabelProps,
+  DropdownMenuProps,
+  DropdownMenuSeparatorProps,
+  DropdownMenuTriggerProps,
+} from './DropdownMenu';
+export { DropdownMenu as default, DropdownMenu } from './DropdownMenu';

--- a/packages/squared/src/index.ts
+++ b/packages/squared/src/index.ts
@@ -35,6 +35,15 @@ export {
   TimeInput,
   TimezoneSelector,
 } from './components/DateTimePicker';
+export type {
+  DropdownMenuContentProps,
+  DropdownMenuItemProps,
+  DropdownMenuLabelProps,
+  DropdownMenuProps,
+  DropdownMenuSeparatorProps,
+  DropdownMenuTriggerProps,
+} from './components/DropdownMenu';
+export { DropdownMenu } from './components/DropdownMenu';
 export type { ErrorMessageProps } from './components/ErrorMessage';
 export { default as ErrorMessage } from './components/ErrorMessage';
 export type { FormFieldProps } from './components/FormField';


### PR DESCRIPTION
## Summary

- Add a `DropdownMenu` component to `@lsst-sqre/squared` wrapping `@radix-ui/react-dropdown-menu`, following the existing Radix-wrapper conventions (CSS Modules with design tokens, `forwardRef`, compound `Object.assign` sub-components, `displayName`) used by `Select`.
- Provide the Root plus `Trigger`, `Content`, `Item`, `Label`, and `Separator` sub-components suited to a bulk-actions menu; the default trigger is a styled button with a chevron and supports `asChild` for composing a custom trigger (e.g. the squared `Button`).
- Export the component and its prop types from the squared `index.ts`.

## Validation steps

- In Storybook (`pnpm storybook --filter @lsst-sqre/squared`), open the **Components/DropdownMenu** stories and confirm the menu opens on trigger click, items are listed, and selecting an item fires its handler and closes the menu.
- Confirm keyboard interaction: focus the trigger, open with Enter, navigate with the arrow keys, select with Enter, and close with Escape.
- Confirm the **Custom Trigger** story renders the squared `Button` as the trigger via `asChild` and still opens the menu.

## References

- Closes #498
- PRD: #495
- Jira: https://rubinobs.atlassian.net/browse/DM-55290