### PR TITLE
Migrate GitHub App token workflows from app-id to client-id

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -38,7 +38,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          client-id: ${{ vars.SQUAREONE_CI_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
 
       # Get PR information from the workflow run

--- a/.github/workflows/dependabot-changesets.yaml
+++ b/.github/workflows/dependabot-changesets.yaml
@@ -11,10 +11,13 @@ name: Add Changesets to Dependabot PRs
 # - This pattern is recommended by GitHub's official Dependabot documentation
 #
 # IMPORTANT: Dependabot Secrets Requirement
-# - GitHub App credentials (SQUAREONE_CI_GH_APP_ID, SQUAREONE_CI_GH_APP_PRIVATE_KEY)
-#   must be configured as DEPENDABOT SECRETS, not just GitHub Actions secrets
+# - The GitHub App private key (SQUAREONE_CI_GH_APP_PRIVATE_KEY) must be
+#   configured as a DEPENDABOT SECRET, not just a GitHub Actions secret
 # - GitHub isolates Dependabot workflows for security - only Dependabot secrets
 #   are accessible when Dependabot triggers pull_request events
+# - The app's client ID (SQUAREONE_CI_GH_APP_CLIENT_ID) is a non-secret
+#   repository variable; Dependabot's secret isolation does not apply to
+#   variables, so it resolves normally in this context
 # - See docs/dev/github-actions-architecture.rst for configuration instructions
 
 permissions:
@@ -35,7 +38,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          client-id: ${{ vars.SQUAREONE_CI_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.SQUAREONE_CI_GH_APP_ID }}
+          client-id: ${{ vars.SQUAREONE_CI_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.SQUAREONE_CI_GH_APP_PRIVATE_KEY }}
 
       - name: Get GitHub App User ID

--- a/docs/dev/github-actions-architecture.rst
+++ b/docs/dev/github-actions-architecture.rst
@@ -231,7 +231,7 @@ The ``release.yaml`` workflow includes several important configuration steps:
 GitHub App authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Uses the ``tibdex/github-app-token`` action to generate a GitHub token from the Squareone CI GitHub App credentials (``SQUAREONE_CI_GH_APP_ID`` and ``SQUAREONE_CI_GH_APP_PRIVATE_KEY`` secrets).
+Uses the ``actions/create-github-app-token@v3`` action to generate a GitHub token from the Squareone CI GitHub App credentials (the ``SQUAREONE_CI_GH_APP_CLIENT_ID`` variable and the ``SQUAREONE_CI_GH_APP_PRIVATE_KEY`` secret).
 This token is used instead of the default ``GITHUB_TOKEN`` because commits made with the default token don't trigger subsequent GitHub Actions workflows.
 
 GitHub Packages authentication
@@ -246,7 +246,10 @@ Git identity configuration
 Manually configures Git identity for the GitHub App bot user:
 
 - User name: ``squareone-ci[bot]``
-- Email: ``<app-id>+squareone-ci[bot]@users.noreply.github.com``
+- Email: ``<user-id>+squareone-ci[bot]@users.noreply.github.com``
+
+The ``<user-id>`` is the bot account's user ID, fetched at runtime with ``gh api "/users/squareone-ci[bot]" --jq .id``.
+This is a distinct value from the GitHub App's numeric App ID (and from its Client ID).
 
 The changesets action is configured with ``setupGitUser: false`` to use this manually configured identity instead of the action's default.
 This configuration ensures that commits made by the changesets action are properly attributed to the GitHub App bot user so that they can trigger GitHub Actions workflows.
@@ -328,7 +331,7 @@ Dependabot secrets requirement
 
 .. important::
 
-   This workflow requires GitHub App credentials to be configured as **Dependabot secrets**, not just GitHub Actions secrets.
+   This workflow requires the GitHub App private key to be configured as a **Dependabot secret**, not just a GitHub Actions secret.
 
 When Dependabot triggers a workflow via ``pull_request`` events, GitHub treats it as if it came from a repository fork for security reasons.
 This means:
@@ -338,7 +341,8 @@ This means:
 - This is by design to prevent secret leakage through malicious dependency updates
 
 The workflow uses a GitHub App (Squareone CI) to generate a token that can trigger other workflows (commits made with the default ``GITHUB_TOKEN`` don't trigger workflows).
-The app credentials must be available as Dependabot secrets.
+The app's private key must be available as a Dependabot secret.
+The app's client ID (``SQUAREONE_CI_GH_APP_CLIENT_ID``) is a non-secret repository **variable**; Dependabot's secret isolation applies only to secrets, so the variable resolves normally in the Dependabot context.
 
 Configuring Dependabot secrets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -346,19 +350,22 @@ Configuring Dependabot secrets
 Organization administrators must configure these secrets at the organization or repository level:
 
 1. Navigate to Settings → Security → Secrets and variables → Dependabot
-2. Create two Dependabot secrets with the same values as the corresponding GitHub Actions secrets:
+2. Create a Dependabot secret with the same value as the corresponding GitHub Actions secret:
 
-   - ``SQUAREONE_CI_GH_APP_ID`` (numeric app ID)
    - ``SQUAREONE_CI_GH_APP_PRIVATE_KEY`` (PEM-formatted private key)
 
 3. Set repository access to include ``squareone``
 
 .. note::
 
-   These secrets must be duplicated (exist as both Actions secrets and Dependabot secrets) because GitHub isolates Dependabot workflows for security.
-   If the credentials are rotated, both sets of secrets must be updated.
+   The private key must be duplicated (exist as both an Actions secret and a Dependabot secret) because GitHub isolates Dependabot workflows for security.
+   If the credentials are rotated, both copies must be updated.
 
-Without these Dependabot secrets configured, the workflow will fail with an error like "app_id is not set" even though the GitHub Actions secrets are properly configured.
+Without the Dependabot secret configured, the workflow will fail to generate a token even though the GitHub Actions secret is properly configured.
+
+.. note::
+
+   If the ``SQUAREONE_CI_GH_APP_CLIENT_ID`` variable ever fails to resolve in a Dependabot-triggered run, the fallback is to additionally store the client ID as a Dependabot secret with the same name and reference it via ``secrets.`` in this workflow only.
 
 For more information, see GitHub's documentation on `Automating Dependabot with GitHub Actions <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions>`__ and `Managing encrypted secrets for Dependabot <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-encrypted-secrets-for-dependabot>`__.
 
@@ -482,8 +489,9 @@ This workflow implements several security best practices aligned with the ``depe
 
 **Authentication:**
 
-- Uses default ``GITHUB_TOKEN`` which is automatically scoped to the repository
-- No additional secrets required (unlike workflows that need to trigger other workflows)
+- Generates a Squareone CI GitHub App token with ``actions/create-github-app-token@v3`` (the ``SQUAREONE_CI_GH_APP_CLIENT_ID`` variable and the ``SQUAREONE_CI_GH_APP_PRIVATE_KEY`` secret)
+- The App token is used for the ``gh`` CLI operations (changeset check, enabling auto-merge, commenting)
+- Because this workflow runs on the ``workflow_run`` trigger (default-branch context), regular GitHub Actions secrets and variables are available — no Dependabot secrets are involved
 
 Timing and workflow coordination
 ---------------------------------
@@ -755,11 +763,11 @@ GitHub Actions secrets
      - Purpose
      - Used By
    * - ``SQUAREONE_CI_GH_APP_ID``
-     - GitHub App ID for Squareone CI app (used to generate tokens that trigger workflows)
-     - release.yaml, dependabot-changesets.yaml
+     - **Deprecated.** Numeric GitHub App ID for the Squareone CI app. No longer referenced by any workflow (superseded by the ``SQUAREONE_CI_GH_APP_CLIENT_ID`` variable); kept in place as a rollback path.
+     - None (deprecated)
    * - ``SQUAREONE_CI_GH_APP_PRIVATE_KEY``
      - Private key for Squareone CI GitHub App (PEM format)
-     - release.yaml, dependabot-changesets.yaml
+     - release.yaml, dependabot-changesets.yaml, dependabot-auto-merge.yaml
    * - ``SENTRY_AUTH_TOKEN``
      - Sentry authentication token for uploading source maps
      - ci.yaml (via build-squareone.yaml), docker-release.yaml (via build-squareone.yaml)
@@ -789,6 +797,9 @@ GitHub Actions variables
    * - Variable Name
      - Purpose
      - Used By
+   * - ``SQUAREONE_CI_GH_APP_CLIENT_ID``
+     - Client ID of the Squareone CI GitHub App (non-sensitive; distinct from the numeric App ID). Used by ``actions/create-github-app-token@v3`` to generate tokens that trigger workflows.
+     - release.yaml, dependabot-changesets.yaml, dependabot-auto-merge.yaml
    * - ``TURBO_API``
      - Turborepo remote cache API endpoint URL
      - ci.yaml, build-squareone.yaml, run-chromatic.yaml
@@ -811,11 +822,14 @@ Dependabot secrets
      - Purpose
      - Used By
    * - ``SQUAREONE_CI_GH_APP_ID``
-     - GitHub App ID (same value as Actions secret)
-     - dependabot-changesets.yaml
+     - **Deprecated.** Numeric GitHub App ID (same value as the deprecated Actions secret). No longer referenced by any workflow; kept in place as a rollback path.
+     - None (deprecated)
    * - ``SQUAREONE_CI_GH_APP_PRIVATE_KEY``
      - GitHub App private key (same value as Actions secret)
      - dependabot-changesets.yaml
+
+The app's client ID is **not** duplicated as a Dependabot secret: it is read from the ``SQUAREONE_CI_GH_APP_CLIENT_ID`` repository variable, and Dependabot's secret isolation does not apply to non-secret variables.
+(If the variable ever fails to resolve in a Dependabot-triggered run, add it as a Dependabot secret and reference it via ``secrets.`` in ``dependabot-changesets.yaml`` only.)
 
 Configuration notes
 -------------------
@@ -837,9 +851,10 @@ Configuration notes
 
 1. Navigate to repository Settings → Security → Secrets and variables → Dependabot
 2. Click "New repository secret" or use organization-level secrets
-3. Add the required secrets (``SQUAREONE_CI_GH_APP_ID`` and ``SQUAREONE_CI_GH_APP_PRIVATE_KEY``)
+3. Add the required secret (``SQUAREONE_CI_GH_APP_PRIVATE_KEY``)
 4. Set repository access to include the squareone repository
 
 .. note::
 
-   When rotating the Squareone CI GitHub App credentials, both the GitHub Actions secrets AND the Dependabot secrets must be updated.
+   When rotating the Squareone CI GitHub App private key, both the GitHub Actions secret AND the Dependabot secret must be updated.
+   The client ID (``SQUAREONE_CI_GH_APP_CLIENT_ID`` variable) is stable for the lifetime of the app and does not rotate with the key.


### PR DESCRIPTION
## Summary

- Migrate the three `actions/create-github-app-token@v3` workflows (`release.yaml`, `dependabot-changesets.yaml`, `dependabot-auto-merge.yaml`) off the deprecated `app-id` input to the recommended `client-id` input, reading the value from the already-provisioned `SQUAREONE_CI_GH_APP_CLIENT_ID` repository variable. This removes the `Input 'app-id' has been deprecated` warning from every App-token run.
- Refresh the App-token documentation in `docs/dev/github-actions-architecture.rst`: correct the stale `tibdex/github-app-token` reference, document the new client-id variable, mark the `SQUAREONE_CI_GH_APP_ID` secret deprecated (kept as a rollback path), add `dependabot-auto-merge.yaml` to the secrets/variables tables, and fix the bot email note that conflated the numeric App ID with the bot user ID.

## Validation steps

- After merge, confirm the next `release.yaml` run's "Generate GitHub App Token" step succeeds with **no** `Input 'app-id' has been deprecated` warning.
- On the next Dependabot PR, confirm `dependabot-changesets.yaml` resolves the `SQUAREONE_CI_GH_APP_CLIENT_ID` variable in the Dependabot-triggered context, generates a token, and pushes a changeset. If the variable does not resolve, apply the documented fallback (duplicate the client ID as a Dependabot secret and reference it via `secrets.` in that workflow only).
- Confirm a `dependabot-auto-merge.yaml` (`workflow_run`) run generates a token successfully with no deprecation warning.

## References

- Closes #552
- PRD: #551