### PR TITLE
DM-55450: Migrate user notifications to /messages path

### DIFF
--- a/.changeset/notifications-mark-unread-ui.md
+++ b/.changeset/notifications-mark-unread-ui.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+Surface "Mark as unread" in the `/notifications` inbox, mirroring the existing mark-read affordances (DM-55450). Read rows now offer a per-row "Mark as unread" menu item (the mirror of "Mark as read" on unread rows), and the selection "Actions" dropdown gains a "Mark as unread" item that marks the read members of the loaded selection unread. Both route through the new `useMarkNotificationsUnread` mutation so the list and the header unread badge update without a manual refresh.

--- a/.changeset/semaphore-mark-unread-capability.md
+++ b/.changeset/semaphore-mark-unread-capability.md
@@ -1,0 +1,11 @@
+---
+'@lsst-sqre/semaphore-client': minor
+---
+
+Add a mark-unread capability mirroring the existing mark-read trio for the Semaphore 2.0 API (DM-55450).
+
+- `markNotificationsUnread(semaphoreUrl, ids, csrfToken)` POSTs `{ ids }` to `POST /v1/notifications/unread` and, like `markNotificationsRead`, is idempotent (already-unread or unknown ids are silently ignored, `204 No Content`) and resolves to `void`. Both named exports now wrap a shared private helper that differs only by the `read`/`unread` path segment; the public API remains two named exports.
+- `markNotificationsUnreadMutationOptions` and its `MarkNotificationsUnreadVariables` type perform the same `onSuccess` invalidations as mark-read (the `['user-notifications', url]` list prefix, `['unread-notification-count', url]`, and per-id `['user-notification', url, id]`).
+- `useMarkNotificationsUnread` is a thin `useMutation` wrapper, exported alongside `useMarkNotificationsRead`.
+
+Existing function signatures are unchanged.

