### PR TITLE
DM-55290: Add user-notifications feature-flag config keys

### DIFF
--- a/.changeset/user-notifications-config-flag.md
+++ b/.changeset/user-notifications-config-flag.md
@@ -1,0 +1,5 @@
+---
+'squareone': minor
+---
+
+Add two feature-flag config keys for the upcoming user notifications UI: `enableUserNotifications` (boolean, default `false`) and `userNotificationsPollIntervalSeconds` (number, default `300`). Both flow through the existing config pipeline — declared in `squareone.config.schema.json` with titles/descriptions/defaults, added to the `AppConfig` type, and defaulted in `squareone.config.yaml` — so they resolve via `getStaticConfig()` / `useStaticConfig()`. They ship `false`/`300` everywhere and no UI consumes them yet; the flag keeps the in-progress notifications feature hidden until it is released.

--- a/apps/squareone/squareone.config.schema.json
+++ b/apps/squareone/squareone.config.schema.json
@@ -150,6 +150,19 @@
       "description": "URL for the preview badge link",
       "default": "https://rsp.lsst.io/roadmap.html"
     },
+    "enableUserNotifications": {
+      "type": "boolean",
+      "title": "Enable user notifications",
+      "description": "Setting this option to true enables the user-facing notifications UI: the unread badge in the header user menu and the /notifications inbox and detail pages. Defaults to false so the feature stays hidden until it is released.",
+      "default": false
+    },
+    "userNotificationsPollIntervalSeconds": {
+      "type": "integer",
+      "title": "User notifications poll interval (seconds)",
+      "description": "Background polling cadence, in seconds, for the unread notification count shown in the header user menu. Consumed by the useUnreadNotificationCount hook (converted to milliseconds for TanStack Query's refetchInterval). Only relevant when enableUserNotifications is true.",
+      "minimum": 30,
+      "default": 300
+    },
     "headerLogoUrl": {
       "type": "string",
       "title": "Header logo URL",

--- a/apps/squareone/squareone.config.yaml
+++ b/apps/squareone/squareone.config.yaml
@@ -17,6 +17,8 @@ appLinks:
     internal: false
 showPreview: true
 previewLink: 'https://rsp.lsst.io/roadmap.html'
+enableUserNotifications: false
+userNotificationsPollIntervalSeconds: 300
 # New configuration for filesystem-based MDX content
 mdxDir: 'src/content/pages'
 sentryTracesSampleRate: 0

--- a/apps/squareone/src/components/AdminLayout/adminNavigation.test.ts
+++ b/apps/squareone/src/components/AdminLayout/adminNavigation.test.ts
@@ -14,6 +14,8 @@ const baseConfig: AppConfigContextValue = {
   enableAppsMenu: false,
   appLinks: [],
   showPreview: false,
+  enableUserNotifications: false,
+  userNotificationsPollIntervalSeconds: 300,
   mdxDir: 'src/content/pages',
 };
 

--- a/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.stories.tsx
+++ b/apps/squareone/src/components/SentryConfigInfo/SentryConfigInfo.stories.tsx
@@ -11,6 +11,8 @@ const baseConfig: AppConfigContextValue = {
   siteDescription: 'The Rubin Science Platform.',
   showPreview: false,
   previewLink: 'https://rsp.lsst.io/roadmap.html',
+  enableUserNotifications: false,
+  userNotificationsPollIntervalSeconds: 300,
   docsBaseUrl: 'https://rsp.lsst.io',
   enableAppsMenu: false,
   appLinks: [],

--- a/apps/squareone/src/components/SettingsLayout/SettingsLayout.stories.tsx
+++ b/apps/squareone/src/components/SettingsLayout/SettingsLayout.stories.tsx
@@ -10,6 +10,8 @@ const defaultConfig: AppConfigContextValue = {
     'The Rubin Science Platform (RSP) provides web-based data access and analysis tools.',
   showPreview: true,
   previewLink: 'https://rsp.lsst.io/roadmap.html',
+  enableUserNotifications: false,
+  userNotificationsPollIntervalSeconds: 300,
   docsBaseUrl: 'https://rsp.lsst.io',
   enableAppsMenu: false,
   appLinks: [],

--- a/apps/squareone/src/components/SettingsLayout/settingsNavigation.test.ts
+++ b/apps/squareone/src/components/SettingsLayout/settingsNavigation.test.ts
@@ -14,6 +14,8 @@ const baseConfig: AppConfigContextValue = {
   enableAppsMenu: false,
   appLinks: [],
   showPreview: false,
+  enableUserNotifications: false,
+  userNotificationsPollIntervalSeconds: 300,
   mdxDir: 'src/content/pages',
 };
 

--- a/apps/squareone/src/lib/config/loader.ts
+++ b/apps/squareone/src/lib/config/loader.ts
@@ -65,6 +65,18 @@ export interface AppConfig {
   }>;
   showPreview: boolean;
   previewLink?: string;
+  /**
+   * Feature flag for the user-facing notifications UI (header badge,
+   * /notifications inbox and detail pages). Defaults to false so the feature
+   * stays hidden until release. Resolved from the schema default when absent.
+   */
+  enableUserNotifications: boolean;
+  /**
+   * Background polling cadence, in seconds, for the header unread-notification
+   * count (consumed by useUnreadNotificationCount). Resolved from the schema
+   * default (300) when absent.
+   */
+  userNotificationsPollIntervalSeconds: number;
   mdxDir: string; // New: configurable MDX directory
   sentryDsn?: string; // Injected from environment
   sentryTracesSampleRate?: number;

--- a/apps/squareone/src/lib/config/userNotificationsConfigKeys.test.ts
+++ b/apps/squareone/src/lib/config/userNotificationsConfigKeys.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Ajv from 'ajv';
+import { load } from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+// Resolve the app-root config files relative to this test (src/lib/config/).
+const appRoot = join(__dirname, '../../../');
+
+const schema = JSON.parse(
+  readFileSync(join(appRoot, 'squareone.config.schema.json'), 'utf8')
+);
+const devConfig = load(
+  readFileSync(join(appRoot, 'squareone.config.yaml'), 'utf8')
+) as Record<string, unknown>;
+
+describe('user notifications feature-flag config keys', () => {
+  it('declares enableUserNotifications in the schema with title, description, and default', () => {
+    expect(schema.properties.enableUserNotifications).toMatchObject({
+      type: 'boolean',
+      default: false,
+    });
+    expect(schema.properties.enableUserNotifications.title).toEqual(
+      expect.any(String)
+    );
+    expect(schema.properties.enableUserNotifications.description).toEqual(
+      expect.any(String)
+    );
+  });
+
+  it('declares userNotificationsPollIntervalSeconds in the schema with title, description, default, and minimum', () => {
+    expect(
+      schema.properties.userNotificationsPollIntervalSeconds
+    ).toMatchObject({
+      type: 'integer',
+      minimum: 30,
+      default: 300,
+    });
+    expect(
+      schema.properties.userNotificationsPollIntervalSeconds.title
+    ).toEqual(expect.any(String));
+    expect(
+      schema.properties.userNotificationsPollIntervalSeconds.description
+    ).toEqual(expect.any(String));
+  });
+
+  it('sets the development defaults in squareone.config.yaml', () => {
+    expect(devConfig.enableUserNotifications).toBe(false);
+    expect(devConfig.userNotificationsPollIntervalSeconds).toBe(300);
+  });
+
+  it('applies the documented defaults via Ajv when the keys are absent (resolvable through the config pipeline)', () => {
+    // Mirrors loader.ts: validation fills defaults so getStaticConfig() /
+    // useStaticConfig() always resolve these keys even when a Phalanx config
+    // omits them.
+    const ajv = new Ajv({ useDefaults: true, removeAdditional: true });
+    const validate = ajv.compile(schema);
+    const data: Record<string, unknown> = {};
+    validate(data);
+
+    expect(data.enableUserNotifications).toBe(false);
+    expect(data.userNotificationsPollIntervalSeconds).toBe(300);
+  });
+});


### PR DESCRIPTION
## Summary

- Add two feature-flag config keys for the upcoming user-notifications UI — `enableUserNotifications` (boolean, default `false`) and `userNotificationsPollIntervalSeconds` (number, default `300`) — so the in-progress feature can ship hidden until release.
- Wire both through the existing config pipeline: declared in `squareone.config.schema.json` with titles/descriptions/defaults, added to the `AppConfig` type, and defaulted in `squareone.config.yaml`, so they resolve via `getStaticConfig()` / `useStaticConfig()`.
- Ships `false`/`300` everywhere; no UI consumes the keys in this slice. Phalanx-side wiring is the separate MANUAL task.

## Validation steps

- Start the dev server (`pnpm dev --filter squareone`) and confirm it boots without a config-validation error, proving the schema accepts the two new keys.
- With the development `squareone.config.yaml`, confirm `getStaticConfig()` / `useStaticConfig()` resolve `enableUserNotifications` to `false` and `userNotificationsPollIntervalSeconds` to `300`.
- Remove both keys from a local config copy and confirm Ajv fills the documented schema defaults (`false` / `300`) instead of erroring, so configs that omit them stay valid.

## References

- Closes #499
- PRD: #495
- Jira: https://rubinobs.atlassian.net/browse/DM-55290