### PR TITLE
DM-55290: Add biome-migrate skill and schema-drift check

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -21,6 +21,7 @@ This directory contains configuration for Claude Code, including specialized ski
 │   ├── data-fetching-patterns/ # SWR data fetching patterns
 │   ├── platform-api-integration/ # RSP API discovery & integration
 │   ├── docker-version-validation/ # Dockerfile version synchronization
+│   ├── biome-migrate/          # Run biome migrate on Biome version bumps
 │   └── file-factory/          # CLI scaffolding for components, hooks, contexts, pages
 ├── tasks/                      # Gitignored task-specific docs
 ├── projects/                   # Project-specific configurations
@@ -232,6 +233,21 @@ Skills are modular capabilities that extend Claude's expertise with domain-speci
 **Supporting files**:
 
 - None (references validation script at `packages/repo-scripts/src/validate-docker-versions.js`)
+
+#### biome-migrate
+
+**When to use**: Processing a dependabot PR that bumps `@biomejs/biome` (arrives via the npm `monorepo-infra` group), seeing a `biome:lint`/`biome:format` schema info ("Expected … Found … Run the command biome migrate"), or noticing `biome.json`'s `$schema` version lagging the installed Biome
+
+**Covers**:
+
+- Running `pnpm exec biome migrate --write` to sync `biome.json`'s `$schema` (and any deprecated config) with the installed Biome
+- Recognizing the non-blocking info-level signal that a migrate is overdue
+- Folding the migrate into a dependabot PR branch vs. a follow-up branch when the bump already merged
+- Why the change needs no Changeset (repo-root tooling config)
+
+**Supporting files**:
+
+- None (references `biome.json` and the root `biome:*` scripts)
 
 #### file-factory
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -236,18 +236,19 @@ Skills are modular capabilities that extend Claude's expertise with domain-speci
 
 #### biome-migrate
 
-**When to use**: Processing a dependabot PR that bumps `@biomejs/biome` (arrives via the npm `monorepo-infra` group), seeing a `biome:lint`/`biome:format` schema info ("Expected … Found … Run the command biome migrate"), or noticing `biome.json`'s `$schema` version lagging the installed Biome
+**When to use**: Processing a dependabot PR that bumps `@biomejs/biome` (arrives via the npm `monorepo-infra` group), seeing a `biome:lint`/`biome:format` schema info ("Expected … Found … Run the command biome migrate"), a failing "Validate Biome schema version" CI step, or noticing `biome.json`'s `$schema` version lagging the installed Biome
 
 **Covers**:
 
 - Running `pnpm exec biome migrate --write` to sync `biome.json`'s `$schema` (and any deprecated config) with the installed Biome
 - Recognizing the non-blocking info-level signal that a migrate is overdue
+- The `validate-biome-schema` enforcement check that runs in CI, on pre-commit, and in `pnpm localci`
 - Folding the migrate into a dependabot PR branch vs. a follow-up branch when the bump already merged
 - Why the change needs no Changeset (repo-root tooling config)
 
 **Supporting files**:
 
-- None (references `biome.json` and the root `biome:*` scripts)
+- None (references the validation script at `packages/repo-scripts/src/validate-biome-schema.js` and the root `biome:*` scripts)
 
 #### file-factory
 

--- a/.claude/skills/biome-migrate/SKILL.md
+++ b/.claude/skills/biome-migrate/SKILL.md
@@ -6,9 +6,10 @@ description: |
   Use when processing a dependabot PR that bumps @biomejs/biome (it arrives via the
   npm monorepo-infra group), when biome:lint/biome:format reports an info like
   "Expected: <new> Found: <old> — Run the command biome migrate", or any time you
-  notice biome.json's $schema version lagging the installed Biome. Trigger keywords:
-  biome, @biomejs/biome, biome migrate, biome.json, $schema mismatch, schema version,
-  dependabot biome bump, Biome upgrade.
+  notice biome.json's $schema version lagging the installed Biome, or when the
+  "Validate Biome schema version" CI step (validate-biome-schema.js) fails.
+  Trigger keywords: biome, @biomejs/biome, biome migrate, biome.json, $schema
+  mismatch, schema version, dependabot biome bump, Biome upgrade.
 allowed-tools:
   - Bash(pnpm exec biome migrate:*)
   - Bash(pnpm exec biome --version:*)
