### PR TITLE
DM-55381: Add @lsst-sqre/sse-client shared SSE transport package

### DIFF
--- a/.changeset/eight-flies-shout.md
+++ b/.changeset/eight-flies-shout.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+Migrate `TimesSquareHtmlEventsProviderClient` to `subscribeToHtmlEvents()` from `@lsst-sqre/times-square-client`, removing the duplicated inline SSE implementation and the local `HtmlEvent` type. The app's Times Square SSE path now gains Zod validation of events, `credentials: 'include'` (Gafaelfawr same-origin cookie auth), and automatic reconnection with backoff from the shared `@lsst-sqre/sse-client` transport. This removes `@microsoft/fetch-event-source` from `apps/squareone` — the dependency is now gone from the entire repo.

--- a/.changeset/spicy-donuts-repeat.md
+++ b/.changeset/spicy-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/times-square-client': minor
+---
+
+Rewrite the Times Square SSE layer (`subscribeToHtmlEvents`) on the shared `@lsst-sqre/sse-client` transport, replacing the unmaintained `@microsoft/fetch-event-source` dependency. The public API is unchanged — `subscribeToHtmlEvents()`, `createHtmlEventsUrl()`, `SubscribeOptions`, `HtmlEventCallback`, and `SseErrorCallback` keep their exact signatures — and Zod validation of `HtmlEvent`, auto-abort on execution completion, `onComplete`, and the optional structured `Logger` all remain in this layer. Reconnect policy now follows the transport's defaults: automatic reconnection with backoff, honoring server `retry:` fields, including after HTTP 4xx responses. Connection interruptions are surfaced through `onError`, and scheduled reconnects are logged through the `Logger` when provided.

--- a/.changeset/tidy-moons-agree.md
+++ b/.changeset/tidy-moons-agree.md
@@ -1,0 +1,6 @@
+---
+'@lsst-sqre/times-square-client': patch
+'squareone': patch
+---
+
+Fix Times Square dev mock API routes that had drifted from the real API: leaf nodes in the GitHub contents-tree mocks now include the required empty `contents` array, and the page-metadata mocks return the full `Page` shape (formatted-text `description`, `date_added`, `uploader_username`, `html_events_url`, `github`). New schema-conformance tests parse every JSON mock route with the Zod schemas from `@lsst-sqre/times-square-client`, and the Times Square v0.24.0 OpenAPI spec is vendored in the package as the reference for those schemas.

--- a/.changeset/tidy-pears-shave.md
+++ b/.changeset/tidy-pears-shave.md
@@ -1,0 +1,8 @@
+---
+'@lsst-sqre/sse-client': minor
+---
+
+Add the @lsst-sqre/sse-client package, the monorepo's shared Server-Sent Events (SSE) transport built on `eventsource-client`. The package follows the no-build-step pattern (consumers transpile TypeScript source directly) and exports:
+
+- `subscribeToEventSource(url, options)` — a framework-agnostic subscribe function with raw `onMessage`/`onConnect`/`onDisconnect`/`onScheduleReconnect` callbacks, custom `headers`, `credentials` (defaulting to `'include'` for Gafaelfawr same-origin cookie auth), an external `AbortSignal`, and a `fetch` override. It returns a cleanup function that closes the connection and stops automatic reconnection. Payload parsing/validation is deliberately left to consumers.
+- `useEventSource(url, options)` — a thin React hook wrapping the subscribe function with effect lifecycle management. The connection follows the component lifecycle and the `url` (pass `null` to disable); callbacks are read through a ref so identity changes never reconnect.

