### PR TITLE
DM-55290: Add unread-notifications badge to header UserMenu

### DIFF
--- a/apps/squareone/next.config.js
+++ b/apps/squareone/next.config.js
@@ -50,6 +50,10 @@ module.exports = (phase) => {
           destination: '/api/dev/semaphore/v1/broadcasts',
         },
         {
+          source: '/semaphore/v1/notifications',
+          destination: '/api/dev/semaphore/v1/notifications',
+        },
+        {
           source: '/semaphore/v1/admin/notifications',
           destination: '/api/dev/semaphore/v1/admin/notifications',
         },

--- a/apps/squareone/squareone.config.yaml
+++ b/apps/squareone/squareone.config.yaml
@@ -17,7 +17,10 @@ appLinks:
     internal: false
 showPreview: true
 previewLink: 'https://rsp.lsst.io/roadmap.html'
-enableUserNotifications: false
+# Enabled in the dev config so the header unread badge and notifications UI are
+# exercisable against the local dev mocks (see src/app/api/dev/semaphore). The
+# production default remains false (schema default; Phalanx configs opt in).
+enableUserNotifications: true
 userNotificationsPollIntervalSeconds: 300
 # New configuration for filesystem-based MDX content
 mdxDir: 'src/content/pages'

--- a/apps/squareone/src/app/api/dev/notifications-count/route.dev.test.ts
+++ b/apps/squareone/src/app/api/dev/notifications-count/route.dev.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resetDevUserNotifications } from '@/lib/mocks/userNotificationsStore';
+
+import { GET, POST } from './route.dev';
+
+const BASE = 'http://localhost:3000/api/dev/notifications-count';
+
+beforeEach(() => {
+  resetDevUserNotifications();
+});
+
+afterEach(() => {
+  resetDevUserNotifications();
+});
+
+function postCount(body: unknown): Promise<Response> {
+  return POST(
+    new Request(BASE, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+describe('GET /api/dev/notifications-count', () => {
+  it('returns the current count', async () => {
+    const response = await GET();
+    const data = (await response.json()) as { count: number };
+    expect(typeof data.count).toBe('number');
+  });
+});
+
+describe('POST /api/dev/notifications-count', () => {
+  it('sets the count and echoes it back', async () => {
+    const response = await postCount({ count: 7 });
+    expect(response.status).toBe(200);
+    expect(((await response.json()) as { count: number }).count).toBe(7);
+
+    const after = (await (await GET()).json()) as { count: number };
+    expect(after.count).toBe(7);
+  });
+
+  it('clamps a fractional count to an integer', async () => {
+    const response = await postCount({ count: 3.9 });
+    expect(((await response.json()) as { count: number }).count).toBe(3);
+  });
+
+  it('rejects a negative count with a 400', async () => {
+    const response = await postCount({ count: -1 });
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects a non-numeric count with a 400', async () => {
+    const response = await postCount({ count: 'lots' });
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/squareone/src/app/api/dev/notifications-count/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/notifications-count/route.dev.ts
@@ -1,0 +1,41 @@
+/**
+ * Dev control endpoint for the mocked unread-notification count.
+ * GET/POST /api/dev/notifications-count
+ *
+ * GET returns the current dev-selected unread count so the `/dev` notifications
+ * panel can populate its control on mount. POST sets it (clamped to a
+ * non-negative integer), which feeds the `/semaphore/v1/notifications` mock and
+ * therefore the header unread badge. There is no production analogue: this is
+ * dev-only tooling and the file is only built into the development server.
+ */
+
+import { NextResponse } from 'next/server';
+
+import {
+  getDevUnreadCount,
+  setDevUnreadCount,
+} from '@/lib/mocks/userNotificationsStore';
+
+export async function GET() {
+  return NextResponse.json({ count: getDevUnreadCount() });
+}
+
+export async function POST(request: Request) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const count = (payload as { count?: unknown })?.count;
+  if (typeof count !== 'number' || !Number.isFinite(count) || count < 0) {
+    return NextResponse.json(
+      { error: 'count must be a non-negative number' },
+      { status: 400 }
+    );
+  }
+
+  setDevUnreadCount(count);
+  return NextResponse.json({ count: getDevUnreadCount() });
+}

--- a/apps/squareone/src/app/api/dev/semaphore/v1/notifications/route.dev.test.ts
+++ b/apps/squareone/src/app/api/dev/semaphore/v1/notifications/route.dev.test.ts
@@ -1,0 +1,87 @@
+import {
+  type UserNotificationSummary,
+  UserNotificationSummarySchema,
+} from '@lsst-sqre/semaphore-client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  resetDevUserNotifications,
+  setDevUnreadCount,
+} from '@/lib/mocks/userNotificationsStore';
+
+import { GET } from './route.dev';
+
+const BASE = 'http://localhost:3000/semaphore/v1/notifications';
+
+beforeEach(() => {
+  resetDevUserNotifications();
+});
+
+afterEach(() => {
+  resetDevUserNotifications();
+});
+
+async function readEntries(
+  response: Response
+): Promise<UserNotificationSummary[]> {
+  const data = (await response.json()) as unknown[];
+  return data.map((entry) => UserNotificationSummarySchema.parse(entry));
+}
+
+describe('GET /api/dev/semaphore/v1/notifications', () => {
+  it('reports the dev-selected unread total via X-Total-Count (badge query)', async () => {
+    setDevUnreadCount(3);
+
+    const response = await GET(new Request(`${BASE}?unread=true&limit=1`));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('X-Total-Count')).toBe('3');
+
+    const entries = await readEntries(response);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].read).toBeNull();
+  });
+
+  it('reports zero unread when the count is set to 0', async () => {
+    setDevUnreadCount(0);
+
+    const response = await GET(new Request(`${BASE}?unread=true&limit=1`));
+
+    expect(response.headers.get('X-Total-Count')).toBe('0');
+    const entries = await readEntries(response);
+    expect(entries).toHaveLength(0);
+  });
+
+  it('omits X-Total-Count when no limit is provided (matching the real contract)', async () => {
+    const response = await GET(new Request(BASE));
+
+    expect(response.headers.get('X-Total-Count')).toBeNull();
+    expect(response.headers.get('Link')).toBeNull();
+  });
+
+  it('returns the selected unread entries plus the static read fixtures unfiltered', async () => {
+    setDevUnreadCount(2);
+
+    const response = await GET(new Request(BASE));
+
+    const entries = await readEntries(response);
+    const unread = entries.filter((n) => n.read === null);
+    const read = entries.filter((n) => n.read !== null);
+    expect(unread).toHaveLength(2);
+    expect(read.length).toBeGreaterThan(0);
+  });
+
+  it('paginates unread results with a Link cursor when a limit is set', async () => {
+    setDevUnreadCount(5);
+
+    const response = await GET(new Request(`${BASE}?unread=true&limit=2`));
+
+    const entries = await readEntries(response);
+    expect(entries).toHaveLength(2);
+    expect(response.headers.get('X-Total-Count')).toBe('5');
+
+    const link = response.headers.get('Link');
+    expect(link).toContain('rel="next"');
+    expect(link).toContain('cursor=2');
+  });
+});

--- a/apps/squareone/src/app/api/dev/semaphore/v1/notifications/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/semaphore/v1/notifications/route.dev.ts
@@ -1,0 +1,50 @@
+/**
+ * Mock of the Semaphore user-facing notifications list endpoint.
+ * GET /semaphore/v1/notifications
+ * (rewritten to /api/dev/semaphore/v1/notifications)
+ *
+ * Filters and cursor-paginates the in-memory dev store via the shared
+ * `filterAndPaginateUserNotifications` helper, conveying the next cursor through
+ * an RFC 5988 `Link` header and the unread/total through `X-Total-Count` — the
+ * same contract the real Semaphore user API uses (and that the semaphore-client
+ * `fetchUserNotifications` parses). The header `useUnreadNotificationCount` hook
+ * reads the total from a `?unread=true&limit=1` request, so the dev-selected
+ * unread count (set from the `/dev` panel) drives the header badge.
+ *
+ * This file is only built into the development server (see `next.config.js`
+ * `pageExtensions`), so it never reaches the production bundle.
+ */
+
+import { filterAndPaginateUserNotifications } from '@lsst-sqre/semaphore-client';
+import { NextResponse } from 'next/server';
+
+import { getDevUserNotifications } from '@/lib/mocks/userNotificationsStore';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const params = url.searchParams;
+
+  const limitParam = params.get('limit');
+  const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : Number.NaN;
+  const limit = Number.isNaN(parsedLimit) ? undefined : parsedLimit;
+
+  const page = filterAndPaginateUserNotifications(getDevUserNotifications(), {
+    unread: params.get('unread') === 'true',
+    cursor: params.get('cursor'),
+    limit,
+  });
+
+  const headers = new Headers();
+  // The real endpoint only surfaces X-Total-Count / Link when a limit is set;
+  // the badge always passes limit=1, which is how it reads the unread total.
+  if (limit !== undefined && page.totalCount !== null) {
+    headers.set('X-Total-Count', String(page.totalCount));
+  }
+  if (page.nextCursor) {
+    const nextUrl = new URL(url);
+    nextUrl.searchParams.set('cursor', page.nextCursor);
+    headers.set('Link', `<${nextUrl.toString()}>; rel="next"`);
+  }
+
+  return NextResponse.json(page.entries, { headers });
+}

--- a/apps/squareone/src/app/dev/DevNotificationsPanel.module.css
+++ b/apps/squareone/src/app/dev/DevNotificationsPanel.module.css
@@ -1,0 +1,72 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sqo-space-lg-fixed);
+  max-width: 640px;
+  margin: var(--sqo-space-lg-fixed) auto;
+  padding: 0 var(--size-screen-padding-min);
+}
+
+.heading {
+  margin: 0 0 var(--sqo-space-xxs-fixed);
+}
+
+.muted {
+  margin: 0;
+  color: var(--rsd-color-gray-600, #4b5563);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sqo-space-sm-fixed);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sqo-space-xxs-fixed);
+}
+
+.fieldLabel {
+  font-weight: 600;
+}
+
+.input {
+  width: 8rem;
+  padding: var(--sqo-space-xs-fixed) var(--sqo-space-sm-fixed);
+  border: 1px solid var(--rsd-color-gray-300, #d1d5db);
+  border-radius: var(--sqo-border-radius-1, 4px);
+  background-color: var(--rsd-component-page-background-color, #fff);
+  color: inherit;
+  font: inherit;
+}
+
+.applyRow {
+  display: flex;
+  align-items: center;
+  gap: var(--sqo-space-sm-fixed);
+}
+
+.applyButton {
+  padding: var(--sqo-space-xs-fixed) var(--sqo-space-md-fixed);
+  border: none;
+  border-radius: var(--sqo-border-radius-1, 4px);
+  background-color: var(--sqo-primary-button-background-color);
+  color: var(--sqo-primary-button-text-color);
+  cursor: pointer;
+  transition: var(--sqo-transition-basic);
+}
+
+.applyButton:hover:not(:disabled) {
+  background-color: var(--sqo-primary-button-background-color-hover);
+}
+
+.applyButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.applied {
+  color: var(--rsd-color-green-600, #237028);
+}

--- a/apps/squareone/src/app/dev/DevNotificationsPanel.tsx
+++ b/apps/squareone/src/app/dev/DevNotificationsPanel.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useId, useState } from 'react';
+
+import styles from './DevNotificationsPanel.module.css';
+
+type CountResponse = { count: number };
+
+/**
+ * Dev-only control for the mocked unread-notification count.
+ *
+ * Lets a developer set how many unread notifications the mocked Semaphore user
+ * endpoint reports, so the header user-menu unread badge (driven by
+ * `useUnreadNotificationCount`) can be exercised without a live Semaphore. The
+ * badge only renders when the `enableUserNotifications` feature flag is on.
+ *
+ * Reads the current count from `GET /api/dev/notifications-count` on mount and
+ * writes back via `POST` on apply. After applying it invalidates the
+ * unread-count query so the open Header reflects the new count without a manual
+ * reload (the badge otherwise refreshes on its background poll / window focus).
+ *
+ * It is only imported by the dev-only `/dev` route, so it is tree-shaken from
+ * production builds.
+ */
+export default function DevNotificationsPanel() {
+  const queryClient = useQueryClient();
+  const inputId = useId();
+
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [applying, setApplying] = useState(false);
+  const [applied, setApplied] = useState(false);
+
+  // Populate the control from the current dev state on mount.
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/dev/notifications-count')
+      .then((response) => response.json() as Promise<CountResponse>)
+      .then((data) => {
+        if (!cancelled) setCount(data.count);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleApply = async () => {
+    setApplying(true);
+    setApplied(false);
+    try {
+      await fetch('/api/dev/notifications-count', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ count }),
+      });
+      // Refresh the header badge without a manual reload. The query key is
+      // ['unread-notification-count', semaphoreUrl]; a prefix match invalidates
+      // it regardless of the resolved Semaphore URL.
+      await queryClient.invalidateQueries({
+        queryKey: ['unread-notification-count'],
+      });
+      setApplied(true);
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className={styles.panel}>
+        <p className={styles.muted}>Loading notifications state…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.panel}>
+      <header>
+        <h1 className={styles.heading}>Dev notifications control panel</h1>
+        <p className={styles.muted}>
+          Set how many unread notifications the mocked Semaphore endpoint
+          reports. The header unread badge shows this count when the{' '}
+          <code>enableUserNotifications</code> feature flag is enabled.
+        </p>
+      </header>
+
+      <section className={styles.section}>
+        <div className={styles.field}>
+          <label className={styles.fieldLabel} htmlFor={inputId}>
+            Unread notifications
+          </label>
+          <input
+            id={inputId}
+            className={styles.input}
+            type="number"
+            min={0}
+            step={1}
+            value={count}
+            onChange={(event) => {
+              setApplied(false);
+              const next = Number.parseInt(event.target.value, 10);
+              setCount(Number.isNaN(next) ? 0 : Math.max(0, next));
+            }}
+          />
+        </div>
+      </section>
+
+      <div className={styles.applyRow}>
+        <button
+          type="button"
+          className={styles.applyButton}
+          onClick={handleApply}
+          disabled={applying}
+        >
+          {applying ? 'Applying…' : 'Apply'}
+        </button>
+        {applied && <span className={styles.applied}>Applied ✓</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/squareone/src/app/dev/page.dev.tsx
+++ b/apps/squareone/src/app/dev/page.dev.tsx
@@ -2,6 +2,7 @@
 
 import MainContent from '../../components/MainContent';
 import DevAuthPanel from './DevAuthPanel';
+import DevNotificationsPanel from './DevNotificationsPanel';
 
 /**
  * Dev-only auth control panel route (`/dev`).
@@ -13,12 +14,15 @@ import DevAuthPanel from './DevAuthPanel';
  *
  * This is the first piece of a future dev-tools hub. For now it renders the
  * {@link DevAuthPanel}, which lets a developer flip login state, pick a persona,
- * and edit the active Gafaelfawr scopes and identity at runtime.
+ * and edit the active Gafaelfawr scopes and identity at runtime, and the
+ * {@link DevNotificationsPanel}, which sets the mocked unread-notification count
+ * that drives the header badge.
  */
 export default function DevPage() {
   return (
     <MainContent>
       <DevAuthPanel />
+      <DevNotificationsPanel />
     </MainContent>
   );
 }

--- a/apps/squareone/src/app/shell.snapshot.test.tsx
+++ b/apps/squareone/src/app/shell.snapshot.test.tsx
@@ -61,6 +61,7 @@ vi.mock('@lsst-sqre/repertoire-client', async (importOriginal) => ({
 vi.mock('@lsst-sqre/semaphore-client', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@lsst-sqre/semaphore-client')>()),
   useBroadcasts: vi.fn(),
+  useUnreadNotificationCount: vi.fn(),
 }));
 
 vi.mock('@lsst-sqre/gafaelfawr-client', async (importOriginal) => ({
@@ -82,7 +83,10 @@ import type {
 import { useLoginInfo, useUserInfo } from '@lsst-sqre/gafaelfawr-client';
 import { useServiceDiscovery } from '@lsst-sqre/repertoire-client';
 import type { Broadcast } from '@lsst-sqre/semaphore-client';
-import { useBroadcasts } from '@lsst-sqre/semaphore-client';
+import {
+  useBroadcasts,
+  useUnreadNotificationCount,
+} from '@lsst-sqre/semaphore-client';
 import { PrimaryNavigation, useGafaelfawrUser } from '@lsst-sqre/squared';
 
 import BroadcastBannerStack from '../components/BroadcastBannerStack';
@@ -153,6 +157,16 @@ function emptyBroadcasts(): ReturnType<typeof useBroadcasts> {
   } as unknown as ReturnType<typeof useBroadcasts>;
 }
 
+function noUnreadCount(): ReturnType<typeof useUnreadNotificationCount> {
+  return {
+    count: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  };
+}
+
 describe('shell render determinism', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -160,6 +174,7 @@ describe('shell render determinism', () => {
     vi.mocked(useServiceDiscovery).mockReturnValue(makeDiscoveryReturn());
     vi.mocked(useUserInfo).mockReturnValue(loggedOutUserInfo());
     vi.mocked(useBroadcasts).mockReturnValue(emptyBroadcasts());
+    vi.mocked(useUnreadNotificationCount).mockReturnValue(noUnreadCount());
   });
 
   test('Header renders identical markup across renders', () => {

--- a/apps/squareone/src/components/Header/UserMenu.test.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.test.tsx
@@ -170,6 +170,25 @@ describe('UserMenu', () => {
       expect(item).toHaveAttribute('href', '/notifications');
     });
 
+    test('uses singular wording when there is exactly one unread message', async () => {
+      const user = userEvent.setup();
+      mockUser();
+      mockConfig({ enableUserNotifications: true });
+      mockUnreadCount(1);
+
+      renderMenu();
+
+      // The badge aria-label is singular for a single notification.
+      expect(
+        screen.getByLabelText('1 unread notification')
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /testuser/i }));
+
+      const item = screen.getByRole('link', { name: '1 unread message' });
+      expect(item).toHaveAttribute('href', '/notifications');
+    });
+
     test('shows a "Notifications" item and no badge when the flag is on and unread is 0', async () => {
       const user = userEvent.setup();
       mockUser();

--- a/apps/squareone/src/components/Header/UserMenu.test.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.test.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 // useGafaelfawrUser comes from @lsst-sqre/squared. Mock it while keeping the
-// real PrimaryNavigation / getLogoutUrl exports so the menu still renders.
+// real PrimaryNavigation / Badge / getLogoutUrl exports so the menu still
+// renders.
 vi.mock('@lsst-sqre/squared', async () => {
   const actual =
     await vi.importActual<typeof import('@lsst-sqre/squared')>(
@@ -21,15 +22,31 @@ vi.mock('@lsst-sqre/gafaelfawr-client', () => ({
   useLoginInfo: vi.fn(),
 }));
 
+// useUnreadNotificationCount feeds the trigger badge and menu-item label.
+vi.mock('@lsst-sqre/semaphore-client', () => ({
+  useUnreadNotificationCount: vi.fn(),
+}));
+
 vi.mock('../../hooks/useRepertoireUrl', () => ({
   useRepertoireUrl: vi.fn(() => undefined),
+}));
+
+vi.mock('../../hooks/useSemaphoreUrl', () => ({
+  useSemaphoreUrl: vi.fn(),
+}));
+
+vi.mock('../../hooks/useStaticConfig', () => ({
+  useStaticConfig: vi.fn(),
 }));
 
 import type { UseLoginInfoReturn } from '@lsst-sqre/gafaelfawr-client';
 // Import after mocking
 import { useLoginInfo } from '@lsst-sqre/gafaelfawr-client';
+import { useUnreadNotificationCount } from '@lsst-sqre/semaphore-client';
 import { PrimaryNavigation, useGafaelfawrUser } from '@lsst-sqre/squared';
-
+import { useSemaphoreUrl } from '../../hooks/useSemaphoreUrl';
+import { useStaticConfig } from '../../hooks/useStaticConfig';
+import type { AppConfig } from '../../lib/config/loader';
 import UserMenu from './UserMenu';
 
 // Helper: a logged-in useGafaelfawrUser return.
@@ -58,6 +75,26 @@ function mockLoginInfoWithScopes(scopes: string[]): UseLoginInfoReturn {
   };
 }
 
+// Helper: set the resolved static config, defaulting the notifications keys.
+function mockConfig(overrides: Partial<AppConfig> = {}) {
+  vi.mocked(useStaticConfig).mockReturnValue({
+    enableUserNotifications: false,
+    userNotificationsPollIntervalSeconds: 300,
+    ...overrides,
+  } as AppConfig);
+}
+
+// Helper: set the unread-count hook return.
+function mockUnreadCount(count: number | undefined) {
+  vi.mocked(useUnreadNotificationCount).mockReturnValue({
+    count,
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+}
+
 // Render the menu inside the navigation root it expects to live in.
 function renderMenu() {
   return render(
@@ -72,6 +109,12 @@ function renderMenu() {
 describe('UserMenu', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Sensible defaults: feature flag off, Semaphore discovered, no unread
+    // count, and no scopes. Individual tests override as needed.
+    mockConfig();
+    vi.mocked(useSemaphoreUrl).mockReturnValue('https://example.com/semaphore');
+    mockUnreadCount(undefined);
+    vi.mocked(useLoginInfo).mockReturnValue(mockLoginInfoWithScopes([]));
   });
 
   test('shows an Admin link to /admin when the user has exec:admin', async () => {
@@ -105,5 +148,90 @@ describe('UserMenu', () => {
     expect(
       screen.queryByRole('link', { name: 'Admin' })
     ).not.toBeInTheDocument();
+  });
+
+  describe('user notifications', () => {
+    test('shows a count badge and "{n} unread messages" item when the flag is on and unread > 0', async () => {
+      const user = userEvent.setup();
+      mockUser();
+      mockConfig({ enableUserNotifications: true });
+      mockUnreadCount(3);
+
+      renderMenu();
+
+      // The unread badge appears on the username trigger before opening.
+      expect(
+        screen.getByLabelText('3 unread notifications')
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /testuser/i }));
+
+      const item = screen.getByRole('link', { name: '3 unread messages' });
+      expect(item).toHaveAttribute('href', '/notifications');
+    });
+
+    test('shows a "Notifications" item and no badge when the flag is on and unread is 0', async () => {
+      const user = userEvent.setup();
+      mockUser();
+      mockConfig({ enableUserNotifications: true });
+      mockUnreadCount(0);
+
+      renderMenu();
+
+      // No count badge on the trigger when there is nothing unread.
+      expect(
+        screen.queryByLabelText(/unread notifications/i)
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /testuser/i }));
+
+      const item = screen.getByRole('link', { name: 'Notifications' });
+      expect(item).toHaveAttribute('href', '/notifications');
+      // The non-zero label is not used when the count is 0.
+      expect(screen.queryByText(/unread messages/i)).not.toBeInTheDocument();
+    });
+
+    test('shows no notifications item and no badge when the flag is off', async () => {
+      const user = userEvent.setup();
+      mockUser();
+      mockConfig({ enableUserNotifications: false });
+      mockUnreadCount(3);
+
+      renderMenu();
+
+      // No badge even though the (disabled) hook reports a count.
+      expect(
+        screen.queryByLabelText(/unread notifications/i)
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /testuser/i }));
+
+      // The menu is open (Settings is visible) but there is no notifications
+      // entry.
+      expect(
+        screen.getByRole('link', { name: 'Settings' })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('link', { name: /notifications/i })
+      ).not.toBeInTheDocument();
+    });
+
+    test('feeds the unread count from useUnreadNotificationCount with the configured poll interval', () => {
+      mockUser();
+      mockConfig({
+        enableUserNotifications: true,
+        userNotificationsPollIntervalSeconds: 120,
+      });
+      mockUnreadCount(1);
+
+      renderMenu();
+
+      // The hook is called with the discovered Semaphore URL and the
+      // configured poll cadence (the hook itself converts seconds to ms).
+      expect(useUnreadNotificationCount).toHaveBeenCalledWith(
+        'https://example.com/semaphore',
+        { pollIntervalSeconds: 120 }
+      );
+    });
   });
 });

--- a/apps/squareone/src/components/Header/UserMenu.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.tsx
@@ -56,7 +56,6 @@ export default function UserMenu({ pageUrl }: UserMenuProps) {
   return (
     <>
       <PrimaryNavigation.Trigger>
-        {user.username}{' '}
         {showUnreadBadge && (
           <Badge
             color="blue"
@@ -66,7 +65,8 @@ export default function UserMenu({ pageUrl }: UserMenuProps) {
           >
             {unreadCount}
           </Badge>
-        )}
+        )}{' '}
+        {user.username}
         <ChevronDown />
       </PrimaryNavigation.Trigger>
       <PrimaryNavigation.Content>

--- a/apps/squareone/src/components/Header/UserMenu.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.tsx
@@ -61,7 +61,9 @@ export default function UserMenu({ pageUrl }: UserMenuProps) {
             color="blue"
             radius="full"
             size="sm"
-            aria-label={`${unreadCount} unread notifications`}
+            aria-label={`${unreadCount} unread notification${
+              unreadCount === 1 ? '' : 's'
+            }`}
           >
             {unreadCount}
           </Badge>
@@ -80,7 +82,9 @@ export default function UserMenu({ pageUrl }: UserMenuProps) {
             <PrimaryNavigation.Link asChild>
               <NextLink href="/notifications">
                 {unreadCount > 0
-                  ? `${unreadCount} unread messages`
+                  ? `${unreadCount} unread message${
+                      unreadCount === 1 ? '' : 's'
+                    }`
                   : 'Notifications'}
               </NextLink>
             </PrimaryNavigation.Link>

--- a/apps/squareone/src/components/Header/UserMenu.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 /* Menu for a user profile and settings. */
 
 import { useLoginInfo } from '@lsst-sqre/gafaelfawr-client';
+import { useUnreadNotificationCount } from '@lsst-sqre/semaphore-client';
 import {
+  Badge,
   getLogoutUrl,
   PrimaryNavigation,
   useGafaelfawrUser,
@@ -11,6 +13,8 @@ import { ChevronDown } from 'lucide-react';
 import NextLink from 'next/link';
 
 import { useRepertoireUrl } from '../../hooks/useRepertoireUrl';
+import { useSemaphoreUrl } from '../../hooks/useSemaphoreUrl';
+import { useStaticConfig } from '../../hooks/useStaticConfig';
 import { ADMIN_SCOPE } from '../AdminRequired';
 
 type UserMenuProps = {
@@ -23,6 +27,20 @@ export default function UserMenu({ pageUrl }: UserMenuProps) {
   const { query } = useLoginInfo(repertoireUrl);
   const logoutUrl = getLogoutUrl(pageUrl.toString());
 
+  const { enableUserNotifications, userNotificationsPollIntervalSeconds } =
+    useStaticConfig();
+  const semaphoreUrl = useSemaphoreUrl();
+
+  // The unread count drives the trigger badge and the menu-item label. The
+  // query is gated on the feature flag by passing an empty URL when the flag
+  // is off — the hook treats an empty URL as "no service" and stays disabled,
+  // so no request is made until the flag is on and Semaphore is discovered.
+  const { count } = useUnreadNotificationCount(
+    enableUserNotifications ? (semaphoreUrl ?? '') : '',
+    { pollIntervalSeconds: userNotificationsPollIntervalSeconds }
+  );
+  const unreadCount = count ?? 0;
+
   // Only admins (holders of the exec:admin scope) see the Admin link, mirroring
   // the client-side gate on the admin pages themselves.
   const isAdmin = query?.hasScope(ADMIN_SCOPE) ?? false;
@@ -33,10 +51,23 @@ export default function UserMenu({ pageUrl }: UserMenuProps) {
     return null;
   }
 
+  const showUnreadBadge = enableUserNotifications && unreadCount > 0;
+
   return (
     <>
       <PrimaryNavigation.Trigger>
-        {user.username} <ChevronDown />
+        {user.username}{' '}
+        {showUnreadBadge && (
+          <Badge
+            color="blue"
+            radius="full"
+            size="sm"
+            aria-label={`${unreadCount} unread notifications`}
+          >
+            {unreadCount}
+          </Badge>
+        )}
+        <ChevronDown />
       </PrimaryNavigation.Trigger>
       <PrimaryNavigation.Content>
         <PrimaryNavigation.ContentItem>
@@ -44,6 +75,17 @@ export default function UserMenu({ pageUrl }: UserMenuProps) {
             <NextLink href="/settings">Settings</NextLink>
           </PrimaryNavigation.Link>
         </PrimaryNavigation.ContentItem>
+        {enableUserNotifications && (
+          <PrimaryNavigation.ContentItem>
+            <PrimaryNavigation.Link asChild>
+              <NextLink href="/notifications">
+                {unreadCount > 0
+                  ? `${unreadCount} unread messages`
+                  : 'Notifications'}
+              </NextLink>
+            </PrimaryNavigation.Link>
+          </PrimaryNavigation.ContentItem>
+        )}
         {isAdmin && (
           <PrimaryNavigation.ContentItem>
             <PrimaryNavigation.Link asChild>

--- a/apps/squareone/src/lib/config/userNotificationsConfigKeys.test.ts
+++ b/apps/squareone/src/lib/config/userNotificationsConfigKeys.test.ts
@@ -45,7 +45,10 @@ describe('user notifications feature-flag config keys', () => {
   });
 
   it('sets the development defaults in squareone.config.yaml', () => {
-    expect(devConfig.enableUserNotifications).toBe(false);
+    // Enabled in the dev config so the header badge / notifications UI are
+    // exercisable against the local dev mocks; the schema default (and thus the
+    // production default when the key is omitted) stays false.
+    expect(devConfig.enableUserNotifications).toBe(true);
     expect(devConfig.userNotificationsPollIntervalSeconds).toBe(300);
   });
 

--- a/apps/squareone/src/lib/mocks/userNotificationsStore.ts
+++ b/apps/squareone/src/lib/mocks/userNotificationsStore.ts
@@ -1,0 +1,79 @@
+// In-memory dev store for the authenticated user's own notifications.
+//
+// Backs the dev `GET /api/dev/semaphore/v1/notifications` mock (the user-facing
+// list endpoint that drives the header unread badge via the semaphore-client
+// `useUnreadNotificationCount` hook). The unread count is adjustable at runtime
+// from the `/dev` control panel through `GET`/`POST /api/dev/notifications-count`
+// so the badge can be exercised end-to-end without a live Semaphore.
+//
+// It is colocated with the rest of the dev tooling so it never reaches the
+// production build.
+
+import {
+  mockUserNotifications,
+  type UserNotificationSummary,
+} from '@lsst-sqre/semaphore-client';
+
+// Base for the synthetic resource URL of generated notifications, matching the
+// shape the Semaphore user list endpoint returns.
+const MOCK_USER_URL_BASE =
+  'https://data.example.com/semaphore/v1/notifications';
+
+// Split the shared fixtures into unread "templates" (reused as realistic
+// content for the generated unread entries) and the static read fixtures (kept
+// so the unfiltered list always has a sensible read/unread mix).
+const UNREAD_TEMPLATES = mockUserNotifications.filter((n) => n.read === null);
+const READ_FIXTURES = mockUserNotifications.filter((n) => n.read !== null);
+
+// Default to the number of unread fixtures so the header badge is populated as
+// soon as the feature flag is enabled; adjustable from the `/dev` panel.
+const DEFAULT_UNREAD_COUNT = UNREAD_TEMPLATES.length;
+
+let unreadCount = DEFAULT_UNREAD_COUNT;
+
+/** The dev-selected number of unread notifications. */
+export function getDevUnreadCount(): number {
+  return unreadCount;
+}
+
+/**
+ * Set the dev-selected unread count, clamped to a non-negative integer.
+ *
+ * @param count - Desired number of unread notifications
+ */
+export function setDevUnreadCount(count: number): void {
+  unreadCount = Number.isFinite(count) ? Math.max(0, Math.floor(count)) : 0;
+}
+
+/**
+ * Synthesize one unread summary, cycling through the realistic unread fixtures
+ * for content but with a deterministic, collision-free id and resource URL.
+ */
+function buildUnread(index: number): UserNotificationSummary {
+  const template = UNREAD_TEMPLATES[index % UNREAD_TEMPLATES.length];
+  const id = `dev-unread-${index + 1}`;
+  return {
+    ...template,
+    id,
+    read: null,
+    url: `${MOCK_USER_URL_BASE}/${id}`,
+  };
+}
+
+/**
+ * The current user notifications, most-recent first: `unreadCount` unread
+ * summaries followed by the static read fixtures.
+ *
+ * `filterAndPaginateUserNotifications` derives both the page slice and the
+ * `X-Total-Count` from this list, so the unread total the badge reads always
+ * matches the dev-selected count.
+ */
+export function getDevUserNotifications(): UserNotificationSummary[] {
+  const unread = Array.from({ length: unreadCount }, (_, i) => buildUnread(i));
+  return [...unread, ...READ_FIXTURES];
+}
+
+/** Reset the unread count to its seeded default. Primarily for tests. */
+export function resetDevUserNotifications(): void {
+  unreadCount = DEFAULT_UNREAD_COUNT;
+}


### PR DESCRIPTION
## Summary

- Extend the header `UserMenu` so that, when `enableUserNotifications` is on and the user is logged in, it shows an unread count `Badge` on the username trigger (only when unread > 0) and a menu item reading "{n} unread messages" (or plain "Notifications" at 0) linking to `/notifications`.
- Feed the count from `useUnreadNotificationCount`, gated on the flag (disabled via an empty Semaphore URL when off) and polling on `userNotificationsPollIntervalSeconds`; with the flag off the menu shows no notifications entry or badge.

## Validation steps

- With `enableUserNotifications: false`, log in and confirm the user menu shows no notifications item and no unread badge on the username.
- With the flag on, logged in, and ≥1 unread message: confirm a count badge appears on the username trigger and the menu item reads "{n} unread messages" and links to `/notifications`.
- With the flag on and 0 unread: confirm the menu item reads "Notifications" (no count badge).
- Confirm the unread count refreshes on navigation and after a mark-read action, and otherwise polls on `userNotificationsPollIntervalSeconds` (default 5 minutes).

## References

- Closes #500
- PRD: #495
- Jira: https://rubinobs.atlassian.net/browse/DM-55290