@@ -43,6 +44,11 @@ follow-up** to any Biome version bump — most often a dependabot PR.
 
   This is *info*-level and does **not** fail lint, so it is easy to miss — but
   it is the signal that a migrate is overdue.
+- **The `validate-biome-schema` check fails.** `biome:lint`'s info is only
+  advisory, so `validate-biome-schema.js` turns the drift into a hard failure —
+  it runs as the "Validate Biome schema version" CI step, on pre-commit when
+  `biome.json` is staged, and in `pnpm localci`. When it fails it prints the same
+  two-step hint (run the command, or use this skill).
 - **You notice `biome.json`'s `$schema` lagging** the installed Biome during any
   other workflow (a rebase, a manual dependency change, etc.).
 
@@ -68,6 +74,9 @@ review the full diff and keep the migrated result.
 ## Verify
 
 ```bash
+# the enforcement check should pass (exit 0, "Biome schema is in sync")
+pnpm run validate-biome
+
 # $schema version should now match the installed Biome
 grep '"\$schema"' biome.json
 pnpm exec biome --version

--- a/.claude/skills/biome-migrate/SKILL.md
+++ b/.claude/skills/biome-migrate/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: biome-migrate
+description: |
+  Run `biome migrate` whenever the @biomejs/biome version changes so biome.json's
+  $schema (and any deprecated config) stays in sync with the installed Biome.
+  Use when processing a dependabot PR that bumps @biomejs/biome (it arrives via the
+  npm monorepo-infra group), when biome:lint/biome:format reports an info like
+  "Expected: <new> Found: <old> — Run the command biome migrate", or any time you
+  notice biome.json's $schema version lagging the installed Biome. Trigger keywords:
+  biome, @biomejs/biome, biome migrate, biome.json, $schema mismatch, schema version,
+  dependabot biome bump, Biome upgrade.
+allowed-tools:
+  - Bash(pnpm exec biome migrate:*)
+  - Bash(pnpm exec biome --version:*)
+  - Bash(pnpm run biome:format:check:*)
+  - Bash(pnpm run biome:lint:*)
+---
+
+# Biome migrate on version bumps
+
+When the pinned Biome version changes, `biome.json` can fall behind the new
+release: its `$schema` URL still points at the old version, and a larger jump
+may leave deprecated config keys in place. Biome ships `biome migrate` to
+reconcile the config file with the installed binary. This is a **required
+follow-up** to any Biome version bump — most often a dependabot PR.
+
+## When to use this skill
+
+- **Processing a dependabot PR that bumps `@biomejs/biome`.** Biome is bumped
+  through the npm **`monorepo-infra`** group (e.g. the group PR that moved
+  Biome `2.3.12` → `2.3.14`), so it rides along with other tooling bumps rather
+  than arriving as a lone "bump @biomejs/biome" PR — check each `monorepo-infra`
+  group PR's file list for a `@biomejs/biome` change. See the user-level
+  `rubin-dependabot-triage` skill for the overall triage flow; this skill is the
+  Biome-specific step to fold into it.
+- **`biome:lint` / `biome:format:check` prints a schema info**, for example:
+
+  ```
+  i Expected: 2.3.14
+    Found:    2.3.12
+  i Run the command biome migrate to migrate the configuration file.
+  ```
+
+  This is *info*-level and does **not** fail lint, so it is easy to miss — but
+  it is the signal that a migrate is overdue.
+- **You notice `biome.json`'s `$schema` lagging** the installed Biome during any
+  other workflow (a rebase, a manual dependency change, etc.).
+
+## The fix
+
+Biome is invoked at the repo root via `pnpm exec biome` (there is no
+`biome:migrate` npm script). From the repo root:
+
+```bash
+pnpm exec biome migrate --write
+```
+
+For a routine patch/minor bump this rewrites only the `$schema` line, e.g.:
+
+```diff
+-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
++  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+```
+
+A larger version jump may also migrate renamed or deprecated config keys —
+review the full diff and keep the migrated result.
+
+## Verify
+
+```bash
+# $schema version should now match the installed Biome
+grep '"\$schema"' biome.json
+pnpm exec biome --version
+
+# the schema info should be gone (both exit clean, no "Run the command biome migrate")
+pnpm run biome:format:check
+pnpm run biome:lint
+```
+
+## Landing the change
+
+- **On a dependabot PR:** apply the migrate on the PR's own branch so the config
+  bump and the migrate ship together. Following `rubin-dependabot-triage`, check
+  the branch out in a worktree, run `pnpm exec biome migrate --write`, commit
+  (e.g. `chore: run biome migrate for the <old>→<new> bump`), and push to the
+  same branch — dependabot PRs accept maintainer pushes.
+- **After the bump already merged** (you spotted the drift late): make a small
+  follow-up branch off `main` and run the migrate there.
+- **No changeset needed.** `biome.json` is repo-root tooling config, not part of
+  any published package, so this change does not get a Changeset.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,9 @@ jobs:
       - name: Validate Docker versions
         run: node packages/repo-scripts/src/validate-docker-versions.js
 
+      - name: Validate Biome schema version
+        run: node packages/repo-scripts/src/validate-biome-schema.js
+
       - name: Check formatting with Biome
         run: pnpm run biome:format:check
 

--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -4,4 +4,7 @@ export default {
   '**/Dockerfile*': [
     'node packages/repo-scripts/src/validate-docker-versions.js',
   ],
+  'biome.{json,jsonc}': [
+    'node packages/repo-scripts/src/validate-biome-schema.js',
+  ],
 };

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "localci": "node packages/repo-scripts/src/validate-docker-versions.js && node scripts/turbo-wrapper.js run biome:format:check prettier:yaml lint type-check test build && pnpm run biome:lint",
+    "localci": "node packages/repo-scripts/src/validate-docker-versions.js && node packages/repo-scripts/src/validate-biome-schema.js && node scripts/turbo-wrapper.js run biome:format:check prettier:yaml lint type-check test build && pnpm run biome:lint",
     "build": "node scripts/turbo-wrapper.js run build",
     "file-factory": "node packages/file-factory/dist/cli.js",
     "dev": "node scripts/turbo-wrapper.js run dev",
@@ -22,6 +22,7 @@
     "build:local": "turbo run build",
     "docs": "uv run noxfile.py -s docs",
     "validate-docker": "node packages/repo-scripts/src/validate-docker-versions.js",
+    "validate-biome": "node packages/repo-scripts/src/validate-biome-schema.js",
     "check-openapi-drift": "node packages/repo-scripts/src/check-openapi-drift.js",
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\" && node scripts/install-playwright.js"
   },

--- a/packages/repo-scripts/src/validate-biome-schema.js
+++ b/packages/repo-scripts/src/validate-biome-schema.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that biome.json's `$schema` version matches the installed
+ * @biomejs/biome version.
+ *
+ * When a dependency bump moves @biomejs/biome to a new version, biome.json's
+ * `$schema` URL keeps pointing at the old version until `biome migrate` is run.
+ * Biome only surfaces this as an info-level lint diagnostic, which is easy to
+ * miss, so this check turns the drift into a hard failure in CI and pre-commit.
+ *
+ * Source of truth is the *installed* Biome version (what the binary reports and
+ * what `biome migrate` writes into `$schema`), so a passing check guarantees
+ * `biome migrate` would be a no-op.
+ *
+ * Exit codes:
+ * - 0: `$schema` matches the installed Biome (or nothing to check)
+ * - 1: Version mismatch found
+ * - 2: Validation error (missing files, parse errors)
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+// ANSI color codes for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  bold: '\x1b[1m',
+};
+
+/**
+ * Extract the version from a Biome `$schema` URL such as
+ * "https://biomejs.dev/schemas/2.3.14/schema.json".
+ * @param {string} schema - The `$schema` string.
+ * @returns {string|null} - The X.Y.Z version, or null if not found.
+ */
+function extractSchemaVersion(schema) {
+  if (!schema) return null;
+  const match = schema.match(/schemas\/(\d+\.\d+\.\d+)\/schema\.json/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extract an X.Y.Z version from a dependency range such as "^2.3.14".
+ * @param {string} range
+ * @returns {string|null}
+ */
+function extractVersion(range) {
+  if (!range) return null;
+  const match = range.match(/(\d+\.\d+\.\d+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Read the `$schema` version declared in biome.json / biome.jsonc.
+ *
+ * The `$schema` value is pulled with a regex rather than JSON.parse so a JSONC
+ * config with comments still parses.
+ *
+ * @param {string} rootDir - Repository root.
+ * @returns {{ path: string, version: string|null }|null} - null if no config found.
+ */
+function readConfigSchemaVersion(rootDir) {
+  const candidates = ['biome.json', 'biome.jsonc'];
+  for (const name of candidates) {
+    const configPath = path.join(rootDir, name);
+    if (!fs.existsSync(configPath)) continue;
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    const match = content.match(/"\$schema"\s*:\s*"([^"]+)"/);
+    return { path: configPath, version: extractSchemaVersion(match?.[1]) };
+  }
+  return null;
+}
+
+/**
+ * Resolve the Biome version to validate against.
+ *
+ * Prefers the installed package (`node_modules/@biomejs/biome/package.json`,
+ * matching what the binary reports and what `biome migrate` writes). Falls back
+ * to the root package.json devDependency range when node_modules is absent.
+ *
+ * @param {string} rootDir - Repository root.
+ * @returns {{ version: string, source: string }|null}
+ */
+function readInstalledBiomeVersion(rootDir) {
+  const installedPath = path.join(
+    rootDir,
+    'node_modules/@biomejs/biome/package.json'
+  );
+  if (fs.existsSync(installedPath)) {
+    try {
+      const version = JSON.parse(
+        fs.readFileSync(installedPath, 'utf8')
+      ).version;
+      if (version) return { version, source: 'installed @biomejs/biome' };
+    } catch (_error) {
+      // Fall through to the package.json fallback.
+    }
+  }
+
+  // Fallback: the declared devDependency range in the root package.json.
+  const rootPackagePath = path.join(rootDir, 'package.json');
+  try {
+    const pkg = JSON.parse(fs.readFileSync(rootPackagePath, 'utf8'));
+    const declared =
+      pkg.devDependencies?.['@biomejs/biome'] ||
+      pkg.dependencies?.['@biomejs/biome'];
+    const version = extractVersion(declared);
+    if (version) {
+      return { version, source: 'package.json @biomejs/biome (not installed)' };
+    }
+  } catch (_error) {
+    // Reported by the caller as a validation error.
+  }
+
+  return null;
+}
+
+/**
+ * Main execution
+ */
+function main() {
+  // Repo root, resolved from this script's home in packages/repo-scripts/src.
+  const rootDir = path.resolve(__dirname, '../../..');
+
+  console.log(`${colors.bold}Biome Schema Validator${colors.reset}`);
+
+  const config = readConfigSchemaVersion(rootDir);
+  if (!config) {
+    console.log(
+      `${colors.yellow}⚠${colors.reset} No biome.json / biome.jsonc found; nothing to validate`
+    );
+    process.exit(0);
+  }
+
+  const relativeConfigPath = path.relative(rootDir, config.path);
+  console.log(
+    `\n${colors.blue}Validating:${colors.reset} ${relativeConfigPath}`
+  );
+
+  const installed = readInstalledBiomeVersion(rootDir);
+  if (!installed) {
+    console.error(
+      `${colors.red}✗${colors.reset} Could not resolve the @biomejs/biome version to validate against`
+    );
+    process.exit(2);
+  }
+
+  console.log(
+    `${colors.blue}Against:${colors.reset} Biome ${installed.version} (${installed.source})`
+  );
+
+  if (!config.version) {
+    console.error(
+      `  ${colors.red}✗${colors.reset} biome.json has no recognizable "$schema" version`
+    );
+    console.error(
+      `    Expected a URL like https://biomejs.dev/schemas/${installed.version}/schema.json`
+    );
+    printFixHint();
+    process.exit(1);
+  }
+
+  if (config.version === installed.version) {
+    console.log(
+      `  ${colors.green}✓${colors.reset} $schema ${config.version} matches Biome ${installed.version}`
+    );
+    console.log(
+      `\n${colors.bold}Summary:${colors.reset} ${colors.green}✓ Biome schema is in sync${colors.reset}\n`
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `  ${colors.red}✗${colors.reset} Biome $schema version mismatch:`
+  );
+  console.error(`    biome.json $schema: ${config.version}`);
+  console.error(`    installed Biome:    ${installed.version}`);
+  printFixHint();
+  process.exit(1);
+}
+
+/**
+ * Print the remediation hint (command + skill).
+ */
+function printFixHint() {
+  console.log(`\n${colors.yellow}To fix:${colors.reset}`);
+  console.log(
+    `  1. Run ${colors.bold}pnpm exec biome migrate --write${colors.reset} to sync biome.json's $schema, or`
+  );
+  console.log(
+    `  2. Use the ${colors.bold}biome-migrate${colors.reset} skill (.claude/skills/biome-migrate)`
+  );
+  console.log('');
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main();
+}
+
+// Export for testing
+module.exports = {
+  extractSchemaVersion,
+  extractVersion,
+  readConfigSchemaVersion,
+  readInstalledBiomeVersion,
+};