--- a/apps/squareone/next.config.js
+++ b/apps/squareone/next.config.js
@@ -50,16 +50,16 @@ module.exports = (phase) => {
           destination: '/api/dev/semaphore/v1/broadcasts',
         },
         {
-          source: '/semaphore/v1/notifications',
-          destination: '/api/dev/semaphore/v1/notifications',
+          source: '/semaphore/v1/notifications/messages',
+          destination: '/api/dev/semaphore/v1/notifications/messages',
         },
         {
           source: '/semaphore/v1/notifications/read',
           destination: '/api/dev/semaphore/v1/notifications/read',
         },
         {
-          source: '/semaphore/v1/notifications/:id',
-          destination: '/api/dev/semaphore/v1/notifications/:id',
+          source: '/semaphore/v1/notifications/messages/:id',
+          destination: '/api/dev/semaphore/v1/notifications/messages/:id',
         },
         {
           source: '/semaphore/v1/admin/notifications',

--- a/apps/squareone/next.config.js
+++ b/apps/squareone/next.config.js
@@ -58,6 +58,10 @@ module.exports = (phase) => {
           destination: '/api/dev/semaphore/v1/notifications/read',
         },
         {
+          source: '/semaphore/v1/notifications/unread',
+          destination: '/api/dev/semaphore/v1/notifications/unread',
+        },
+        {
           source: '/semaphore/v1/notifications/messages/:id',
           destination: '/api/dev/semaphore/v1/notifications/messages/:id',
         },

--- a/apps/squareone/src/app/api/dev/semaphore/v1/notifications/messages/[id]/route.dev.test.ts
+++ b/apps/squareone/src/app/api/dev/semaphore/v1/notifications/messages/[id]/route.dev.test.ts
@@ -11,7 +11,7 @@ import {
 
 import { GET } from './route.dev';
 
-const BASE = 'http://localhost:3000/semaphore/v1/notifications';
+const BASE = 'http://localhost:3000/semaphore/v1/notifications/messages';
 
 beforeEach(() => {
   resetDevUserNotifications();
@@ -34,7 +34,7 @@ async function readDetail(
   return UserNotificationFormattedSchema.parse(data);
 }
 
-describe('GET /api/dev/semaphore/v1/notifications/[id]', () => {
+describe('GET /api/dev/semaphore/v1/notifications/messages/[id]', () => {
   it('returns the formatted notification with summary and body as FormattedText', async () => {
     const response = await getDetail('ntf-001');
 

--- a/apps/squareone/src/app/api/dev/semaphore/v1/notifications/messages/[id]/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/semaphore/v1/notifications/messages/[id]/route.dev.ts
@@ -1,7 +1,7 @@
 /**
  * Mock of the Semaphore user-facing notification detail endpoint.
- * GET /semaphore/v1/notifications/:id
- * (rewritten to /api/dev/semaphore/v1/notifications/:id)
+ * GET /semaphore/v1/notifications/messages/:id
+ * (rewritten to /api/dev/semaphore/v1/notifications/messages/:id)
  *
  * Returns a single notification from the persistent user-notifications dev
  * store, in the user-facing detail shape (`UserNotificationFormatted`: `summary`

--- a/apps/squareone/src/app/api/dev/semaphore/v1/notifications/messages/route.dev.test.ts
+++ b/apps/squareone/src/app/api/dev/semaphore/v1/notifications/messages/route.dev.test.ts
@@ -8,7 +8,7 @@ import { resetDevUserNotifications } from '@/lib/mocks/userNotificationsStore';
 
 import { GET } from './route.dev';
 
-const BASE = 'http://localhost:3000/semaphore/v1/notifications';
+const BASE = 'http://localhost:3000/semaphore/v1/notifications/messages';
 
 beforeEach(() => {
   resetDevUserNotifications();
@@ -25,7 +25,7 @@ async function readEntries(
   return data.map((entry) => UserNotificationSummarySchema.parse(entry));
 }
 
-describe('GET /api/dev/semaphore/v1/notifications', () => {
+describe('GET /api/dev/semaphore/v1/notifications/messages', () => {
   it("returns the user's notifications as FormattedText summaries", async () => {
     const response = await GET(new Request(BASE));
 

--- a/apps/squareone/src/app/api/dev/semaphore/v1/notifications/messages/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/semaphore/v1/notifications/messages/route.dev.ts
@@ -1,7 +1,7 @@
 /**
  * Mock of the Semaphore user-facing notifications list endpoint.
- * GET /semaphore/v1/notifications
- * (rewritten to /api/dev/semaphore/v1/notifications)
+ * GET /semaphore/v1/notifications/messages
+ * (rewritten to /api/dev/semaphore/v1/notifications/messages)
  *
  * Filters and cursor-paginates the in-memory dev store via the shared
  * `filterAndPaginateUserNotifications` helper, conveying the next cursor through

--- a/apps/squareone/src/app/api/dev/semaphore/v1/notifications/unread/route.dev.test.ts
+++ b/apps/squareone/src/app/api/dev/semaphore/v1/notifications/unread/route.dev.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getDevUserNotificationById,
+  resetDevUserNotifications,
+} from '@/lib/mocks/userNotificationsStore';
+
+import { POST } from './route.dev';
+
+const BASE = 'http://localhost:3000/semaphore/v1/notifications/unread';
+
+function postUnread(ids: unknown): Promise<Response> {
+  return POST(
+    new Request(BASE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids }),
+    })
+  );
+}
+
+beforeEach(() => {
+  resetDevUserNotifications();
+});
+
+afterEach(() => {
+  resetDevUserNotifications();
+});
+
+describe('POST /api/dev/semaphore/v1/notifications/unread', () => {
+  it('marks the given ids unread and returns 204', async () => {
+    // ntf-002 and ntf-005 are seeded read.
+    expect(getDevUserNotificationById('ntf-005')?.read).not.toBeNull();
+
+    const response = await postUnread(['ntf-002', 'ntf-005']);
+
+    expect(response.status).toBe(204);
+    expect(getDevUserNotificationById('ntf-002')?.read).toBeNull();
+    expect(getDevUserNotificationById('ntf-005')?.read).toBeNull();
+  });
+
+  it('is idempotent for already-unread ids', async () => {
+    // ntf-001 is a seeded unread fixture.
+    expect(getDevUserNotificationById('ntf-001')?.read).toBeNull();
+
+    const response = await postUnread(['ntf-001']);
+
+    expect(response.status).toBe(204);
+    expect(getDevUserNotificationById('ntf-001')?.read).toBeNull();
+  });
+
+  it('silently ignores unknown ids', async () => {
+    const response = await postUnread(['does-not-exist']);
+
+    expect(response.status).toBe(204);
+  });
+
+  it('rejects a payload whose ids is not an array of strings', async () => {
+    const response = await postUnread('not-an-array');
+
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects an invalid JSON body', async () => {
+    const response = await POST(
+      new Request(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'not json',
+      })
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/squareone/src/app/api/dev/semaphore/v1/notifications/unread/route.dev.ts
+++ b/apps/squareone/src/app/api/dev/semaphore/v1/notifications/unread/route.dev.ts
@@ -1,0 +1,41 @@
+/**
+ * Mock of the Semaphore user-facing mark-unread endpoint.
+ * POST /semaphore/v1/notifications/unread
+ * (rewritten to /api/dev/semaphore/v1/notifications/unread)
+ *
+ * The mirror of the mark-read route. Accepts a `{ ids: string[] }` body and
+ * marks those notifications unread in the persistent user-notifications store
+ * via `markDevUserNotificationsUnread`, mirroring the real endpoint's
+ * idempotent, silently-ignoring semantics: already-unread and unknown ids are
+ * no-ops, and a successful call responds `204 No Content`. The semaphore-client
+ * `markNotificationsUnread` POSTs exactly this shape.
+ *
+ * This file is only built into the development server (see `next.config.js`
+ * `pageExtensions`), so it never reaches the production bundle.
+ */
+
+import { NextResponse } from 'next/server';
+
+import { markDevUserNotificationsUnread } from '@/lib/mocks/userNotificationsStore';
+
+export async function POST(request: Request) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  // Validate the `{ ids: string[] }` shape the user mark-unread endpoint expects.
+  const ids = (payload as { ids?: unknown } | null)?.ids;
+  if (!Array.isArray(ids) || !ids.every((id) => typeof id === 'string')) {
+    return NextResponse.json(
+      { error: 'Invalid payload; expected { ids: string[] }' },
+      { status: 400 }
+    );
+  }
+
+  markDevUserNotificationsUnread(ids);
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/squareone/src/app/notifications/NotificationsPageClient.test.tsx
+++ b/apps/squareone/src/app/notifications/NotificationsPageClient.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@lsst-sqre/semaphore-client', async (importOriginal) => {
     useUserNotifications: vi.fn(),
     useUserNotification: vi.fn(),
     useMarkNotificationsRead: vi.fn(),
+    useMarkNotificationsUnread: vi.fn(),
     fetchUserNotifications: vi.fn(),
   };
 });
@@ -64,6 +65,9 @@ const mockUseUserNotification = vi.mocked(semaphoreClient.useUserNotification);
 const mockUseMarkNotificationsRead = vi.mocked(
   semaphoreClient.useMarkNotificationsRead
 );
+const mockUseMarkNotificationsUnread = vi.mocked(
+  semaphoreClient.useMarkNotificationsUnread
+);
 const mockFetchUserNotifications = vi.mocked(
   semaphoreClient.fetchUserNotifications
 );
@@ -81,6 +85,8 @@ const MARK_ALL_PAGE_SIZE = 100;
 
 const markReadMutate = vi.fn();
 const markReadMutateAsync = vi.fn();
+const markUnreadMutate = vi.fn();
+const markUnreadMutateAsync = vi.fn();
 
 function makeNotificationsReturn(
   overrides: Partial<semaphoreClient.UseUserNotificationsReturn> = {}
@@ -146,6 +152,13 @@ describe('NotificationsPageClient', () => {
       mutateAsync: markReadMutateAsync,
     } as unknown as ReturnType<
       typeof semaphoreClient.useMarkNotificationsRead
+    >);
+    markUnreadMutateAsync.mockResolvedValue(undefined);
+    mockUseMarkNotificationsUnread.mockReturnValue({
+      mutate: markUnreadMutate,
+      mutateAsync: markUnreadMutateAsync,
+    } as unknown as ReturnType<
+      typeof semaphoreClient.useMarkNotificationsUnread
     >);
     mockUseLoginInfo.mockReturnValue({
       csrfToken: 'csrf-token-xyz',
@@ -354,6 +367,42 @@ describe('NotificationsPageClient', () => {
       ids: ['ntf-001'],
       csrfToken: 'csrf-token-xyz',
     });
+  });
+
+  it('marks a read row unread through the mark-unread mutation', async () => {
+    const user = userEvent.setup();
+
+    render(<NotificationsPageClient />);
+
+    // ntf-002 is the first read row; its per-row menu offers "Mark as unread".
+    const menus = screen.getAllByRole('button', {
+      name: /notification actions/i,
+    });
+    await user.click(menus[1]);
+    await user.click(screen.getByRole('menuitem', { name: /mark as unread/i }));
+
+    expect(markUnreadMutate).toHaveBeenCalledWith({
+      ids: ['ntf-002'],
+      csrfToken: 'csrf-token-xyz',
+    });
+    expect(markReadMutate).not.toHaveBeenCalled();
+  });
+
+  it('does not call the mark-unread mutation without a CSRF token', async () => {
+    const user = userEvent.setup();
+    mockUseLoginInfo.mockReturnValue({
+      csrfToken: null,
+    } as unknown as ReturnType<typeof useLoginInfo>);
+
+    render(<NotificationsPageClient />);
+
+    const menus = screen.getAllByRole('button', {
+      name: /notification actions/i,
+    });
+    await user.click(menus[1]);
+    await user.click(screen.getByRole('menuitem', { name: /mark as unread/i }));
+
+    expect(markUnreadMutate).not.toHaveBeenCalled();
   });
 
   it('marks all matching read by enumerating the unread ids when selection is extended across pages', async () => {

--- a/apps/squareone/src/app/notifications/NotificationsPageClient.tsx
+++ b/apps/squareone/src/app/notifications/NotificationsPageClient.tsx
@@ -5,6 +5,7 @@ import {
   fetchUserNotifications,
   type UserNotificationSummary,
   useMarkNotificationsRead,
+  useMarkNotificationsUnread,
   useUserNotification,
   useUserNotifications,
 } from '@lsst-sqre/semaphore-client';
@@ -104,6 +105,23 @@ function NotificationsContent() {
     [semaphoreUrl, csrfToken, markRead]
   );
 
+  // The mirror of the mark-read mutation: the per-row "Mark as unread" on read
+  // rows and the bulk "Mark as unread" on the read members of a selection route
+  // through this one mutation, whose shared `onSuccess` invalidates the list,
+  // the unread count, and each affected detail — so the inbox and the header
+  // badge update without a manual refresh.
+  const { mutate: markUnread } = useMarkNotificationsUnread(semaphoreUrl ?? '');
+
+  const handleMarkUnread = useCallback(
+    (ids: string[]) => {
+      if (!semaphoreUrl || !csrfToken || ids.length === 0) {
+        return;
+      }
+      markUnread({ ids, csrfToken });
+    },
+    [semaphoreUrl, csrfToken, markUnread]
+  );
+
   // The two-tier "Select all M notifications" path has no standing query for the
   // full unread set, so it enumerates the unread ids on demand by walking the
   // cursor-paginated `?unread=true` list to exhaustion — Semaphore caps a single
@@ -190,6 +208,7 @@ function NotificationsContent() {
         renderExpandedBody={renderExpandedBody}
         permalinkBase={baseUrl}
         onMarkRead={handleMarkRead}
+        onMarkUnread={handleMarkUnread}
         onMarkAllMatchingRead={handleMarkAllMatchingRead}
       />
     </div>

--- a/apps/squareone/src/components/UserNotifications/UserNotificationsTableView.stories.tsx
+++ b/apps/squareone/src/components/UserNotifications/UserNotificationsTableView.stories.tsx
@@ -217,6 +217,67 @@ export const PerRowMenu: Story = {
 };
 
 /**
+ * Supplying `onMarkUnread` mirrors the mark-read affordances for read rows.
+ * Per-row, a read row's "…" menu offers "Mark as unread" (unread rows offer
+ * "Mark as read" instead). In the selection "Actions" dropdown, a "Mark as
+ * unread" item marks the read members of the selection unread — the mirror of
+ * "Mark as read" acting on the unread members. The container owns the mutation
+ * and the shared cache invalidation that updates the list and the header count.
+ */
+export const WithMarkUnread: Story = {
+  name: 'With mark unread',
+  args: {
+    notifications: mockUserNotifications,
+    totalCount: mockUserNotifications.length,
+    onShowUnreadOnlyChange: fn(),
+    onMarkRead: fn(),
+    onMarkUnread: fn(),
+    permalinkBase: 'https://example.test',
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const menus = canvas.getAllByRole('button', {
+      name: /notification actions/i,
+    });
+
+    // ntf-002 is read → its per-row menu offers "Mark as unread" (not read).
+    await userEvent.click(menus[1]);
+    await expect(
+      await screen.findByRole('menuitem', { name: /mark as unread/i })
+    ).toBeInTheDocument();
+    await expect(
+      screen.queryByRole('menuitem', { name: /mark as read/i })
+    ).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: /mark as unread/i })
+    );
+    await expect(args.onMarkUnread).toHaveBeenCalledWith(['ntf-002']);
+
+    // Wait for the per-row menu to fully close before opening the toolbar menu.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('menuitem', { name: /mark as unread/i })
+      ).not.toBeInTheDocument()
+    );
+
+    // Bulk: selecting all rows and choosing "Mark as unread" from Actions marks
+    // the read members (ntf-002, ntf-005) unread.
+    await userEvent.click(
+      canvas.getByRole('checkbox', { name: /select all/i })
+    );
+    await userEvent.click(canvas.getByRole('button', { name: 'Actions' }));
+    await userEvent.click(
+      await screen.findByRole('menuitem', { name: /mark as unread/i })
+    );
+    await expect(args.onMarkUnread).toHaveBeenCalledWith([
+      'ntf-002',
+      'ntf-005',
+    ]);
+  },
+};
+
+/**
  * Toggling "Show unread only" calls back to the caller, which owns the filter
  * state and re-queries.
  */

--- a/apps/squareone/src/components/UserNotifications/UserNotificationsTableView.test.tsx
+++ b/apps/squareone/src/components/UserNotifications/UserNotificationsTableView.test.tsx
@@ -315,6 +315,75 @@ describe('UserNotificationsTableView', () => {
     expect(onMarkRead).toHaveBeenCalledWith(['ntf-001', 'ntf-003']);
   });
 
+  it('offers a bulk Mark as unread that marks the read members of the selection', async () => {
+    const user = userEvent.setup();
+    const onMarkRead = vi.fn();
+    const onMarkUnread = vi.fn();
+    render(
+      <UserNotificationsTableView
+        notifications={mockUserNotifications}
+        totalCount={mockUserNotifications.length}
+        onMarkRead={onMarkRead}
+        onMarkUnread={onMarkUnread}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /select all/i }));
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(screen.getByRole('menuitem', { name: /mark as unread/i }));
+
+    // ntf-002 and ntf-005 are the only read rows, so only those are marked
+    // unread; the unread rows are left untouched.
+    expect(onMarkUnread).toHaveBeenCalledWith(['ntf-002', 'ntf-005']);
+    expect(onMarkRead).not.toHaveBeenCalled();
+  });
+
+  it('clears the selection after the bulk Mark as unread', async () => {
+    const user = userEvent.setup();
+    render(
+      <UserNotificationsTableView
+        notifications={mockUserNotifications}
+        totalCount={mockUserNotifications.length}
+        onMarkRead={vi.fn()}
+        onMarkUnread={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /select all/i }));
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(screen.getByRole('menuitem', { name: /mark as unread/i }));
+
+    expect(
+      screen.queryByRole('button', { name: 'Actions' })
+    ).not.toBeInTheDocument();
+    for (const checkbox of screen.getAllByRole('checkbox', {
+      name: /select notification/i,
+    })) {
+      expect(checkbox).not.toBeChecked();
+    }
+  });
+
+  it('omits the bulk Mark as unread item without an onMarkUnread handler', async () => {
+    const user = userEvent.setup();
+    render(
+      <UserNotificationsTableView
+        notifications={mockUserNotifications}
+        totalCount={mockUserNotifications.length}
+        onMarkRead={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('checkbox', { name: /select all/i }));
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+
+    expect(
+      screen.getByRole('menuitem', { name: /mark as read/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: /mark as unread/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('offers select-all-across-pages when every loaded row is selected and more pages exist', async () => {
     const user = userEvent.setup();
     const onMarkRead = vi.fn();
@@ -574,6 +643,71 @@ describe('UserNotificationsTableView', () => {
     expect(
       screen.getByRole('menuitem', { name: /copy link/i })
     ).toBeInTheDocument();
+  });
+
+  it('shows Mark as unread for a read row and marks it unread', async () => {
+    const user = userEvent.setup();
+    const onMarkUnread = vi.fn();
+    render(
+      <UserNotificationsTableView
+        notifications={mockUserNotifications.slice(0, 2)}
+        totalCount={2}
+        permalinkBase="https://example.test"
+        onMarkRead={vi.fn()}
+        onMarkUnread={onMarkUnread}
+      />
+    );
+
+    const menus = screen.getAllByRole('button', {
+      name: /notification actions/i,
+    });
+
+    // ntf-001 is unread → Mark as read, no Mark as unread.
+    await user.click(menus[0]);
+    expect(
+      screen.getByRole('menuitem', { name: /mark as read/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: /mark as unread/i })
+    ).not.toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    // ntf-002 is read → Mark as unread, no Mark as read.
+    const menusAgain = screen.getAllByRole('button', {
+      name: /notification actions/i,
+    });
+    await user.click(menusAgain[1]);
+    expect(
+      screen.queryByRole('menuitem', { name: /mark as read/i })
+    ).not.toBeInTheDocument();
+    const markUnread = screen.getByRole('menuitem', {
+      name: /mark as unread/i,
+    });
+    expect(markUnread).toBeInTheDocument();
+
+    await user.click(markUnread);
+    expect(onMarkUnread).toHaveBeenCalledWith(['ntf-002']);
+  });
+
+  it('hides the per-row Mark as unread item without an onMarkUnread handler', async () => {
+    const user = userEvent.setup();
+    render(
+      <UserNotificationsTableView
+        notifications={mockUserNotifications.slice(0, 2)}
+        totalCount={2}
+        onMarkRead={vi.fn()}
+      />
+    );
+
+    // ntf-002 is read, but with no onMarkUnread handler the item is absent.
+    const menus = screen.getAllByRole('button', {
+      name: /notification actions/i,
+    });
+    await user.click(menus[1]);
+    expect(
+      screen.queryByRole('menuitem', { name: /mark as unread/i })
+    ).not.toBeInTheDocument();
   });
 
   it('copies the absolute permalink when "Copy link" is chosen', async () => {

--- a/apps/squareone/src/components/UserNotifications/UserNotificationsTableView.tsx
+++ b/apps/squareone/src/components/UserNotifications/UserNotificationsTableView.tsx
@@ -73,6 +73,19 @@ export type UserNotificationsTableViewProps = {
    */
   onMarkRead?: (ids: string[]) => void;
   /**
+   * Mark a set of notifications unread.
+   *
+   * The mirror of {@link onMarkRead}. Supplying this backs each read row's
+   * per-row "Mark as unread" menu item and adds a "Mark as unread" item to the
+   * selection "Actions" dropdown that marks the read members of the selection
+   * unread. Like mark-read, the container owns the mutation and the shared cache
+   * invalidation that updates the list and the header unread count. It does not,
+   * on its own, enable the selection chrome — that is still gated on
+   * {@link onMarkRead}. When omitted, no per-row or bulk mark-unread action is
+   * shown.
+   */
+  onMarkUnread?: (ids: string[]) => void;
+  /**
    * Mark the entire filtered result set read, including pages not yet loaded.
    *
    * Backs the two-tier "Select all M notifications" extension: once every loaded
@@ -106,6 +119,8 @@ type NotificationRowProps = {
   permalinkBase: string;
   /** Mark this single notification read; enables the per-row "Mark as read". */
   onMarkRead?: (ids: string[]) => void;
+  /** Mark this single notification unread; enables the per-row "Mark as unread". */
+  onMarkUnread?: (ids: string[]) => void;
   /** Whether the leading selection checkbox is shown. */
   selectionEnabled: boolean;
 };
@@ -127,6 +142,7 @@ function NotificationRow({
   renderExpandedBody,
   permalinkBase,
   onMarkRead,
+  onMarkUnread,
   selectionEnabled,
 }: NotificationRowProps) {
   const isUnread = notification.read === null;
@@ -231,6 +247,11 @@ function NotificationRow({
               Mark as read
             </DropdownMenu.Item>
           )}
+          {!isUnread && onMarkUnread && (
+            <DropdownMenu.Item onSelect={() => onMarkUnread([notification.id])}>
+              Mark as unread
+            </DropdownMenu.Item>
+          )}
           <DropdownMenu.Item onSelect={handleCopyLink}>
             Copy link
           </DropdownMenu.Item>
@@ -276,6 +297,7 @@ export default function UserNotificationsTableView({
   renderExpandedBody,
   permalinkBase = '',
   onMarkRead,
+  onMarkUnread,
   onMarkAllMatchingRead,
 }: UserNotificationsTableViewProps) {
   const entries = notifications ?? [];
@@ -403,6 +425,22 @@ export default function UserNotificationsTableView({
     clearSelection();
   };
 
+  // Bulk mark-unread is loaded-selection-only: there is no "mark everything
+  // unread" across pages (the list API has no `read=true` filter, and it is not
+  // a real inbox action). Acting on the read members of whatever is selected
+  // among the loaded rows — via `isRowSelected` so an active "all matching"
+  // extension still covers the loaded read rows — mirrors mark-read's unread
+  // members.
+  const handleBulkMarkUnread = () => {
+    const ids = entries
+      .filter((n) => isRowSelected(n.id) && n.read !== null)
+      .map((n) => n.id);
+    if (ids.length > 0) {
+      onMarkUnread?.(ids);
+    }
+    clearSelection();
+  };
+
   let body: React.ReactNode;
   if (isLoading) {
     body = <div className={styles.loadingState}>Loading notifications…</div>;
@@ -449,6 +487,7 @@ export default function UserNotificationsTableView({
               renderExpandedBody={renderExpandedBody}
               permalinkBase={permalinkBase}
               onMarkRead={onMarkRead}
+              onMarkUnread={onMarkUnread}
               selectionEnabled={selectionEnabled}
             />
           ))}
@@ -505,6 +544,11 @@ export default function UserNotificationsTableView({
                     <DropdownMenu.Item onSelect={handleBulkMarkRead}>
                       Mark as read
                     </DropdownMenu.Item>
+                    {onMarkUnread && (
+                      <DropdownMenu.Item onSelect={handleBulkMarkUnread}>
+                        Mark as unread
+                      </DropdownMenu.Item>
+                    )}
                   </DropdownMenu.Content>
                 </DropdownMenu>
               </>

--- a/apps/squareone/src/lib/mocks/userNotificationsStore.test.ts
+++ b/apps/squareone/src/lib/mocks/userNotificationsStore.test.ts
@@ -5,6 +5,7 @@ import {
   getDevUserNotificationById,
   getDevUserNotifications,
   markDevUserNotificationsRead,
+  markDevUserNotificationsUnread,
   resetDevUserNotifications,
 } from './userNotificationsStore';
 
@@ -77,6 +78,41 @@ describe('userNotificationsStore', () => {
       resetDevUserNotifications();
 
       expect(getDevUserNotificationById('ntf-001')?.read).toBeNull();
+    });
+  });
+
+  describe('markDevUserNotificationsUnread', () => {
+    it('marks a seeded read notification unread', () => {
+      // ntf-005 is a seeded read fixture.
+      expect(getDevUserNotificationById('ntf-005')?.read).not.toBeNull();
+
+      markDevUserNotificationsUnread(['ntf-005']);
+
+      expect(getDevUserNotificationById('ntf-005')?.read).toBeNull();
+    });
+
+    it('leaves an already-unread notification untouched (idempotent)', () => {
+      // ntf-001 is a seeded unread fixture.
+      expect(getDevUserNotificationById('ntf-001')?.read).toBeNull();
+
+      markDevUserNotificationsUnread(['ntf-001']);
+
+      expect(getDevUserNotificationById('ntf-001')?.read).toBeNull();
+    });
+
+    it('ignores unknown ids without throwing', () => {
+      expect(() =>
+        markDevUserNotificationsUnread(['does-not-exist'])
+      ).not.toThrow();
+    });
+
+    it('is undone by resetDevUserNotifications', () => {
+      markDevUserNotificationsUnread(['ntf-005']);
+      expect(getDevUserNotificationById('ntf-005')?.read).toBeNull();
+
+      resetDevUserNotifications();
+
+      expect(getDevUserNotificationById('ntf-005')?.read).not.toBeNull();
     });
   });
 });

--- a/apps/squareone/src/lib/mocks/userNotificationsStore.ts
+++ b/apps/squareone/src/lib/mocks/userNotificationsStore.ts
@@ -1,7 +1,7 @@
 // In-memory dev store for the authenticated user's own notifications.
 //
 // Backs the user-facing notification dev mocks:
-//   - GET /api/dev/semaphore/v1/notifications        (the inbox list)
+//   - GET /api/dev/semaphore/v1/notifications/messages   (the inbox list)
 // and therefore the header unread badge, which the semaphore-client
 // `useUnreadNotificationCount` hook derives from that list endpoint's
 // `X-Total-Count` for an `?unread=true` query.

--- a/apps/squareone/src/lib/mocks/userNotificationsStore.ts
+++ b/apps/squareone/src/lib/mocks/userNotificationsStore.ts
@@ -1,7 +1,9 @@
 // In-memory dev store for the authenticated user's own notifications.
 //
 // Backs the user-facing notification dev mocks:
-//   - GET /api/dev/semaphore/v1/notifications/messages   (the inbox list)
+//   - GET  /api/dev/semaphore/v1/notifications/messages  (the inbox list)
+//   - POST /api/dev/semaphore/v1/notifications/read      (mark read)
+//   - POST /api/dev/semaphore/v1/notifications/unread    (mark unread)
 // and therefore the header unread badge, which the semaphore-client
 // `useUnreadNotificationCount` hook derives from that list endpoint's
 // `X-Total-Count` for an `?unread=true` query.
@@ -94,6 +96,27 @@ export function markDevUserNotificationsRead(ids: string[]): void {
   notifications = notifications.map((notification) =>
     idSet.has(notification.id) && notification.read === null
       ? { ...notification, read: readDate }
+      : notification
+  );
+}
+
+/**
+ * Mark the given notifications unread, in place.
+ *
+ * The mirror of {@link markDevUserNotificationsRead} for `POST
+ * /v1/notifications/unread`: matching notifications that are currently read get
+ * their `read` timestamp cleared to `null`; already-unread notifications stay
+ * `null`, and unknown ids are silently ignored. Because the store is
+ * persistent, this raises the unread total the header badge reads from the list
+ * endpoint.
+ *
+ * @param ids - The notification ids to mark unread
+ */
+export function markDevUserNotificationsUnread(ids: string[]): void {
+  const idSet = new Set(ids);
+  notifications = notifications.map((notification) =>
+    idSet.has(notification.id) && notification.read !== null
+      ? { ...notification, read: null }
       : notification
   );
 }

--- a/packages/semaphore-client/src/client.notifications.test.ts
+++ b/packages/semaphore-client/src/client.notifications.test.ts
@@ -6,6 +6,7 @@ import {
   fetchUserNotification,
   fetchUserNotifications,
   markNotificationsRead,
+  markNotificationsUnread,
   SemaphoreError,
 } from './client';
 
@@ -468,6 +469,53 @@ describe('markNotificationsRead', () => {
 
     await expect(
       markNotificationsRead(
+        'https://example.com/semaphore',
+        ['n1'],
+        'csrf-token-abc'
+      )
+    ).rejects.toThrow(SemaphoreError);
+  });
+});
+
+describe('markNotificationsUnread', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs { ids } to the unread path with credentials and the CSRF header, treating 204 as success', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await expect(
+      markNotificationsUnread(
+        'https://example.com/semaphore',
+        ['n1', 'n2'],
+        'csrf-token-abc'
+      )
+    ).resolves.toBeUndefined();
+
+    const [calledUrl, init] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe(
+      'https://example.com/semaphore/v1/notifications/unread'
+    );
+    expect(init?.method).toBe('POST');
+    expect(init?.credentials).toBe('include');
+
+    const headers = init?.headers as Record<string, string>;
+    expect(headers['x-csrf-token']).toBe('csrf-token-abc');
+    expect(headers['Content-Type']).toBe('application/json');
+
+    expect(JSON.parse(init?.body as string)).toEqual({ ids: ['n1', 'n2'] });
+  });
+
+  it('throws SemaphoreError on HTTP error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('Forbidden', { status: 403, statusText: 'Forbidden' })
+    );
+
+    await expect(
+      markNotificationsUnread(
         'https://example.com/semaphore',
         ['n1'],
         'csrf-token-abc'

--- a/packages/semaphore-client/src/client.notifications.test.ts
+++ b/packages/semaphore-client/src/client.notifications.test.ts
@@ -41,7 +41,7 @@ const userListPayload = [
       gfm: 'You are approaching your disk space **quota** limit',
       html: '<p>You are approaching your disk space <strong>quota</strong> limit</p>',
     },
-    url: 'https://example.com/semaphore/v1/notifications/4561-a7513',
+    url: 'https://example.com/semaphore/v1/notifications/messages/4561-a7513',
   },
 ];
 
@@ -316,7 +316,7 @@ describe('fetchUserNotifications', () => {
         status: 200,
         headers: {
           'Content-Type': 'application/json',
-          Link: '<https://example.com/semaphore/v1/notifications?cursor=1614985055_4234>; rel="next"',
+          Link: '<https://example.com/semaphore/v1/notifications/messages?cursor=1614985055_4234>; rel="next"',
           'X-Total-Count': '7',
         },
       })
@@ -352,7 +352,7 @@ describe('fetchUserNotifications', () => {
     });
 
     const calledUrl = new URL(mockFetch.mock.calls[0][0] as string);
-    expect(calledUrl.pathname).toBe('/semaphore/v1/notifications');
+    expect(calledUrl.pathname).toBe('/semaphore/v1/notifications/messages');
     expect(calledUrl.searchParams.get('unread')).toBe('true');
     expect(calledUrl.searchParams.get('limit')).toBe('25');
     expect(calledUrl.searchParams.get('cursor')).toBe('p123_4');
@@ -368,7 +368,9 @@ describe('fetchUserNotifications', () => {
     });
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
-    expect(calledUrl).toBe('https://example.com/semaphore/v1/notifications');
+    expect(calledUrl).toBe(
+      'https://example.com/semaphore/v1/notifications/messages'
+    );
   });
 
   it('sends credentials with the request', async () => {
@@ -411,7 +413,7 @@ describe('fetchUserNotification', () => {
 
     expect(result).toEqual(userDetailPayload);
     expect(mockFetch.mock.calls[0][0]).toBe(
-      'https://example.com/semaphore/v1/notifications/4561-a7513'
+      'https://example.com/semaphore/v1/notifications/messages/4561-a7513'
     );
     expect(mockFetch.mock.calls[0][1]?.credentials).toBe('include');
   });

--- a/packages/semaphore-client/src/client.ts
+++ b/packages/semaphore-client/src/client.ts
@@ -325,7 +325,7 @@ export async function createAdminNotification(
  * are only present when `limit` is set). The request is authenticated via the
  * browser's session cookie (`credentials: 'include'`).
  *
- * @endpoint GET /v1/notifications
+ * @endpoint GET /v1/notifications/messages
  *
  * @param semaphoreUrl - Base URL of the Semaphore service
  * @param params - `unread` / `limit` filters and the pagination `cursor`
@@ -344,7 +344,7 @@ export async function fetchUserNotifications(
   if (params.cursor) search.set('cursor', params.cursor);
 
   const queryString = search.toString();
-  const url = `${baseUrl}/v1/notifications${queryString ? `?${queryString}` : ''}`;
+  const url = `${baseUrl}/v1/notifications/messages${queryString ? `?${queryString}` : ''}`;
 
   const response = await fetch(url, {
     credentials: 'include',
@@ -377,7 +377,7 @@ export async function fetchUserNotifications(
  * `body` as `FormattedText`. Fetching the detail does **not** auto-mark the
  * notification read — that is an explicit action via {@link markNotificationsRead}.
  *
- * @endpoint GET /v1/notifications/{id}
+ * @endpoint GET /v1/notifications/messages/{id}
  *
  * @param semaphoreUrl - Base URL of the Semaphore service
  * @param id - Opaque notification id
@@ -389,7 +389,7 @@ export async function fetchUserNotification(
   id: string
 ): Promise<UserNotificationFormatted> {
   const baseUrl = normalizeUrl(semaphoreUrl);
-  const url = `${baseUrl}/v1/notifications/${encodeURIComponent(id)}`;
+  const url = `${baseUrl}/v1/notifications/messages/${encodeURIComponent(id)}`;
 
   const response = await fetch(url, {
     credentials: 'include',

--- a/packages/semaphore-client/src/client.ts
+++ b/packages/semaphore-client/src/client.ts
@@ -408,28 +408,30 @@ export async function fetchUserNotification(
 }
 
 /**
- * Mark a set of the authenticated user's notifications read.
+ * POST a set of notification ids to a user-facing read-state endpoint.
  *
- * POSTs `{ ids }` with `credentials: 'include'` and the Gafaelfawr
- * `x-csrf-token` header — the same mutation pattern used by
- * {@link createAdminNotification}. The endpoint is idempotent: already-read or
- * nonexistent ids are silently ignored and it responds with `204 No Content`,
- * so this function resolves to `void` on success.
- *
- * @endpoint POST /v1/notifications/read
+ * Shared implementation behind {@link markNotificationsRead} and
+ * {@link markNotificationsUnread}, which differ only by the `state` path
+ * segment (`read` vs `unread`). POSTs `{ ids }` with `credentials: 'include'`
+ * and the Gafaelfawr `x-csrf-token` header — the same mutation pattern used by
+ * {@link createAdminNotification}. Both endpoints are idempotent: already-in-
+ * state or nonexistent ids are silently ignored and the service responds with
+ * `204 No Content`, so this resolves to `void` on success.
  *
  * @param semaphoreUrl - Base URL of the Semaphore service
- * @param ids - The notification ids to mark read
+ * @param ids - The notification ids to update
  * @param csrfToken - CSRF token from Gafaelfawr login info
+ * @param state - The target read state (`read` or `unread`), used as the path segment
  * @throws SemaphoreError if the request fails
  */
-export async function markNotificationsRead(
+async function markNotifications(
   semaphoreUrl: string,
   ids: string[],
-  csrfToken: string
+  csrfToken: string,
+  state: 'read' | 'unread'
 ): Promise<void> {
   const baseUrl = normalizeUrl(semaphoreUrl);
-  const url = `${baseUrl}/v1/notifications/read`;
+  const url = `${baseUrl}/v1/notifications/${state}`;
 
   const response = await fetch(url, {
     method: 'POST',
@@ -447,4 +449,52 @@ export async function markNotificationsRead(
       response.status
     );
   }
+}
+
+/**
+ * Mark a set of the authenticated user's notifications read.
+ *
+ * POSTs `{ ids }` with `credentials: 'include'` and the Gafaelfawr
+ * `x-csrf-token` header — the same mutation pattern used by
+ * {@link createAdminNotification}. The endpoint is idempotent: already-read or
+ * nonexistent ids are silently ignored and it responds with `204 No Content`,
+ * so this function resolves to `void` on success.
+ *
+ * @endpoint POST /v1/notifications/read
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param ids - The notification ids to mark read
+ * @param csrfToken - CSRF token from Gafaelfawr login info
+ * @throws SemaphoreError if the request fails
+ */
+export function markNotificationsRead(
+  semaphoreUrl: string,
+  ids: string[],
+  csrfToken: string
+): Promise<void> {
+  return markNotifications(semaphoreUrl, ids, csrfToken, 'read');
+}
+
+/**
+ * Mark a set of the authenticated user's notifications unread.
+ *
+ * The mirror of {@link markNotificationsRead}: POSTs `{ ids }` with
+ * `credentials: 'include'` and the Gafaelfawr `x-csrf-token` header. The
+ * endpoint is idempotent — already-unread or nonexistent ids are silently
+ * ignored and it responds with `204 No Content`, so this function resolves to
+ * `void` on success.
+ *
+ * @endpoint POST /v1/notifications/unread
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param ids - The notification ids to mark unread
+ * @param csrfToken - CSRF token from Gafaelfawr login info
+ * @throws SemaphoreError if the request fails
+ */
+export function markNotificationsUnread(
+  semaphoreUrl: string,
+  ids: string[],
+  csrfToken: string
+): Promise<void> {
+  return markNotifications(semaphoreUrl, ids, csrfToken, 'unread');
 }

--- a/packages/semaphore-client/src/hooks/index.ts
+++ b/packages/semaphore-client/src/hooks/index.ts
@@ -9,6 +9,7 @@ export {
 export { useBroadcasts } from './useBroadcasts';
 export { useCreateAdminNotification } from './useCreateAdminNotification';
 export { useMarkNotificationsRead } from './useMarkNotificationsRead';
+export { useMarkNotificationsUnread } from './useMarkNotificationsUnread';
 export {
   type UseUnreadNotificationCountOptions,
   type UseUnreadNotificationCountReturn,

--- a/packages/semaphore-client/src/hooks/useMarkNotificationsUnread.test.tsx
+++ b/packages/semaphore-client/src/hooks/useMarkNotificationsUnread.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMarkNotificationsUnread } from './useMarkNotificationsUnread';
+
+const url = 'https://example.com/semaphore';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
+}
+
+describe('useMarkNotificationsUnread', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('exposes a mark-unread mutation', () => {
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useMarkNotificationsUnread(url), {
+      wrapper: Wrapper,
+    });
+
+    expect(typeof result.current.mutate).toBe('function');
+    expect(typeof result.current.mutateAsync).toBe('function');
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('POSTs { ids } to the unread path with the CSRF header and credentials', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useMarkNotificationsUnread(url), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        ids: ['n1', 'n2'],
+        csrfToken: 'csrf-token-abc',
+      });
+    });
+
+    const [calledUrl, init] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe(
+      'https://example.com/semaphore/v1/notifications/unread'
+    );
+    expect(init?.method).toBe('POST');
+    expect(init?.credentials).toBe('include');
+    expect((init?.headers as Record<string, string>)['x-csrf-token']).toBe(
+      'csrf-token-abc'
+    );
+    expect(JSON.parse(init?.body as string)).toEqual({ ids: ['n1', 'n2'] });
+  });
+
+  it('invalidates the user list, the unread count, and each detail on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 })
+    );
+    const { Wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useMarkNotificationsUnread(url), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        ids: ['n1'],
+        csrfToken: 'csrf-token-abc',
+      });
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['user-notifications', url],
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['unread-notification-count', url],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['user-notification', url, 'n1'],
+    });
+  });
+});

--- a/packages/semaphore-client/src/hooks/useMarkNotificationsUnread.ts
+++ b/packages/semaphore-client/src/hooks/useMarkNotificationsUnread.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { markNotificationsUnreadMutationOptions } from '../mutation-options';
+
+/**
+ * Mark user notifications unread via a TanStack Query mutation.
+ *
+ * The mirror of {@link useMarkNotificationsRead}. Wraps
+ * {@link markNotificationsUnreadMutationOptions}, wiring in the `QueryClient`
+ * so a successful mark-unread invalidates the user-notifications list(s), the
+ * unread count, and each affected detail query. The returned mutation's
+ * `mutate`/`mutateAsync` take `{ ids, csrfToken }`; the caller sources the CSRF
+ * token from Gafaelfawr login info.
+ *
+ * @endpoint POST /v1/notifications/unread
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ */
+export function useMarkNotificationsUnread(semaphoreUrl: string) {
+  const queryClient = useQueryClient();
+  return useMutation(
+    markNotificationsUnreadMutationOptions(semaphoreUrl, queryClient)
+  );
+}

--- a/packages/semaphore-client/src/hooks/useUnreadNotificationCount.ts
+++ b/packages/semaphore-client/src/hooks/useUnreadNotificationCount.ts
@@ -39,7 +39,7 @@ export type UseUnreadNotificationCountReturn = {
  * {@link unreadNotificationCountQueryOptions}) and, when `pollIntervalSeconds`
  * is provided, polls in the background on that cadence.
  *
- * @endpoint GET /v1/notifications?unread=true&limit=1
+ * @endpoint GET /v1/notifications/messages?unread=true&limit=1
  *
  * @param semaphoreUrl - Base URL of the Semaphore service. The query is
  *   disabled when empty.

--- a/packages/semaphore-client/src/hooks/useUserNotification.ts
+++ b/packages/semaphore-client/src/hooks/useUserNotification.ts
@@ -27,7 +27,7 @@ export type UseUserNotificationReturn = {
  * detail page can render a graceful not-found state. Fetching does not
  * auto-mark the notification read.
  *
- * @endpoint GET /v1/notifications/{id}
+ * @endpoint GET /v1/notifications/messages/{id}
  *
  * @param semaphoreUrl - Base URL of the Semaphore service. The query is
  *   disabled when empty.

--- a/packages/semaphore-client/src/hooks/useUserNotifications.test.tsx
+++ b/packages/semaphore-client/src/hooks/useUserNotifications.test.tsx
@@ -11,7 +11,7 @@ const n1 = {
   created: '2026-06-12T17:10:32+00:00',
   read: null,
   summary: { gfm: 'First', html: '<p>First</p>' },
-  url: 'https://example.com/semaphore/v1/notifications/n1',
+  url: 'https://example.com/semaphore/v1/notifications/messages/n1',
 };
 
 const n2 = {
@@ -19,7 +19,7 @@ const n2 = {
   created: '2026-06-11T17:10:32+00:00',
   read: null,
   summary: { gfm: 'Second', html: '<p>Second</p>' },
-  url: 'https://example.com/semaphore/v1/notifications/n2',
+  url: 'https://example.com/semaphore/v1/notifications/messages/n2',
 };
 
 function createWrapper() {
@@ -47,7 +47,7 @@ describe('useUserNotifications', () => {
       new Response(JSON.stringify([n1]), {
         status: 200,
         headers: {
-          Link: '<https://example.com/semaphore/v1/notifications?cursor=c2>; rel="next"',
+          Link: '<https://example.com/semaphore/v1/notifications/messages?cursor=c2>; rel="next"',
           'X-Total-Count': '2',
         },
       })
@@ -90,7 +90,7 @@ describe('useUserNotifications', () => {
         new Response(JSON.stringify([n1]), {
           status: 200,
           headers: {
-            Link: '<https://example.com/semaphore/v1/notifications?cursor=c2>; rel="next"',
+            Link: '<https://example.com/semaphore/v1/notifications/messages?cursor=c2>; rel="next"',
             'X-Total-Count': '2',
           },
         })

--- a/packages/semaphore-client/src/hooks/useUserNotifications.ts
+++ b/packages/semaphore-client/src/hooks/useUserNotifications.ts
@@ -39,7 +39,7 @@ export type UseUserNotificationsReturn = {
  * Pages are flattened into a single `entries` array, most-recent first (server
  * order); see {@link userNotificationsInfiniteQueryOptions}.
  *
- * @endpoint GET /v1/notifications
+ * @endpoint GET /v1/notifications/messages
  *
  * @param semaphoreUrl - Base URL of the Semaphore service. The query is
  *   disabled when empty.

--- a/packages/semaphore-client/src/index.ts
+++ b/packages/semaphore-client/src/index.ts
@@ -11,6 +11,7 @@ export {
   fetchUserNotifications,
   getEmptyBroadcasts,
   markNotificationsRead,
+  markNotificationsUnread,
   SemaphoreError,
 } from './client';
 // React hooks
@@ -28,6 +29,7 @@ export {
   useBroadcasts,
   useCreateAdminNotification,
   useMarkNotificationsRead,
+  useMarkNotificationsUnread,
   useUnreadNotificationCount,
   useUserNotification,
   useUserNotifications,
@@ -56,10 +58,12 @@ export {
 export type {
   CreateAdminNotificationVariables,
   MarkNotificationsReadVariables,
+  MarkNotificationsUnreadVariables,
 } from './mutation-options';
 export {
   createAdminNotificationMutationOptions,
   markNotificationsReadMutationOptions,
+  markNotificationsUnreadMutationOptions,
 } from './mutation-options';
 export type {
   BroadcastsQueryConfig,

--- a/packages/semaphore-client/src/mock-notifications.ts
+++ b/packages/semaphore-client/src/mock-notifications.ts
@@ -185,7 +185,7 @@ export function filterAndPaginateNotifications(
 // =============================================================================
 
 const MOCK_USER_URL_BASE =
-  'https://data.example.com/semaphore/v1/notifications';
+  'https://data.example.com/semaphore/v1/notifications/messages';
 
 /**
  * A realistic set of user-facing notification summaries, ordered most-recent

--- a/packages/semaphore-client/src/mutation-options.test.ts
+++ b/packages/semaphore-client/src/mutation-options.test.ts
@@ -4,7 +4,9 @@ import {
   type CreateAdminNotificationVariables,
   createAdminNotificationMutationOptions,
   type MarkNotificationsReadVariables,
+  type MarkNotificationsUnreadVariables,
   markNotificationsReadMutationOptions,
+  markNotificationsUnreadMutationOptions,
 } from './mutation-options';
 import type { UserNotificationWithUrl } from './schemas';
 
@@ -122,6 +124,67 @@ describe('markNotificationsReadMutationOptions', () => {
     const onSuccess = opts.onSuccess as (
       data: undefined,
       variables: MarkNotificationsReadVariables
+    ) => void;
+    onSuccess(undefined, variables);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['user-notifications', url],
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['unread-notification-count', url],
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['user-notification', url, 'n1'],
+    });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['user-notification', url, 'n2'],
+    });
+  });
+});
+
+describe('markNotificationsUnreadMutationOptions', () => {
+  const variables: MarkNotificationsUnreadVariables = {
+    ids: ['n1', 'n2'],
+    csrfToken: 'csrf-token-abc',
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('marks the notifications unread via markNotificationsUnread', async () => {
+    const mockFetch = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    } as unknown as QueryClient;
+
+    const opts = markNotificationsUnreadMutationOptions(url, queryClient);
+    const mutationFn = opts.mutationFn as (
+      v: MarkNotificationsUnreadVariables
+    ) => Promise<void>;
+    await mutationFn(variables);
+
+    const [calledUrl, init] = mockFetch.mock.calls[0];
+    expect(calledUrl).toBe(
+      'https://example.com/semaphore/v1/notifications/unread'
+    );
+    expect(init?.method).toBe('POST');
+    expect((init?.headers as Record<string, string>)['x-csrf-token']).toBe(
+      'csrf-token-abc'
+    );
+    expect(JSON.parse(init?.body as string)).toEqual({ ids: ['n1', 'n2'] });
+  });
+
+  it('invalidates the user list, the unread count, and each affected detail on success', () => {
+    const invalidateQueries = vi.fn();
+    const queryClient = { invalidateQueries } as unknown as QueryClient;
+
+    const opts = markNotificationsUnreadMutationOptions(url, queryClient);
+    const onSuccess = opts.onSuccess as (
+      data: undefined,
+      variables: MarkNotificationsUnreadVariables
     ) => void;
     onSuccess(undefined, variables);
 

--- a/packages/semaphore-client/src/mutation-options.ts
+++ b/packages/semaphore-client/src/mutation-options.ts
@@ -1,5 +1,9 @@
 import { mutationOptions, type QueryClient } from '@tanstack/react-query';
-import { createAdminNotification, markNotificationsRead } from './client';
+import {
+  createAdminNotification,
+  markNotificationsRead,
+  markNotificationsUnread,
+} from './client';
 import type {
   CreateUserNotification,
   UserNotificationWithUrl,
@@ -76,6 +80,54 @@ export const markNotificationsReadMutationOptions = (
     }: MarkNotificationsReadVariables): Promise<void> =>
       markNotificationsRead(semaphoreUrl, ids, csrfToken),
     onSuccess: (_data, { ids }: MarkNotificationsReadVariables) => {
+      queryClient.invalidateQueries({
+        queryKey: ['user-notifications', semaphoreUrl],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['unread-notification-count', semaphoreUrl],
+      });
+      for (const id of ids) {
+        queryClient.invalidateQueries({
+          queryKey: ['user-notification', semaphoreUrl, id],
+        });
+      }
+    },
+  });
+
+/**
+ * Variables for the mark-notifications-unread mutation.
+ */
+export type MarkNotificationsUnreadVariables = {
+  /** The notification ids to mark unread. */
+  ids: string[];
+  /** CSRF token sourced by the caller from Gafaelfawr login info. */
+  csrfToken: string;
+};
+
+/**
+ * TanStack Query mutation options for marking user notifications unread.
+ *
+ * The mirror of {@link markNotificationsReadMutationOptions}: on success it
+ * invalidates the same set of queries the change affects — the user-
+ * notifications list (the `['user-notifications', semaphoreUrl]` prefix,
+ * covering all filter variants), the unread count, and the detail query for
+ * each affected id — so the inbox, header badge, and any open detail view all
+ * reflect the new unread state.
+ *
+ * @param semaphoreUrl - Base URL of the Semaphore service
+ * @param queryClient - Query client used to invalidate affected queries on success
+ */
+export const markNotificationsUnreadMutationOptions = (
+  semaphoreUrl: string,
+  queryClient: QueryClient
+) =>
+  mutationOptions({
+    mutationFn: ({
+      ids,
+      csrfToken,
+    }: MarkNotificationsUnreadVariables): Promise<void> =>
+      markNotificationsUnread(semaphoreUrl, ids, csrfToken),
+    onSuccess: (_data, { ids }: MarkNotificationsUnreadVariables) => {
       queryClient.invalidateQueries({
         queryKey: ['user-notifications', semaphoreUrl],
       });

--- a/packages/semaphore-client/src/query-options.notifications.test.ts
+++ b/packages/semaphore-client/src/query-options.notifications.test.ts
@@ -153,7 +153,7 @@ describe('unreadNotificationCountQueryOptions', () => {
 
     expect(count).toBe(3);
     const calledUrl = new URL(mockFetch.mock.calls[0][0] as string);
-    expect(calledUrl.pathname).toBe('/semaphore/v1/notifications');
+    expect(calledUrl.pathname).toBe('/semaphore/v1/notifications/messages');
     expect(calledUrl.searchParams.get('unread')).toBe('true');
     expect(calledUrl.searchParams.get('limit')).toBe('1');
   });

--- a/packages/semaphore-client/src/schemas.notifications.test.ts
+++ b/packages/semaphore-client/src/schemas.notifications.test.ts
@@ -95,7 +95,7 @@ describe('UserNotificationSummarySchema', () => {
         gfm: 'You are approaching your disk space **quota** limit',
         html: '<p>You are approaching your disk space <strong>quota</strong> limit</p>',
       },
-      url: 'https://data.example.com/semaphore/v1/notifications/4561-a7513',
+      url: 'https://data.example.com/semaphore/v1/notifications/messages/4561-a7513',
     };
 
     const parsed = UserNotificationSummarySchema.parse(payload);
@@ -108,7 +108,7 @@ describe('UserNotificationSummarySchema', () => {
       created: '2026-06-12T17:10:32+00:00',
       read: null,
       summary: { gfm: 'Heads up', html: '<p>Heads up</p>' },
-      url: 'https://data.example.com/semaphore/v1/notifications/abc',
+      url: 'https://data.example.com/semaphore/v1/notifications/messages/abc',
     };
 
     expect(() => UserNotificationSummarySchema.parse(payload)).not.toThrow();
@@ -120,7 +120,7 @@ describe('UserNotificationSummarySchema', () => {
       created: '2026-06-12T17:10:32+00:00',
       read: null,
       summary: 'Heads up',
-      url: 'https://data.example.com/semaphore/v1/notifications/abc',
+      url: 'https://data.example.com/semaphore/v1/notifications/messages/abc',
     };
 
     expect(() => UserNotificationSummarySchema.parse(payload)).toThrow();

--- a/packages/semaphore-client/src/schemas.ts
+++ b/packages/semaphore-client/src/schemas.ts
@@ -64,7 +64,7 @@ export const UserNotificationWithUrlSchema = UserNotificationSchema.extend({
 /**
  * A user-facing notification summary from the Semaphore user API.
  *
- * Returned by the user list endpoint (`GET /v1/notifications`). Unlike the
+ * Returned by the user list endpoint (`GET /v1/notifications/messages`). Unlike the
  * admin shape (raw Markdown strings), the user endpoints return
  * {@link FormattedTextSchema} (`{ gfm, html }`) for `summary` so the client can
  * render the `gfm` field for visual consistency with the admin UI. `created`
@@ -84,7 +84,7 @@ export const UserNotificationSummarySchema = z.object({
 /**
  * A full user-facing notification from the Semaphore user API.
  *
- * Returned by the user detail endpoint (`GET /v1/notifications/{id}`). Carries
+ * Returned by the user detail endpoint (`GET /v1/notifications/messages/{id}`). Carries
  * the same fields as {@link UserNotificationSummarySchema} except it replaces
  * `url` with the formatted `body` ({@link FormattedTextSchema} or null when the
  * notification has no body). Fetching the detail does **not** auto-mark the

--- a/packages/semaphore-client/src/types.ts
+++ b/packages/semaphore-client/src/types.ts
@@ -42,7 +42,7 @@ export type AdminNotificationsPage = {
 /**
  * Filter options for the user-facing notifications list query.
  *
- * Mirrors the query parameters accepted by `GET /v1/notifications`, minus the
+ * Mirrors the query parameters accepted by `GET /v1/notifications/messages`, minus the
  * cursor, which is handled separately by the pagination layer.
  */
 export type UserNotificationFilters = {
@@ -53,7 +53,7 @@ export type UserNotificationFilters = {
 };
 
 /**
- * Parameters for a single page request against `GET /v1/notifications`.
+ * Parameters for a single page request against `GET /v1/notifications/messages`.
  *
  * Extends {@link UserNotificationFilters} with the opaque pagination cursor
  * returned as a previous page's `nextCursor`.


### PR DESCRIPTION
## Summary

- Migrate the user-facing notification list and detail endpoints to the finalized Semaphore 2.0 `/messages` paths (`/v1/notifications/messages` and `.../messages/{id}`) as a hard cutover — no old-path fallback, since squareone and Semaphore deploy together via Phalanx. `markNotificationsRead`'s `/v1/notifications/read` path is unchanged.
- Add a mark-unread capability to `@lsst-sqre/semaphore-client` mirroring the mark-read trio — a `markNotificationsUnread` client fn (`POST /v1/notifications/unread`), `markNotificationsUnreadMutationOptions` with the same cache invalidations, and a `useMarkNotificationsUnread` hook — plus the squareone dev-mock store fn and route.
- Surface "Mark as unread" in the `/notifications` inbox: a per-row menu item on read rows (mirror of "Mark as read" on unread rows) and a bulk "Mark as unread" in the selection "Actions" dropdown that acts on the read members of the loaded selection, wired through `useMarkNotificationsUnread`.

## Validation steps

- Run `pnpm dev --filter squareone` and open `/notifications`: the list loads via `/semaphore/v1/notifications/messages`, expanding a row loads its body via `.../messages/{id}`, and the old `/semaphore/v1/notifications` path 404s in dev.
- Confirm the header user-menu unread badge still reflects the unread count.
- On an unread row, use the per-row "Mark as read" and confirm the badge decrements and the row restyles. On a read row, use the per-row "Mark as unread" and confirm the badge increments and the row restyles — and, because the row is collapsed, it is not immediately re-marked read.
- With a mixed selection, open the "Actions" dropdown and confirm it offers both "Mark as read" (acts on the unread members) and "Mark as unread" (acts on the read members); each updates the affected rows and the badge.
- Confirm `POST /semaphore/v1/notifications/unread` is idempotent in the dev mock: re-marking an already-unread or unknown id is a no-op 204.

## References

- Closes #546
- Closes #547
- Closes #548
- PRD: #545
- Jira: https://rubinobs.atlassian.net/browse/DM-55450