--- a/apps/squareone/next.config.js
+++ b/apps/squareone/next.config.js
@@ -22,6 +22,7 @@ module.exports = (phase) => {
       '@lsst-sqre/repertoire-client',
       '@lsst-sqre/gafaelfawr-client',
       '@lsst-sqre/semaphore-client',
+      '@lsst-sqre/sse-client',
       '@lsst-sqre/times-square-client',
     ],
     async rewrites() {

--- a/apps/squareone/package.json
+++ b/apps/squareone/package.json
@@ -25,7 +25,6 @@
     "@lsst-sqre/semaphore-client": "workspace:*",
     "@lsst-sqre/squared": "workspace:*",
     "@lsst-sqre/times-square-client": "workspace:*",
-    "@microsoft/fetch-event-source": "^2.0.1",
     "@sentry/nextjs": "^10.58.0",
     "@tanstack/react-query": "^5.90.20",
     "ajv": "^8.18.0",

--- a/apps/squareone/src/app/api/dev/times-square/schema-conformance.test.ts
+++ b/apps/squareone/src/app/api/dev/times-square/schema-conformance.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Schema conformance tests for the Times Square dev mock API routes.
+ *
+ * Each mock route's payload is parsed with the corresponding Zod schema from
+ * @lsst-sqre/times-square-client (which mirrors the Times Square OpenAPI spec
+ * vendored at packages/times-square-client/openapi.json), so drift between the
+ * mocks and the real API fails here instead of as a runtime ZodError in dev.
+ */
+
+import {
+  GitHubContentsRootSchema,
+  GitHubPrContentsSchema,
+  HtmlStatusSchema,
+  PageSchema,
+  PageSummarySchema,
+} from '@lsst-sqre/times-square-client';
+import { describe, expect, it, vi } from 'vitest';
+import { GET as getGithubPage } from './v1/github/[...tsSlug]/route.dev';
+import { GET as getGithubContents } from './v1/github/route.dev';
+import { GET as getGithubPrPage } from './v1/github-pr/[owner]/[repo]/[commit]/[...tsSlug]/route.dev';
+import { GET as getGithubPrContents } from './v1/github-pr/[owner]/[repo]/[commit]/route.dev';
+import { GET as getHtmlStatus } from './v1/pages/[page]/htmlstatus/route.dev';
+import { GET as getPage } from './v1/pages/[page]/route.dev';
+import { GET as getPages } from './v1/pages/route.dev';
+
+vi.mock('@/lib/config/loader', () => ({
+  loadAppConfig: vi.fn().mockResolvedValue({
+    timesSquareUrl: 'http://localhost:3000/times-square/api',
+  }),
+}));
+
+vi.mock('@/lib/logger', () => {
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return { default: log, createRouteLogger: () => log };
+});
+
+type Parseable = {
+  safeParse: (data: unknown) => { success: boolean; error?: unknown };
+};
+
+/** Parse a route response with a schema, surfacing Zod issues on failure. */
+async function expectConforms(response: Response, schema: Parseable) {
+  expect(response.status).toBe(200);
+  const payload = await response.json();
+  const result = schema.safeParse(payload);
+  expect(result.error).toBeUndefined();
+}
+
+describe('Times Square dev mock schema conformance', () => {
+  it('GET /v1/pages conforms to PageSummary[]', async () => {
+    const response = await getPages();
+    await expectConforms(response, PageSummarySchema.array());
+  });
+
+  it('GET /v1/pages/[page] conforms to PageSchema', async () => {
+    const response = await getPage(new Request('http://localhost/mock'), {
+      params: Promise.resolve({ page: 'mypage' }),
+    });
+    await expectConforms(response, PageSchema);
+  });
+
+  it('GET /v1/pages/[page]/htmlstatus conforms to HtmlStatusSchema', async () => {
+    const response = await getHtmlStatus(
+      new Request('http://localhost/mock?a=1'),
+      { params: Promise.resolve({ page: 'mypage' }) }
+    );
+    await expectConforms(response, HtmlStatusSchema);
+  });
+
+  it('GET /v1/pages/[page]/htmlstatus (unavailable mode) conforms to HtmlStatusSchema', async () => {
+    const response = await getHtmlStatus(
+      new Request('http://localhost/mock?a=2'),
+      { params: Promise.resolve({ page: 'mypage' }) }
+    );
+    await expectConforms(response, HtmlStatusSchema);
+  });
+
+  it('GET /v1/github conforms to GitHubContentsRootSchema', async () => {
+    const response = await getGithubContents();
+    await expectConforms(response, GitHubContentsRootSchema);
+  });
+
+  it('GET /v1/github/[...tsSlug] conforms to PageSchema', async () => {
+    const response = await getGithubPage(new Request('http://localhost/mock'), {
+      params: Promise.resolve({
+        tsSlug: ['lsst-sqre', 'times-square-demo', 'matplotlib', 'gaussian2d'],
+      }),
+    });
+    await expectConforms(response, PageSchema);
+  });
+
+  it('GET /v1/github-pr/[owner]/[repo]/[commit] conforms to GitHubPrContentsSchema', async () => {
+    const response = await getGithubPrContents();
+    await expectConforms(response, GitHubPrContentsSchema);
+  });
+
+  it('GET /v1/github-pr/[owner]/[repo]/[commit]/[...tsSlug] conforms to PageSchema', async () => {
+    const response = await getGithubPrPage();
+    await expectConforms(response, PageSchema);
+  });
+});

--- a/apps/squareone/src/app/api/dev/times-square/v1/github-pr/[owner]/[repo]/[commit]/[...tsSlug]/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/times-square/v1/github-pr/[owner]/[repo]/[commit]/[...tsSlug]/route.dev.ts
@@ -3,6 +3,7 @@
  * /times-square/v1/github-pr/:owner/:repo/:commit/:slug (App Router version)
  */
 
+import type { Page } from '@lsst-sqre/times-square-client';
 import { NextResponse } from 'next/server';
 
 import { loadAppConfig } from '@/lib/config/loader';
@@ -19,15 +20,25 @@ export async function GET() {
     const { timesSquareUrl } = appConfig;
     const pageBaseUrl = `${timesSquareUrl}/v1/pages/${page}`;
 
-    const content = {
+    // Shape must conform to the PageSchema Zod schema in
+    // @lsst-sqre/times-square-client (packages/times-square-client/src/schemas.ts).
+    const content: Page = {
       name: page,
       title: `Title for ${page}`,
-      description: '<p>This is the description.</p>',
+      description: {
+        gfm: 'This is the description.',
+        html: '<p>This is the description.</p>',
+      },
+      date_added: '2024-01-15T10:00:00Z',
+      authors: [],
+      tags: [],
+      uploader_username: null,
       self_url: pageBaseUrl,
       source_url: `${pageBaseUrl}/source`,
       rendered_url: `${pageBaseUrl}/rendered`,
       html_url: `${pageBaseUrl}/html`,
       html_status_url: `${pageBaseUrl}/htmlstatus`,
+      html_events_url: `${pageBaseUrl}/htmlevents`,
       parameters: {
         a: {
           type: 'number',
@@ -39,6 +50,12 @@ export async function GET() {
           default: 'Hello',
           description: 'A string.',
         },
+      },
+      github: {
+        owner: 'lsst-sqre',
+        repository: 'times-square-demo',
+        source_path: `${page}.ipynb`,
+        sidecar_path: `${page}.yaml`,
       },
     };
 

--- a/apps/squareone/src/app/api/dev/times-square/v1/github-pr/[owner]/[repo]/[commit]/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/times-square/v1/github-pr/[owner]/[repo]/[commit]/route.dev.ts
@@ -3,10 +3,11 @@
  * /times-square/v1/github-pr/:owner/:repo/:commit (App Router version)
  */
 
+import type { GitHubPrContents } from '@lsst-sqre/times-square-client';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const data = {
+  const data: GitHubPrContents = {
     contents: [
       {
         node_type: 'owner',
@@ -17,6 +18,7 @@ export async function GET() {
             node_type: 'page',
             title: 'Demo',
             path: 'demo',
+            contents: [],
           },
           {
             node_type: 'directory',
@@ -27,6 +29,7 @@ export async function GET() {
                 node_type: 'page',
                 title: 'Gaussian 2D',
                 path: 'matplotlib/gaussian2d',
+                contents: [],
               },
             ],
           },

--- a/apps/squareone/src/app/api/dev/times-square/v1/github/[...tsSlug]/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/times-square/v1/github/[...tsSlug]/route.dev.ts
@@ -31,10 +31,17 @@ export async function GET(
       return new Response(null, { status: 404 });
     }
 
+    // Shape must conform to the PageSchema Zod schema in
+    // @lsst-sqre/times-square-client (packages/times-square-client/src/schemas.ts).
     const content = {
       name: page,
       title: `Title for ${page}`,
-      description: '<p>This is the description.</p>',
+      description: {
+        gfm: 'This is the description.',
+        html: '<p>This is the description.</p>',
+      },
+      date_added: '2024-01-15T10:00:00Z',
+      uploader_username: null as string | null,
       self_url: pageBaseUrl,
       source_url: `${pageBaseUrl}/source`,
       rendered_url: `${pageBaseUrl}/rendered`,

--- a/apps/squareone/src/app/api/dev/times-square/v1/github/[...tsSlug]/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/times-square/v1/github/[...tsSlug]/route.dev.ts
@@ -4,6 +4,7 @@
  * Fixed URLs to use mock API endpoints
  */
 
+import type { Page } from '@lsst-sqre/times-square-client';
 import { NextResponse } from 'next/server';
 
 import { loadAppConfig } from '@/lib/config/loader';
@@ -33,7 +34,7 @@ export async function GET(
 
     // Shape must conform to the PageSchema Zod schema in
     // @lsst-sqre/times-square-client (packages/times-square-client/src/schemas.ts).
-    const content = {
+    const content: Page = {
       name: page,
       title: `Title for ${page}`,
       description: {
@@ -41,7 +42,9 @@ export async function GET(
         html: '<p>This is the description.</p>',
       },
       date_added: '2024-01-15T10:00:00Z',
-      uploader_username: null as string | null,
+      authors: [],
+      tags: [],
+      uploader_username: null,
       self_url: pageBaseUrl,
       source_url: `${pageBaseUrl}/source`,
       rendered_url: `${pageBaseUrl}/rendered`,

--- a/apps/squareone/src/app/api/dev/times-square/v1/github/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/times-square/v1/github/route.dev.ts
@@ -2,10 +2,11 @@
  * Mock Times Square API endpoint: /times-square/v1/github (App Router version)
  */
 
+import type { GitHubContentsRoot } from '@lsst-sqre/times-square-client';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const content = {
+  const content: GitHubContentsRoot = {
     contents: [
       {
         node_type: 'owner',
@@ -21,6 +22,7 @@ export async function GET() {
                 node_type: 'page',
                 title: 'Demo',
                 path: 'lsst-sqre/times-square-demo/demo',
+                contents: [],
               },
               {
                 node_type: 'directory',
@@ -31,6 +33,7 @@ export async function GET() {
                     node_type: 'page',
                     title: 'Gaussian 2D',
                     path: 'lsst-sqre/times-square-demo/matplotlib/gaussian2d',
+                    contents: [],
                   },
                 ],
               },

--- a/apps/squareone/src/app/api/dev/times-square/v1/pages/[page]/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/times-square/v1/pages/[page]/route.dev.ts
@@ -2,6 +2,7 @@
  * Mock Times Square API endpoint: /times-square/v1/pages/:page (App Router version)
  */
 
+import type { Page } from '@lsst-sqre/times-square-client';
 import { NextResponse } from 'next/server';
 
 import { loadAppConfig } from '@/lib/config/loader';
@@ -24,15 +25,25 @@ export async function GET(
       return new Response(null, { status: 404 });
     }
 
-    const content = {
+    // Shape must conform to the PageSchema Zod schema in
+    // @lsst-sqre/times-square-client (packages/times-square-client/src/schemas.ts).
+    const content: Page = {
       name: page,
       title: `Title for ${page}`,
-      description: '<p>This is the description.</p>',
+      description: {
+        gfm: 'This is the description.',
+        html: '<p>This is the description.</p>',
+      },
+      date_added: '2024-01-15T10:00:00Z',
+      authors: [],
+      tags: [],
+      uploader_username: 'someuser',
       self_url: pageBaseUrl,
       source_url: `${pageBaseUrl}/source`,
       rendered_url: `${pageBaseUrl}/rendered`,
       html_url: `${pageBaseUrl}/html`,
       html_status_url: `${pageBaseUrl}/htmlstatus`,
+      html_events_url: `${pageBaseUrl}/htmlevents`,
       parameters: {
         a: {
           type: 'number',
@@ -45,6 +56,7 @@ export async function GET(
           description: 'A string.',
         },
       },
+      github: null,
     };
 
     return NextResponse.json(content);

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.test.tsx
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Tests for TimesSquareHtmlEventsProviderClient.
+ *
+ * The SSE transport is owned by @lsst-sqre/times-square-client's
+ * subscribeToHtmlEvents; these tests mock that package and verify the
+ * provider wires the subscription lifecycle and context updates.
+ */
+
+import type { HtmlEvent } from '@lsst-sqre/times-square-client';
+import {
+  subscribeToHtmlEvents,
+  useTimesSquarePage,
+} from '@lsst-sqre/times-square-client';
+import { act, render, screen } from '@testing-library/react';
+import { type ContextType, useContext } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TimesSquareUrlParametersContext } from '../TimesSquareUrlParametersProvider';
+import { TimesSquareHtmlEventsContext } from './TimesSquareHtmlEventsProvider';
+import TimesSquareHtmlEventsProviderClient from './TimesSquareHtmlEventsProviderClient';
+
+vi.mock('@lsst-sqre/times-square-client', () => ({
+  subscribeToHtmlEvents: vi.fn(() => vi.fn()),
+  useTimesSquarePage: vi.fn(() => ({ htmlEventsUrl: null })),
+}));
+
+vi.mock('../../hooks/useRepertoireUrl', () => ({
+  useRepertoireUrl: () => 'https://example.com/repertoire',
+}));
+
+const mockSubscribe = vi.mocked(subscribeToHtmlEvents);
+const mockUseTimesSquarePage = vi.mocked(useTimesSquarePage);
+
+const htmlEventsUrl =
+  'https://example.com/times-square/api/v1/pages/mypage/html/events';
+
+const completeEvent: HtmlEvent = {
+  date_submitted: '2024-01-15T10:00:00Z',
+  date_started: '2024-01-15T10:00:01Z',
+  date_finished: '2024-01-15T10:00:15Z',
+  execution_status: 'complete',
+  execution_duration: 14.2,
+  html_hash: 'abc123def456',
+  html_url: 'https://example.com/times-square/api/v1/pages/mypage/html',
+};
+
+type UrlParametersValue = NonNullable<
+  ContextType<typeof TimesSquareUrlParametersContext>
+>;
+
+function makeUrlParameters(urlQueryString = ''): UrlParametersValue {
+  return {
+    tsPageUrl: 'https://example.com/times-square/api/v1/github/owner/repo/nb',
+    displaySettings: { ts_hide_code: '1' },
+    notebookParameters: {},
+    owner: null,
+    repo: null,
+    commit: null,
+    tsSlug: ['owner', 'repo', 'nb'],
+    githubSlug: 'owner/repo/nb',
+    urlQueryString,
+  };
+}
+
+function ContextProbe() {
+  const context = useContext(TimesSquareHtmlEventsContext);
+  return (
+    <div>
+      <span data-testid="executionStatus">
+        {context?.executionStatus ?? 'null'}
+      </span>
+      <span data-testid="htmlHash">{context?.htmlHash ?? 'null'}</span>
+      <span data-testid="htmlUrl">{context?.htmlUrl ?? 'null'}</span>
+      <span data-testid="dateSubmitted">
+        {context?.dateSubmitted ?? 'null'}
+      </span>
+    </div>
+  );
+}
+
+function renderProvider(urlQueryString = '') {
+  return render(
+    <TimesSquareUrlParametersContext.Provider
+      value={makeUrlParameters(urlQueryString)}
+    >
+      <TimesSquareHtmlEventsProviderClient>
+        <ContextProbe />
+      </TimesSquareHtmlEventsProviderClient>
+    </TimesSquareUrlParametersContext.Provider>
+  );
+}
+
+describe('TimesSquareHtmlEventsProviderClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSubscribe.mockReturnValue(vi.fn());
+    mockUseTimesSquarePage.mockReturnValue({
+      htmlEventsUrl,
+      // biome-ignore lint/suspicious/noExplicitAny: only htmlEventsUrl is consumed by the provider
+    } as any);
+  });
+
+  it('subscribes to HTML events with the events URL and URL query parameters', () => {
+    renderProvider('a=1&ts_hide_code=1');
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    expect(mockSubscribe).toHaveBeenCalledWith(
+      htmlEventsUrl,
+      { a: '1', ts_hide_code: '1' },
+      expect.objectContaining({ onEvent: expect.any(Function) })
+    );
+  });
+
+  it('does not subscribe when the events URL is not available', () => {
+    mockUseTimesSquarePage.mockReturnValue({
+      htmlEventsUrl: null,
+      // biome-ignore lint/suspicious/noExplicitAny: only htmlEventsUrl is consumed by the provider
+    } as any);
+
+    renderProvider();
+
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('updates context values when an HTML event is received', () => {
+    renderProvider();
+
+    expect(screen.getByTestId('executionStatus')).toHaveTextContent('null');
+
+    const options = mockSubscribe.mock.calls[0][2];
+    act(() => {
+      options?.onEvent(completeEvent);
+    });
+
+    expect(screen.getByTestId('executionStatus')).toHaveTextContent('complete');
+    expect(screen.getByTestId('htmlHash')).toHaveTextContent('abc123def456');
+    expect(screen.getByTestId('htmlUrl')).toHaveTextContent(
+      completeEvent.html_url
+    );
+    expect(screen.getByTestId('dateSubmitted')).toHaveTextContent(
+      '2024-01-15T10:00:00Z'
+    );
+  });
+
+  it('cleans up the subscription on unmount', () => {
+    const cleanup = vi.fn();
+    mockSubscribe.mockReturnValue(cleanup);
+
+    const { unmount } = renderProvider();
+    expect(cleanup).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.tsx
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.tsx
@@ -1,9 +1,18 @@
 /*
  * Client-only TimesSquareHtmlEventsProvider component - handles SSE events on client side only.
+ *
+ * The SSE transport lives in @lsst-sqre/times-square-client's
+ * subscribeToHtmlEvents (built on @lsst-sqre/sse-client), which owns Zod
+ * validation of events, credentials, reconnection, and auto-abort on
+ * execution completion. This component only wires the subscription to the
+ * React lifecycle and exposes event fields through context.
  */
 
-import { useTimesSquarePage } from '@lsst-sqre/times-square-client';
-import { fetchEventSource } from '@microsoft/fetch-event-source';
+import {
+  type HtmlEvent,
+  subscribeToHtmlEvents,
+  useTimesSquarePage,
+} from '@lsst-sqre/times-square-client';
 import {
   type ReactNode,
   useContext,
@@ -19,16 +28,6 @@ import {
   type TimesSquareHtmlEventsContextValue,
 } from './TimesSquareHtmlEventsProvider';
 
-type HtmlEvent = {
-  date_submitted: string;
-  date_started: string;
-  date_finished: string;
-  execution_status: string;
-  execution_duration: number;
-  html_hash: string;
-  html_url: string;
-};
-
 type TimesSquareHtmlEventsProviderClientProps = {
   children: ReactNode;
 };
@@ -36,72 +35,31 @@ type TimesSquareHtmlEventsProviderClientProps = {
 export default function TimesSquareHtmlEventsProviderClient({
   children,
 }: TimesSquareHtmlEventsProviderClientProps) {
-  const [isClient, setIsClient] = useState(false);
   const [htmlEvent, setHtmlEvent] = useState<HtmlEvent | null>(null);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
 
   const repertoireUrl = useRepertoireUrl();
   const urlParameters = useContext(TimesSquareUrlParametersContext);
   const githubSlug = urlParameters?.githubSlug ?? '';
   const { htmlEventsUrl } = useTimesSquarePage(githubSlug, { repertoireUrl });
 
-  const urlQueryString = urlParameters?.urlQueryString;
-  const fullHtmlEventsUrl = htmlEventsUrl
-    ? `${htmlEventsUrl}?${urlQueryString}`
-    : null;
+  const urlQueryString = urlParameters?.urlQueryString ?? '';
 
   useEffect(() => {
-    // Don't run SSE on server side
-    if (!isClient) return () => {};
-
-    const abortController = new AbortController();
-
-    async function runEffect(): Promise<void> {
-      if (htmlEventsUrl && fullHtmlEventsUrl) {
-        await fetchEventSource(fullHtmlEventsUrl, {
-          method: 'GET',
-          signal: abortController.signal,
-          async onopen(res) {
-            if (res.status >= 400 && res.status < 500 && res.status !== 429) {
-              console.error(`Client side error ${fullHtmlEventsUrl}`, res);
-            }
-          },
-          onmessage(event) {
-            let parsedData: HtmlEvent;
-            try {
-              parsedData = JSON.parse(event.data);
-            } catch (_error) {
-              return;
-            }
-            setHtmlEvent(parsedData);
-
-            if (
-              parsedData.execution_status === 'complete' &&
-              parsedData.html_hash
-            ) {
-              abortController.abort();
-            }
-          },
-          onclose() {},
-          onerror(err) {
-            console.error(
-              `Error fetching Times Square events SSE ${fullHtmlEventsUrl}`,
-              err
-            );
-          },
-        });
-      }
+    if (!htmlEventsUrl) {
+      return undefined;
     }
-    runEffect();
 
-    return () => {
-      // Clean up: close the event source connection
-      abortController.abort();
-    };
-  }, [fullHtmlEventsUrl, htmlEventsUrl, isClient]);
+    const params = Object.fromEntries(new URLSearchParams(urlQueryString));
+    return subscribeToHtmlEvents(htmlEventsUrl, params, {
+      onEvent: setHtmlEvent,
+      onError: (error) => {
+        console.error(
+          `Error fetching Times Square events SSE ${htmlEventsUrl}`,
+          error
+        );
+      },
+    });
+  }, [htmlEventsUrl, urlQueryString]);
 
   const contextValue = useMemo(
     (): TimesSquareHtmlEventsContextValue => ({

--- a/packages/sse-client/eslint.config.mjs
+++ b/packages/sse-client/eslint.config.mjs
@@ -1,0 +1,10 @@
+import eslintConfig from '@lsst-sqre/eslint-config';
+
+export default [
+  ...eslintConfig,
+  {
+    rules: {
+      '@next/next/no-html-link-for-pages': 'off',
+    },
+  },
+];

--- a/packages/sse-client/package.json
+++ b/packages/sse-client/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@lsst-sqre/sse-client",
+  "description": "Shared Server-Sent Events (SSE) transport for Rubin Science Platform clients",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src/**"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "test": "vitest run",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint . --ext .ts,.tsx",
+    "clean": "rm -rf node_modules"
+  },
+  "dependencies": {
+    "eventsource-client": "^1.2.0"
+  },
+  "peerDependencies": {
+    "react": "^18 || ^19"
+  },
+  "devDependencies": {
+    "@lsst-sqre/eslint-config": "workspace:*",
+    "@lsst-sqre/tsconfig": "workspace:*",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.17",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/sse-client/src/index.ts
+++ b/packages/sse-client/src/index.ts
@@ -1,0 +1,6 @@
+export type { EventSourceMessage, FetchLike } from 'eventsource-client';
+export {
+  type SubscribeToEventSourceOptions,
+  subscribeToEventSource,
+} from './subscribeToEventSource';
+export { type UseEventSourceOptions, useEventSource } from './useEventSource';

--- a/packages/sse-client/src/subscribeToEventSource.test.ts
+++ b/packages/sse-client/src/subscribeToEventSource.test.ts
@@ -1,0 +1,242 @@
+import type { FetchLikeResponse } from 'eventsource-client';
+import { describe, expect, it, vi } from 'vitest';
+
+import { subscribeToEventSource } from './subscribeToEventSource';
+
+/**
+ * A single mocked SSE connection produced by `createMockSseFetch`.
+ */
+type MockSseConnection = {
+  /** The URL the connection was opened against. */
+  url: string;
+  /** The request init the client passed to fetch. */
+  init: {
+    signal?: AbortSignal;
+    headers?: Record<string, string>;
+    credentials?: 'include' | 'omit' | 'same-origin';
+  };
+  /** Enqueue raw SSE text onto the response stream. */
+  push: (text: string) => void;
+  /** Close the response stream (simulates a server disconnect). */
+  end: () => void;
+};
+
+/**
+ * Create a mocked `fetch` that returns a `ReadableStream` SSE body. The
+ * stream honors the request's `AbortSignal` by erroring with an
+ * `AbortError`, matching real fetch behavior when a request is aborted.
+ */
+function createMockSseFetch() {
+  const connections: MockSseConnection[] = [];
+  const encoder = new TextEncoder();
+
+  const fetchMock = vi.fn(
+    async (
+      url: string | URL,
+      init?: MockSseConnection['init']
+    ): Promise<FetchLikeResponse> => {
+      let controller!: ReadableStreamDefaultController<Uint8Array<ArrayBuffer>>;
+      const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
+        start(c) {
+          controller = c;
+        },
+      });
+
+      init?.signal?.addEventListener('abort', () => {
+        try {
+          controller.error(
+            new DOMException('The operation was aborted.', 'AbortError')
+          );
+        } catch {
+          // Stream already closed or errored.
+        }
+      });
+
+      connections.push({
+        url: String(url),
+        init: init ?? {},
+        push: (text: string) => controller.enqueue(encoder.encode(text)),
+        end: () => controller.close(),
+      });
+
+      return {
+        body: stream,
+        url: String(url),
+        status: 200,
+        redirected: false,
+      };
+    }
+  );
+
+  return { fetchMock, connections };
+}
+
+describe('subscribeToEventSource', () => {
+  it('delivers messages to onMessage', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+    const onMessage = vi.fn();
+
+    const cleanup = subscribeToEventSource('https://example.com/events', {
+      onMessage,
+      fetch: fetchMock,
+    });
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    connections[0].push('event: status\nid: 1\ndata: hello\n\n');
+
+    await vi.waitFor(() => expect(onMessage).toHaveBeenCalledTimes(1));
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ data: 'hello', event: 'status', id: '1' })
+    );
+
+    cleanup();
+  });
+
+  it('calls onConnect when the connection is established', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+    const onConnect = vi.fn();
+
+    const cleanup = subscribeToEventSource('https://example.com/events', {
+      onMessage: vi.fn(),
+      onConnect,
+      fetch: fetchMock,
+    });
+
+    await vi.waitFor(() => expect(onConnect).toHaveBeenCalledTimes(1));
+    expect(connections).toHaveLength(1);
+
+    cleanup();
+  });
+
+  it('calls onDisconnect and onScheduleReconnect when the server disconnects', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+    const onDisconnect = vi.fn();
+    const onScheduleReconnect = vi.fn();
+
+    const cleanup = subscribeToEventSource('https://example.com/events', {
+      onMessage: vi.fn(),
+      onDisconnect,
+      onScheduleReconnect,
+      fetch: fetchMock,
+    });
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    connections[0].end();
+
+    await vi.waitFor(() => expect(onDisconnect).toHaveBeenCalledTimes(1));
+    expect(onScheduleReconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ delay: expect.any(Number) })
+    );
+
+    cleanup();
+  });
+
+  it('closes the stream and stops reconnecting when cleaned up', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+    const onMessage = vi.fn();
+
+    const cleanup = subscribeToEventSource('https://example.com/events', {
+      onMessage,
+      fetch: fetchMock,
+    });
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    expect(connections[0].init.signal?.aborted).toBe(false);
+
+    cleanup();
+
+    // The request's abort signal fires, which closes the response stream.
+    expect(connections[0].init.signal?.aborted).toBe(true);
+
+    // No reconnection is attempted after cleanup.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('aborts the connection when the external signal aborts', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+    const abortController = new AbortController();
+
+    subscribeToEventSource('https://example.com/events', {
+      onMessage: vi.fn(),
+      signal: abortController.signal,
+      fetch: fetchMock,
+    });
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    expect(connections[0].init.signal?.aborted).toBe(false);
+
+    abortController.abort();
+
+    expect(connections[0].init.signal?.aborted).toBe(true);
+
+    // No reconnection is attempted after an external abort.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not connect when the external signal is already aborted', async () => {
+    const { fetchMock } = createMockSseFetch();
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const cleanup = subscribeToEventSource('https://example.com/events', {
+      onMessage: vi.fn(),
+      signal: abortController.signal,
+      fetch: fetchMock,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    // Cleanup is still safe to call.
+    cleanup();
+  });
+
+  it("sends credentials 'include' by default", async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+
+    const cleanup = subscribeToEventSource('https://example.com/events', {
+      onMessage: vi.fn(),
+      fetch: fetchMock,
+    });
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    expect(connections[0].init.credentials).toBe('include');
+
+    cleanup();
+  });
+
+  it('honors a credentials override', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+
+    const cleanup = subscribeToEventSource('https://example.com/events', {
+      onMessage: vi.fn(),
+      credentials: 'omit',
+      fetch: fetchMock,
+    });
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    expect(connections[0].init.credentials).toBe('omit');
+
+    cleanup();
+  });
+
+  it('passes custom headers with the request', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+
+    const cleanup = subscribeToEventSource('https://example.com/events', {
+      onMessage: vi.fn(),
+      headers: { 'X-Custom-Header': 'value' },
+      fetch: fetchMock,
+    });
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    expect(connections[0].init.headers).toEqual(
+      expect.objectContaining({ 'X-Custom-Header': 'value' })
+    );
+
+    cleanup();
+  });
+});

--- a/packages/sse-client/src/subscribeToEventSource.ts
+++ b/packages/sse-client/src/subscribeToEventSource.ts
@@ -1,0 +1,100 @@
+/**
+ * Framework-agnostic Server-Sent Events (SSE) subscription built on
+ * `eventsource-client`.
+ *
+ * This layer is a raw transport: it delivers SSE messages as strings and
+ * deliberately performs no payload parsing or validation — consumers own
+ * their schemas.
+ */
+import {
+  createEventSource,
+  type EventSourceMessage,
+  type FetchLike,
+} from 'eventsource-client';
+
+/**
+ * Options for `subscribeToEventSource`.
+ */
+export type SubscribeToEventSourceOptions = {
+  /** Called for each SSE message received (raw data string, event name, id). */
+  onMessage: (message: EventSourceMessage) => void;
+  /**
+   * Called each time the connection is established (including after
+   * reconnects).
+   */
+  onConnect?: () => void;
+  /**
+   * Called each time the connection is broken. The client will attempt to
+   * reconnect automatically unless the subscription has been cleaned up.
+   */
+  onDisconnect?: () => void;
+  /**
+   * Called each time a reconnect attempt is scheduled, with the delay in
+   * milliseconds before the attempt.
+   */
+  onScheduleReconnect?: (info: { delay: number }) => void;
+  /**
+   * External signal for aborting the subscription. When the signal aborts,
+   * the connection is closed and automatic reconnection stops. If the
+   * signal is already aborted, no connection is opened.
+   */
+  signal?: AbortSignal;
+  /** Additional request headers (e.g. authorization). */
+  headers?: Record<string, string>;
+  /**
+   * Credentials mode for the request. Defaults to `'include'` so
+   * same-origin auth cookies (e.g. Gafaelfawr) are sent.
+   */
+  credentials?: 'include' | 'omit' | 'same-origin';
+  /** Fetch implementation override. Defaults to `globalThis.fetch`. */
+  fetch?: FetchLike;
+};
+
+/**
+ * Subscribe to a Server-Sent Events endpoint.
+ *
+ * @param url - The SSE endpoint URL.
+ * @param options - Callbacks and connection options.
+ * @returns A cleanup function that closes the connection and prevents
+ *   automatic reconnection.
+ */
+export function subscribeToEventSource(
+  url: string | URL,
+  options: SubscribeToEventSourceOptions
+): () => void {
+  const {
+    onMessage,
+    onConnect,
+    onDisconnect,
+    onScheduleReconnect,
+    signal,
+    headers,
+    credentials = 'include',
+    fetch,
+  } = options;
+
+  if (signal?.aborted) {
+    return () => {};
+  }
+
+  const client = createEventSource({
+    url,
+    onMessage,
+    onConnect,
+    onDisconnect,
+    onScheduleReconnect,
+    headers,
+    credentials,
+    fetch,
+  });
+
+  const handleAbort = () => {
+    client.close();
+  };
+  signal?.addEventListener('abort', handleAbort);
+
+  return () => {
+    signal?.removeEventListener('abort', handleAbort);
+    client.close();
+  };
+}

--- a/packages/sse-client/src/useEventSource.test.tsx
+++ b/packages/sse-client/src/useEventSource.test.tsx
@@ -1,0 +1,171 @@
+import { renderHook } from '@testing-library/react';
+import type { FetchLikeResponse } from 'eventsource-client';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useEventSource } from './useEventSource';
+
+/**
+ * A single mocked SSE connection produced by `createMockSseFetch`.
+ */
+type MockSseConnection = {
+  /** The URL the connection was opened against. */
+  url: string;
+  /** The request init the client passed to fetch. */
+  init: {
+    signal?: AbortSignal;
+    headers?: Record<string, string>;
+    credentials?: 'include' | 'omit' | 'same-origin';
+  };
+  /** Enqueue raw SSE text onto the response stream. */
+  push: (text: string) => void;
+};
+
+/**
+ * Create a mocked `fetch` that returns a `ReadableStream` SSE body.
+ */
+function createMockSseFetch() {
+  const connections: MockSseConnection[] = [];
+  const encoder = new TextEncoder();
+
+  const fetchMock = vi.fn(
+    async (
+      url: string | URL,
+      init?: MockSseConnection['init']
+    ): Promise<FetchLikeResponse> => {
+      let controller!: ReadableStreamDefaultController<Uint8Array<ArrayBuffer>>;
+      const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
+        start(c) {
+          controller = c;
+        },
+      });
+
+      init?.signal?.addEventListener('abort', () => {
+        try {
+          controller.error(
+            new DOMException('The operation was aborted.', 'AbortError')
+          );
+        } catch {
+          // Stream already closed or errored.
+        }
+      });
+
+      connections.push({
+        url: String(url),
+        init: init ?? {},
+        push: (text: string) => controller.enqueue(encoder.encode(text)),
+      });
+
+      return {
+        body: stream,
+        url: String(url),
+        status: 200,
+        redirected: false,
+      };
+    }
+  );
+
+  return { fetchMock, connections };
+}
+
+describe('useEventSource', () => {
+  it('subscribes on mount and delivers messages', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+    const onMessage = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useEventSource('https://example.com/events', {
+        onMessage,
+        fetch: fetchMock,
+      })
+    );
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    expect(connections[0].url).toBe('https://example.com/events');
+
+    connections[0].push('data: hello\n\n');
+    await vi.waitFor(() => expect(onMessage).toHaveBeenCalledTimes(1));
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ data: 'hello' })
+    );
+
+    unmount();
+  });
+
+  it('closes the connection on unmount', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+
+    const { unmount } = renderHook(() =>
+      useEventSource('https://example.com/events', {
+        onMessage: vi.fn(),
+        fetch: fetchMock,
+      })
+    );
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+    expect(connections[0].init.signal?.aborted).toBe(false);
+
+    unmount();
+
+    expect(connections[0].init.signal?.aborted).toBe(true);
+  });
+
+  it('reconnects when the URL changes', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+
+    const { rerender, unmount } = renderHook(
+      ({ url }: { url: string }) =>
+        useEventSource(url, { onMessage: vi.fn(), fetch: fetchMock }),
+      { initialProps: { url: 'https://example.com/a' } }
+    );
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+
+    rerender({ url: 'https://example.com/b' });
+
+    await vi.waitFor(() => expect(connections).toHaveLength(2));
+    expect(connections[0].init.signal?.aborted).toBe(true);
+    expect(connections[1].url).toBe('https://example.com/b');
+    expect(connections[1].init.signal?.aborted).toBe(false);
+
+    unmount();
+  });
+
+  it('does not subscribe when the URL is null', async () => {
+    const { fetchMock } = createMockSseFetch();
+
+    const { unmount } = renderHook(() =>
+      useEventSource(null, { onMessage: vi.fn(), fetch: fetchMock })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it('invokes the latest onMessage callback without reconnecting', async () => {
+    const { fetchMock, connections } = createMockSseFetch();
+    const firstOnMessage = vi.fn();
+    const secondOnMessage = vi.fn();
+
+    const { rerender, unmount } = renderHook(
+      ({ onMessage }: { onMessage: (message: unknown) => void }) =>
+        useEventSource('https://example.com/events', {
+          onMessage,
+          fetch: fetchMock,
+        }),
+      { initialProps: { onMessage: firstOnMessage } }
+    );
+
+    await vi.waitFor(() => expect(connections).toHaveLength(1));
+
+    rerender({ onMessage: secondOnMessage });
+
+    connections[0].push('data: hello\n\n');
+    await vi.waitFor(() => expect(secondOnMessage).toHaveBeenCalledTimes(1));
+    expect(firstOnMessage).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+});

--- a/packages/sse-client/src/useEventSource.ts
+++ b/packages/sse-client/src/useEventSource.ts
@@ -1,0 +1,69 @@
+/**
+ * React hook wrapping `subscribeToEventSource` with effect lifecycle
+ * management.
+ */
+import { useEffect, useRef } from 'react';
+
+import {
+  type SubscribeToEventSourceOptions,
+  subscribeToEventSource,
+} from './subscribeToEventSource';
+
+/**
+ * Options for `useEventSource`. Identical to
+ * `SubscribeToEventSourceOptions`; the hook reads the latest options
+ * through a ref, so changing them does not re-establish the connection.
+ */
+export type UseEventSourceOptions = SubscribeToEventSourceOptions;
+
+/**
+ * Subscribe to a Server-Sent Events endpoint for the lifetime of the
+ * component.
+ *
+ * The connection is opened on mount and closed on unmount. Changing `url`
+ * closes the current connection and opens a new one. Pass `null` or
+ * `undefined` as the URL to disable the subscription. Option changes
+ * (including callback identity) do not reconnect — callbacks are read
+ * through a ref, so the latest ones are always invoked.
+ *
+ * @param url - The SSE endpoint URL, or `null`/`undefined` to disable.
+ * @param options - Callbacks and connection options.
+ *
+ * @example
+ * ```tsx
+ * useEventSource(notificationsUrl, {
+ *   onMessage: (message) => handleRawMessage(message.data),
+ * });
+ * ```
+ */
+export function useEventSource(
+  url: string | null | undefined,
+  options: UseEventSourceOptions
+): void {
+  const optionsRef = useRef(options);
+
+  // Keep the latest options available to the subscription without
+  // re-triggering the effect. This effect must be declared before the
+  // subscription effect so it runs first on each commit.
+  useEffect(() => {
+    optionsRef.current = options;
+  });
+
+  useEffect(() => {
+    if (url == null) {
+      return undefined;
+    }
+
+    return subscribeToEventSource(url, {
+      onMessage: (message) => optionsRef.current.onMessage(message),
+      onConnect: () => optionsRef.current.onConnect?.(),
+      onDisconnect: () => optionsRef.current.onDisconnect?.(),
+      onScheduleReconnect: (info) =>
+        optionsRef.current.onScheduleReconnect?.(info),
+      signal: optionsRef.current.signal,
+      headers: optionsRef.current.headers,
+      credentials: optionsRef.current.credentials,
+      fetch: optionsRef.current.fetch,
+    });
+  }, [url]);
+}

--- a/packages/sse-client/tsconfig.json
+++ b/packages/sse-client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@lsst-sqre/tsconfig/react-library.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"],
+    "moduleResolution": "bundler"
+  },
+  "include": ["."],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/sse-client/vitest.config.ts
+++ b/packages/sse-client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+});

--- a/packages/times-square-client/openapi.json
+++ b/packages/times-square-client/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Times Square",
     "description": "**Times Square is a Rubin Science Platform (RSP) service for displaying parameterized Jupyter Notebooks as websites.**\n\nExcellent applications for Times Square include:\n\n- Engineering dashboards\n- Quick-look data previewing\n- Reports that incorporate live data sources\n\nThe design and architecture of Times Square is described in [The Times Square service for publishing parameterized Jupyter Notebooks in the Rubin Science platform](https://sqr-062.lsst.io).\nTimes Square uses Noteburst ([GitHub](https://github.com/lsst-sqre/noteburst), [SQR-065](https://sqr-065.lsst.io)) to execute Jupyter Notebooks in Nublado (JupyterLab) instances, thereby mechanizing the RSP's notebook aspect.\n\nThis Times Square API service is developed at [https://github.com/lsst-sqre/times-square](https://github.com/lsst-sqre/times-square).\nThe user interface is developed separately at [https://github.com/lsst-sqre/times-square-ui](https://github.com/lsst-sqre/times-square-ui).\n",
-    "version": "0.23.1.dev24+g576ef1393"
+    "version": "0.24.0"
   },
   "paths": {
     "/healthcheck": {
@@ -23,11 +23,11 @@
         }
       }
     },
-    "/times-square/": {
+    "/times-square/api/": {
       "get": {
         "summary": "Application metadata",
         "description": "GET metadata about the application.",
-        "operationId": "get_index_times_square__get",
+        "operationId": "get_index_times_square_api__get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -42,11 +42,11 @@
         }
       }
     },
-    "/times-square/github/webhook": {
+    "/times-square/api/github/webhook": {
       "post": {
         "summary": "GitHub App webhook",
         "description": "This endpoint receives webhook events from GitHub",
-        "operationId": "post_github_webhook_times_square_github_webhook_post",
+        "operationId": "post_github_webhook_times_square_api_github_webhook_post",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -55,11 +55,11 @@
         }
       }
     },
-    "/times-square/v1/": {
+    "/times-square/api/v1/": {
       "get": {
         "summary": "v1 API metadata",
         "description": "Get metadata about the v1 REST API, including links to documentation and\nendpoints.",
-        "operationId": "get_index_times_square_v1__get",
+        "operationId": "get_index_times_square_api_v1__get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -74,12 +74,12 @@
         }
       }
     },
-    "/times-square/v1/pages/{page}": {
+    "/times-square/api/v1/pages/{page}": {
       "get": {
         "tags": ["Pages"],
         "summary": "Page metadata",
         "description": "Get metadata about a page resource, which models a webpage that is\nrendered from a parameterized Jupyter Notebook.",
-        "operationId": "get_page_times_square_v1_pages__page__get",
+        "operationId": "get_page_times_square_api_v1_pages__page__get",
         "parameters": [
           {
             "name": "page",
@@ -122,12 +122,12 @@
         }
       }
     },
-    "/times-square/v1/pages": {
+    "/times-square/api/v1/pages": {
       "get": {
         "tags": ["Pages"],
         "summary": "List pages",
         "description": "List available pages.",
-        "operationId": "get_pages_times_square_v1_pages_get",
+        "operationId": "get_pages_times_square_api_v1_pages_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -136,7 +136,7 @@
                 "schema": {
                   "type": "array",
                   "items": { "$ref": "#/components/schemas/PageSummary" },
-                  "title": "Response Get Pages Times Square V1 Pages Get"
+                  "title": "Response Get Pages Times Square Api V1 Pages Get"
                 }
               }
             }
@@ -147,7 +147,7 @@
         "tags": ["Pages"],
         "summary": "Create a new page",
         "description": "Register a new page with a Jinja-templated Jupyter Notebook.\n\n## Preparing the ipynb file\n\nThe `ipynb` property is a Jupyter Notebook file, either as a JSON-encoded\nstring or a parsed object. You can *parameterize* the notebook by\nadding Jinja template syntax. You can create Jinja variables that get\ntheir values from the URL query string of users viewing the notebook.\n\nFor example, a code cell:\n\n```\na = {{params.a}}\nb = {{params.b}}\na + b\n```\n\nA viewer can set these parameters by modifying URLs query string:\n\n```\n?a=4&b=2\n```\n\nTo declare these parameters, add a `times-square` field to the notebook's\nmetadata (top-level metadata, not per-cell metadata). This field should\ncontain a ``parameters`` field that contains an object keyed by parameter\nname and the value is a\n[JSON Schema](https://json-schema.org/understanding-json-schema/) object\ndescribing that parameter. For example, to declare that parameters\nmust be integers:\n\n```json\n{\n  \"times-square\": {\n    \"parameters\": {\n      \"a\": {\n        \"type\": \"integer\",\n        \"default\": 0,\n        \"description\": \"A demo value\"\n      },\n      \"b\": {\n        \"type\": \"integer\",\n        \"default\": 0,\n        \"description\": \"Another demo value\"\n      }\n    }\n  }\n}\n```\n\nThese JSON Schema parameters have special use by Times Square beyond\ndata validation:\n\n- ``default`` is used when the URL does not override a parameter value.\n- ``description`` is used for documentation.",
-        "operationId": "post_page_times_square_v1_pages_post",
+        "operationId": "post_page_times_square_api_v1_pages_post",
         "requestBody": {
           "required": true,
           "content": {
@@ -176,12 +176,12 @@
         }
       }
     },
-    "/times-square/v1/pages/{page}/source": {
+    "/times-square/api/v1/pages/{page}/source": {
       "get": {
         "tags": ["Pages"],
         "summary": "Get the source parameterized notebook (ipynb)",
         "description": "Get the content of the source ipynb file, which is unexecuted and has\nJinja templating of parameterizations.",
-        "operationId": "get_page_source_times_square_v1_pages__page__source_get",
+        "operationId": "get_page_source_times_square_api_v1_pages__page__source_get",
         "parameters": [
           {
             "name": "page",
@@ -220,12 +220,12 @@
         }
       }
     },
-    "/times-square/v1/pages/{page}/rendered": {
+    "/times-square/api/v1/pages/{page}/rendered": {
       "get": {
         "tags": ["Pages"],
         "summary": "Get the unexecuted notebook source with rendered parameters",
         "description": "Get a Jupyter Notebook by page slug, with the parameter values filled\nin. The notebook is still unexecuted.",
-        "operationId": "get_rendered_notebook_times_square_v1_pages__page__rendered_get",
+        "operationId": "get_rendered_notebook_times_square_api_v1_pages__page__rendered_get",
         "parameters": [
           {
             "name": "page",
@@ -264,12 +264,12 @@
         }
       }
     },
-    "/times-square/v1/pages/{page}/html": {
+    "/times-square/api/v1/pages/{page}/html": {
       "get": {
         "tags": ["Pages"],
         "summary": "Get the HTML page of an computed notebook",
         "description": "Get the rendered HTML of a notebook.",
-        "operationId": "get_page_html_times_square_v1_pages__page__html_get",
+        "operationId": "get_page_html_times_square_api_v1_pages__page__html_get",
         "parameters": [
           {
             "name": "page",
@@ -311,7 +311,7 @@
         "tags": ["Pages"],
         "summary": "Delete the cached HTML of a notebook.",
         "description": "Delete the cached HTML of a notebook execution, causing it to be\nrecomputed in the background.\n\nBy default, the HTML is soft-deleted so that it remains available to\nexisting clients until the new HTML replaces it in the cache. This endpoint\ntriggers a background task that recomputes the notebook and replaces the\ncached HTML.",
-        "operationId": "delete_page_html_times_square_v1_pages__page__html_delete",
+        "operationId": "delete_page_html_times_square_api_v1_pages__page__html_delete",
         "parameters": [
           {
             "name": "page",
@@ -354,11 +354,11 @@
         }
       }
     },
-    "/times-square/v1/pages/{page}/htmlstatus": {
+    "/times-square/api/v1/pages/{page}/htmlstatus": {
       "get": {
         "tags": ["Pages"],
         "summary": "Get the status of a page's HTML rendering",
-        "operationId": "get_page_html_status_times_square_v1_pages__page__htmlstatus_get",
+        "operationId": "get_page_html_status_times_square_api_v1_pages__page__htmlstatus_get",
         "parameters": [
           {
             "name": "page",
@@ -401,12 +401,12 @@
         }
       }
     },
-    "/times-square/v1/pages/{page}/html/events": {
+    "/times-square/api/v1/pages/{page}/html/events": {
       "get": {
         "tags": ["Pages"],
         "summary": "Subscribe to an event stream for a page's execution and rendering.",
         "description": "Subscribe to an event stream for a page's execution and rendering.",
-        "operationId": "get_page_html_events_times_square_v1_pages__page__html_events_get",
+        "operationId": "get_page_html_events_times_square_api_v1_pages__page__html_events_get",
         "parameters": [
           {
             "name": "page",
@@ -448,12 +448,12 @@
         }
       }
     },
-    "/times-square/v1/github": {
+    "/times-square/api/v1/github": {
       "get": {
         "tags": ["GitHub Notebooks"],
         "summary": "Get a tree of GitHub-backed pages",
         "description": "Get the tree of GitHub-backed pages.\n\nThis endpoint is primarily intended to be used by Squareone to power\nits navigational view of GitHub pages. Pages are included in the\nhierarchical structure of GitHub organization, repository, directories\n(as necessary) and finally the page itself.",
-        "operationId": "get_github_tree_times_square_v1_github_get",
+        "operationId": "get_github_tree_times_square_api_v1_github_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -466,12 +466,12 @@
         }
       }
     },
-    "/times-square/v1/github/rendered/{display_path}": {
+    "/times-square/api/v1/github/rendered/{display_path}": {
       "get": {
         "tags": ["GitHub Notebooks"],
         "summary": "Get the unexecuted notebook source with rendered parameters for a GitHub-based notebook.",
         "description": "Get a Jupyter Notebook by GitHub path, with the parameter values filled\nin. The notebook is still unexecuted.\n\nThis route provides the same functionality as ``get_rendered_notebook``,\nbut exposed at a different path so that different access controls can be\napplied upstream.",
-        "operationId": "get_github_rendered_notebook_times_square_v1_github_rendered__display_path__get",
+        "operationId": "get_github_rendered_notebook_times_square_api_v1_github_rendered__display_path__get",
         "parameters": [
           {
             "name": "display_path",
@@ -510,12 +510,12 @@
         }
       }
     },
-    "/times-square/v1/github/{display_path}": {
+    "/times-square/api/v1/github/{display_path}": {
       "get": {
         "tags": ["GitHub Notebooks"],
         "summary": "Metadata for GitHub-backed page",
         "description": "Get the metadata for a GitHub-backed page.\n\nThis endpoint provides the same data as ``GET /v1/pages/:page``, but\nis queried via the page's GitHub \"display path\" rather than the opaque\npage name.",
-        "operationId": "get_github_page_times_square_v1_github__display_path__get",
+        "operationId": "get_github_page_times_square_api_v1_github__display_path__get",
         "parameters": [
           {
             "name": "display_path",
@@ -558,12 +558,12 @@
         }
       }
     },
-    "/times-square/v1/github-pr/{owner}/{repo}/{commit}": {
+    "/times-square/api/v1/github-pr/{owner}/{repo}/{commit}": {
       "get": {
         "tags": ["Pull Requests"],
         "summary": "Get a tree of GitHub PR preview pages",
         "description": "Get the tree of GitHub-backed pages for a pull request.\n\nThis endpoint is primarily intended to be used by Squareone to power\nits navigational view of GitHub pages for a specific pull request\n(actually a commit SHA) of a repository.",
-        "operationId": "get_github_pr_tree_times_square_v1_github_pr__owner___repo___commit__get",
+        "operationId": "get_github_pr_tree_times_square_api_v1_github_pr__owner___repo___commit__get",
         "parameters": [
           {
             "name": "owner",
@@ -616,12 +616,12 @@
         }
       }
     },
-    "/times-square/v1/github-pr/{owner}/{repo}/{commit}/{path}": {
+    "/times-square/api/v1/github-pr/{owner}/{repo}/{commit}/{path}": {
       "get": {
         "tags": ["Pull Requests"],
         "summary": "Metadata for page in a pull request",
         "description": "Get the metadata for a pull request preview of a GitHub-backed page.",
-        "operationId": "get_github_pr_page_times_square_v1_github_pr__owner___repo___commit___path__get",
+        "operationId": "get_github_pr_page_times_square_api_v1_github_pr__owner___repo___commit___path__get",
         "parameters": [
           {
             "name": "owner",
@@ -1372,7 +1372,9 @@
             "title": "Location"
           },
           "msg": { "type": "string", "title": "Message" },
-          "type": { "type": "string", "title": "Error Type" }
+          "type": { "type": "string", "title": "Error Type" },
+          "input": { "title": "Input" },
+          "ctx": { "type": "object", "title": "Context" }
         },
         "type": "object",
         "required": ["loc", "msg", "type"],
@@ -1421,5 +1423,6 @@
         "description": "Metadata returned by the external root URL of the application."
       }
     }
-  }
+  },
+  "tags": [{ "name": "v1", "description": "Times Square v1 REST API" }]
 }

--- a/packages/times-square-client/package.json
+++ b/packages/times-square-client/package.json
@@ -28,7 +28,7 @@
     "fetch-openapi": "curl -o openapi.json https://times-square.lsst.io/_static/openapi.json"
   },
   "dependencies": {
-    "@microsoft/fetch-event-source": "^2.0.1",
+    "@lsst-sqre/sse-client": "workspace:*",
     "zod": "^3.24.0"
   },
   "peerDependencies": {

--- a/packages/times-square-client/src/sse.test.ts
+++ b/packages/times-square-client/src/sse.test.ts
@@ -1,0 +1,231 @@
+import { subscribeToEventSource } from '@lsst-sqre/sse-client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createHtmlEventsUrl, subscribeToHtmlEvents } from './sse';
+
+vi.mock('@lsst-sqre/sse-client', () => ({
+  subscribeToEventSource: vi.fn(() => vi.fn()),
+}));
+
+const subscribeMock = vi.mocked(subscribeToEventSource);
+
+/**
+ * Get the URL and options from the most recent subscribeToEventSource call.
+ */
+function lastSubscription() {
+  const call = subscribeMock.mock.calls.at(-1);
+  if (!call) {
+    throw new Error('subscribeToEventSource was not called');
+  }
+  return { url: call[0], options: call[1] };
+}
+
+/**
+ * Emit a raw SSE message through the captured onMessage callback.
+ */
+function emitMessage(data: string) {
+  lastSubscription().options.onMessage({ data });
+}
+
+const inProgressEvent = {
+  date_submitted: '2026-07-03T00:00:00Z',
+  date_started: '2026-07-03T00:00:01Z',
+  date_finished: null,
+  execution_status: 'in_progress',
+  execution_duration: null,
+  html_hash: null,
+  html_url: 'https://example.com/times-square/v1/pages/mypage/html',
+};
+
+beforeEach(() => {
+  subscribeMock.mockClear();
+});
+
+const completeEvent = {
+  ...inProgressEvent,
+  date_finished: '2026-07-03T00:00:42Z',
+  execution_status: 'complete',
+  execution_duration: 41.0,
+  html_hash: 'abc123',
+};
+
+describe('subscribeToHtmlEvents', () => {
+  it('delivers a valid event to onEvent', () => {
+    const onEvent = vi.fn();
+
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent,
+    });
+
+    emitMessage(JSON.stringify(inProgressEvent));
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith(inProgressEvent);
+  });
+
+  it('auto-aborts the connection and calls onComplete on a completion event', () => {
+    const onEvent = vi.fn();
+    const onComplete = vi.fn();
+
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent,
+      onComplete,
+    });
+
+    const { options } = lastSubscription();
+    expect(options.signal?.aborted).toBe(false);
+
+    emitMessage(JSON.stringify(completeEvent));
+
+    expect(onEvent).toHaveBeenCalledWith(completeEvent);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(options.signal?.aborted).toBe(true);
+  });
+
+  it('aborts the connection when the cleanup function is called', () => {
+    const cleanup = subscribeToHtmlEvents('https://example.com/events');
+
+    const { options } = lastSubscription();
+    expect(options.signal?.aborted).toBe(false);
+
+    cleanup();
+
+    expect(options.signal?.aborted).toBe(true);
+  });
+
+  it('aborts the connection when the external signal aborts', () => {
+    const externalController = new AbortController();
+
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent: vi.fn(),
+      signal: externalController.signal,
+    });
+
+    const { options } = lastSubscription();
+    expect(options.signal?.aborted).toBe(false);
+
+    externalController.abort();
+
+    expect(options.signal?.aborted).toBe(true);
+  });
+
+  it('logs scheduled reconnects through the logger', () => {
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent: vi.fn(),
+      logger,
+    });
+
+    lastSubscription().options.onScheduleReconnect?.({ delay: 2000 });
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ delay: 2000 }),
+      expect.any(String)
+    );
+  });
+
+  it('surfaces connection loss through onError', () => {
+    const onError = vi.fn();
+
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent: vi.fn(),
+      onError,
+    });
+
+    lastSubscription().options.onDisconnect?.();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('does not report connection loss after the subscription is aborted', () => {
+    const onError = vi.fn();
+
+    const cleanup = subscribeToHtmlEvents(
+      'https://example.com/events',
+      undefined,
+      {
+        onEvent: vi.fn(),
+        onError,
+      }
+    );
+
+    cleanup();
+    lastSubscription().options.onDisconnect?.();
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('appends params to the subscription URL', () => {
+    subscribeToHtmlEvents('https://example.com/events', {
+      ts_hide_code: '0',
+    });
+
+    expect(lastSubscription().url).toBe(
+      'https://example.com/events?ts_hide_code=0'
+    );
+  });
+
+  it('ignores malformed JSON messages such as heartbeats', () => {
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent,
+      onError,
+    });
+
+    emitMessage(': heartbeat');
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('rejects Zod-invalid payloads with a logger warning', () => {
+    const onEvent = vi.fn();
+    const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent,
+      logger,
+    });
+
+    emitMessage(JSON.stringify({ execution_status: 'not-a-real-status' }));
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ zodError: expect.anything() }),
+      expect.any(String)
+    );
+  });
+
+  it('does not auto-abort when autoAbortOnComplete is false', () => {
+    const onComplete = vi.fn();
+
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent: vi.fn(),
+      onComplete,
+      autoAbortOnComplete: false,
+    });
+
+    emitMessage(JSON.stringify(completeEvent));
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(lastSubscription().options.signal?.aborted).toBe(false);
+  });
+});
+
+describe('createHtmlEventsUrl', () => {
+  it('appends params to the base events URL', () => {
+    expect(
+      createHtmlEventsUrl('https://example.com/events', { a: '1', b: '2' })
+    ).toBe('https://example.com/events?a=1&b=2');
+  });
+
+  it('returns the base URL unchanged without params', () => {
+    expect(createHtmlEventsUrl('https://example.com/events')).toBe(
+      'https://example.com/events'
+    );
+  });
+});

--- a/packages/times-square-client/src/sse.ts
+++ b/packages/times-square-client/src/sse.ts
@@ -1,10 +1,12 @@
 /**
  * Server-Sent Events (SSE) handler for Times Square HTML events.
  *
- * Uses @microsoft/fetch-event-source for SSE support with features like
- * automatic reconnection and proper abort handling.
+ * Built on the shared @lsst-sqre/sse-client transport, which provides
+ * automatic reconnection with backoff (honoring server `retry:` fields)
+ * and proper abort handling. This layer owns Times Square semantics:
+ * Zod validation of HTML events and auto-abort on execution completion.
  */
-import { fetchEventSource } from '@microsoft/fetch-event-source';
+import { subscribeToEventSource } from '@lsst-sqre/sse-client';
 
 import { buildUrlWithParams } from './client';
 import type { Logger } from './query-options';
@@ -44,6 +46,8 @@ export type SubscribeOptions = {
  * Opens an SSE connection to the Times Square API and invokes callbacks
  * as events are received. The connection is automatically closed when
  * the execution completes (status === 'complete' and html_hash is present).
+ * If the connection drops before completion, the transport reconnects
+ * automatically with backoff.
  *
  * @param eventsUrl - The full URL to the html/events endpoint
  * @param params - Optional parameters to append to the URL
@@ -86,33 +90,22 @@ export function subscribeToHtmlEvents(
 
   // Link external signal to internal abort controller
   if (signal) {
-    signal.addEventListener('abort', () => abortController.abort());
+    if (signal.aborted) {
+      abortController.abort();
+    } else {
+      signal.addEventListener('abort', () => abortController.abort(), {
+        once: true,
+      });
+    }
   }
 
-  // Start the SSE connection
-  fetchEventSource(fullUrl, {
-    method: 'GET',
+  subscribeToEventSource(fullUrl, {
     signal: abortController.signal,
-    credentials: 'include',
-
-    async onopen(response) {
-      if (
-        response.status >= 400 &&
-        response.status < 500 &&
-        response.status !== 429
-      ) {
-        const error = new Error(
-          `SSE connection failed: ${response.status} ${response.statusText}`
-        );
-        onError?.(error);
-      }
-    },
-
-    onmessage(event) {
+    onMessage(message) {
       // Parse and validate the event data
       let parsedData: unknown;
       try {
-        parsedData = JSON.parse(event.data);
+        parsedData = JSON.parse(message.data);
       } catch {
         // Ignore non-JSON events (e.g., heartbeats)
         return;
@@ -143,30 +136,19 @@ export function subscribeToHtmlEvents(
       }
     },
 
-    onclose() {
-      // Connection closed normally
-    },
-
-    onerror(error) {
-      // Only report errors if we haven't aborted
+    onDisconnect() {
+      // The transport reconnects automatically; report the interruption
+      // unless the subscription was deliberately aborted.
       if (!abortController.signal.aborted) {
-        const sseError =
-          error instanceof Error
-            ? error
-            : new Error(`SSE error: ${String(error)}`);
-        onError?.(sseError);
+        onError?.(new Error('SSE connection lost'));
       }
     },
-  }).catch((error) => {
-    // Catch any unhandled errors from fetchEventSource
-    // AbortError is expected when we clean up
-    if (error instanceof Error && error.name === 'AbortError') {
-      return;
-    }
-    onError?.(error instanceof Error ? error : new Error(String(error)));
+
+    onScheduleReconnect({ delay }) {
+      log?.debug({ delay }, 'SSE reconnect scheduled');
+    },
   });
 
-  // Return cleanup function
   return () => {
     abortController.abort();
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,6 +625,37 @@ importers:
         specifier: ^4.1.0
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.12.9(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.48.0)(yaml@2.9.0))
 
+  packages/sse-client:
+    dependencies:
+      eventsource-client:
+        specifier: ^1.2.0
+        version: 1.2.0
+    devDependencies:
+      '@lsst-sqre/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@lsst-sqre/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.6(@types/node@25.2.3)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.48.0)(yaml@2.9.0))
+
   packages/times-square-client:
     dependencies:
       '@microsoft/fetch-event-source':
@@ -4456,6 +4487,14 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  eventsource-client@1.2.0:
+    resolution: {integrity: sha512-kDI75RSzO3TwyG/K9w1ap8XwqSPcwi6jaMkNulfVeZmSeUM49U8kUzk1s+vKNt0tGrXgK47i+620Yasn1ccFiw==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
 
   execa@7.2.0:
     resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
@@ -11782,7 +11821,7 @@ snapshots:
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
       eslint-plugin-react: 7.37.5(eslint@9.39.2)
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2)
@@ -11841,7 +11880,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -11881,7 +11920,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12214,6 +12253,12 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
+
+  eventsource-client@1.2.0:
+    dependencies:
+      eventsource-parser: 3.1.0
+
+  eventsource-parser@3.1.0: {}
 
   execa@7.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,9 +658,9 @@ importers:
 
   packages/times-square-client:
     dependencies:
-      '@microsoft/fetch-event-source':
-        specifier: ^2.0.1
-        version: 2.0.1
+      '@lsst-sqre/sse-client':
+        specifier: workspace:*
+        version: link:../sse-client
       zod:
         specifier: ^3.24.0
         version: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       '@lsst-sqre/times-square-client':
         specifier: workspace:*
         version: link:../../packages/times-square-client
-      '@microsoft/fetch-event-source':
-        specifier: ^2.0.1
-        version: 2.0.1
       '@sentry/nextjs':
         specifier: ^10.58.0
         version: 10.58.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.91.0))(react@19.2.7)(webpack@5.108.3(esbuild@0.28.1)(lightningcss@1.31.1))
@@ -1626,9 +1623,6 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
-
-  '@microsoft/fetch-event-source@2.0.1':
-    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
 
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
@@ -8871,8 +8865,6 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.17
       react: 19.2.7
-
-  '@microsoft/fetch-event-source@2.0.1': {}
 
   '@mswjs/interceptors@0.41.9':
     dependencies:


### PR DESCRIPTION
## Summary

- Add `@lsst-sqre/sse-client`, a new minimal workspace package wrapping `eventsource-client` as the monorepo's shared SSE transport, replacing the unmaintained `@microsoft/fetch-event-source`. It exports `subscribeToEventSource(url, options)` — raw message/connect/disconnect/reconnect callbacks, custom `headers`, `credentials` defaulting to `'include'` (Gafaelfawr same-origin cookie auth), external `AbortSignal`, `fetch` override, with a cleanup function that closes the client — and a thin `useEventSource()` React hook. No payload parsing/validation in this layer; consumers own their schemas.
- Rewrite `@lsst-sqre/times-square-client`'s SSE layer (`subscribeToHtmlEvents()`) on `subscribeToEventSource()`, preserving the public API exactly. Zod validation of `HtmlEvent`, auto-abort on execution completion, `onComplete`, and the optional structured `Logger` stay in this layer; reconnect policy follows the transport default (automatic backoff honoring server `retry:`, including after 4xx), with connection loss surfaced via `onError` and scheduled reconnects logged through the `Logger`.
- Migrate the app's `TimesSquareHtmlEventsProviderClient` to the packaged `subscribeToHtmlEvents()`, deleting its duplicated inline `fetchEventSource` logic and local `HtmlEvent` type; the app's SSE path gains Zod validation, `credentials: 'include'`, and automatic reconnection. `@microsoft/fetch-event-source` is now removed from every `package.json` in the repo. Also conforms the dev mock `github/[...tsSlug]` route to the client's `PageSchema` so the dev-mode Times Square flow works end-to-end.
- Follow the no-build-step pattern (`main`/`types` point at `src/index.ts`; consumers transpile) and register the package in `transpilePackages` in `apps/squareone/next.config.js`. Includes changesets for `@lsst-sqre/sse-client` (new), `@lsst-sqre/times-square-client`, and `squareone`.

## Validation steps

- Run `pnpm install` and confirm it succeeds with `eventsource-client` present only in `packages/sse-client`, and that `grep -r "fetch-event-source"` across the repo's `package.json` files and source returns no matches.
- Run `pnpm test --filter @lsst-sqre/sse-client --filter @lsst-sqre/times-square-client` from the repo root and confirm the SSE tests pass (transport: message delivery, connect/disconnect callbacks, cleanup, external abort; Times Square layer: valid event → `onEvent`, malformed JSON ignored, Zod-invalid payload rejected with logger warning, auto-abort + `onComplete` on completion, cleanup aborts).
- Confirm `@lsst-sqre/sse-client` is listed in `transpilePackages` in `apps/squareone/next.config.js`.
- Confirm `subscribeToHtmlEvents()` call sites in `apps/squareone` compile unchanged, and that `TimesSquareHtmlEventsProviderClient.tsx` contains no inline SSE parsing and no local `HtmlEvent` type.
- With `pnpm dev --filter squareone`, open `/times-square/github/lsst-sqre/times-square-demo/matplotlib/gaussian2d?a=1` and confirm the page receives the mock SSE event (execution stats render, e.g. "in 14.2 seconds"), context values update, and the `htmlevents` connection closes after the `complete` event (a single request in the Network tab, no reconnect loop).

## References

- Closes #525
- Closes #526
- Closes #527
- PRD: #524
- Jira: https://rubinobs.atlassian.net/browse/DM-55381