--- a/packages/repo-scripts/src/validate-biome-schema.test.ts
+++ b/packages/repo-scripts/src/validate-biome-schema.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractSchemaVersion,
+  extractVersion,
+} from './validate-biome-schema.js';
+
+describe('extractSchemaVersion', () => {
+  it('extracts the version from a Biome $schema URL', () => {
+    expect(
+      extractSchemaVersion('https://biomejs.dev/schemas/2.3.14/schema.json')
+    ).toBe('2.3.14');
+  });
+
+  it('returns null when the URL has no version segment', () => {
+    expect(
+      extractSchemaVersion('https://biomejs.dev/schemas/schema.json')
+    ).toBe(null);
+  });
+
+  it('returns null for an empty or missing value', () => {
+    expect(extractSchemaVersion('')).toBe(null);
+    expect(extractSchemaVersion(undefined as unknown as string)).toBe(null);
+  });
+});
+
+describe('extractVersion', () => {
+  it('strips a caret range prefix', () => {
+    expect(extractVersion('^2.3.14')).toBe('2.3.14');
+  });
+
+  it('strips a tilde range prefix', () => {
+    expect(extractVersion('~2.3.14')).toBe('2.3.14');
+  });
+
+  it('returns an exact version unchanged', () => {
+    expect(extractVersion('2.3.14')).toBe('2.3.14');
+  });
+
+  it('returns null for a missing range', () => {
+    expect(extractVersion(null as unknown as string)).toBe(null);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a `biome-migrate` Claude skill that documents running `biome migrate` whenever the pinned `@biomejs/biome` version changes — most often a dependabot PR in the npm `monorepo-infra` group — so `biome.json`'s `$schema` (and any deprecated config) stays in sync with the installed Biome. The skill is indexed in `.claude/README.md`.
- Add a `validate-biome-schema` check (mirroring `validate-docker-versions`) that turns Biome's advisory info-level `$schema` drift into a hard failure. It runs as a CI step, on pre-commit via lint-staged (on `biome.{json,jsonc}`), through the `pnpm validate-biome` root script, and in `pnpm localci`; on mismatch it prints a hint to run `biome migrate` or use the skill. Version parsing is covered by unit tests.
- Run `biome migrate` now to clear the current drift: the recent `monorepo-infra` bump moved Biome `2.3.12` → `2.3.14` but left `biome.json`'s `$schema` pointing at `2.3.12`.

## Validation steps

- Run `pnpm validate-biome` and confirm it reports "Biome schema is in sync" (exit 0).
- Temporarily edit `biome.json`'s `$schema` to a different version, run `pnpm validate-biome`, and confirm it exits non-zero with the two-step fix hint; restore the file.
- Confirm `pnpm run biome:lint` no longer prints the `Expected … Found … Run the command biome migrate` info.
- Ask Claude to process a dependabot PR that bumps `@biomejs/biome` and confirm the `biome-migrate` skill activates.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55290