### PR TITLE
DM-55465: Wire up PR-aware page-metadata fetch in useTimesSquarePage

### DIFF
--- a/.changeset/pr-aware-times-square-page.md
+++ b/.changeset/pr-aware-times-square-page.md
@@ -1,0 +1,8 @@
+---
+'@lsst-sqre/times-square-client': minor
+'squareone': patch
+---
+
+Make the Times Square page-metadata fetch PR-aware so GitHub PR-preview pages load again.
+
+`useTimesSquarePage` now accepts optional `owner`, `repo`, and `commit` coordinates on its options object. When all three are provided it fetches the PR-preview endpoint (`/v1/github-pr/{owner}/{repo}/{commit}/{path}`); otherwise it keeps the existing merged-page behavior (`/v1/github/{displayPath}`). The new parameters are optional and additive, so existing callers are unaffected. The four Squareone Times Square components now forward these coordinates from `TimesSquareUrlParametersContext`, fixing the notebook viewer, parameter form, live execution status, and download/edit links on PR-preview pages.

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanelClient.tsx
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/TimesSquareGitHubPagePanelClient.tsx
@@ -30,9 +30,14 @@ export default function TimesSquareGitHubPagePanelClient() {
       'TimesSquareUrlParametersContext must be used within a provider'
     );
   }
-  const { urlQueryString, githubSlug } = context;
+  const { urlQueryString, githubSlug, owner, repo, commit } = context;
   const { title, description, renderedUrl, github, isLoading, error } =
-    useTimesSquarePage(githubSlug ?? '', { repertoireUrl });
+    useTimesSquarePage(githubSlug ?? '', {
+      repertoireUrl,
+      owner,
+      repo,
+      commit,
+    });
 
   // Show loading state until client-side hydration
   if (!isClient) {

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.tsx
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.tsx
@@ -46,7 +46,12 @@ export default function TimesSquareHtmlEventsProviderClient({
   const repertoireUrl = useRepertoireUrl();
   const urlParameters = useContext(TimesSquareUrlParametersContext);
   const githubSlug = urlParameters?.githubSlug ?? '';
-  const { htmlEventsUrl } = useTimesSquarePage(githubSlug, { repertoireUrl });
+  const { htmlEventsUrl } = useTimesSquarePage(githubSlug, {
+    repertoireUrl,
+    owner: urlParameters?.owner,
+    repo: urlParameters?.repo,
+    commit: urlParameters?.commit,
+  });
 
   const urlQueryString = urlParameters?.urlQueryString;
   const fullHtmlEventsUrl = htmlEventsUrl

--- a/apps/squareone/src/components/TimesSquareNotebookViewer/TimesSquareNotebookViewerClient.tsx
+++ b/apps/squareone/src/components/TimesSquareNotebookViewer/TimesSquareNotebookViewerClient.tsx
@@ -25,12 +25,22 @@ export default function TimesSquareNotebookViewerClient() {
       'TimesSquareUrlParametersContext must be used within a provider'
     );
   }
-  const { githubSlug, notebookParameters, displaySettings, tsPageUrl } =
-    context;
+  const {
+    githubSlug,
+    notebookParameters,
+    displaySettings,
+    tsPageUrl,
+    owner,
+    repo,
+    commit,
+  } = context;
 
   // First get page metadata to get htmlStatusUrl
   const { htmlStatusUrl } = useTimesSquarePage(githubSlug ?? '', {
     repertoireUrl,
+    owner,
+    repo,
+    commit,
   });
 
   // Combine notebook params with display settings for the status URL

--- a/apps/squareone/src/components/TimesSquareParameters/TimesSquareParametersClient.tsx
+++ b/apps/squareone/src/components/TimesSquareParameters/TimesSquareParametersClient.tsx
@@ -82,9 +82,15 @@ export default function TimesSquareParametersClient() {
     displaySettings,
     notebookParameters: userParameters,
     githubSlug,
+    owner,
+    repo,
+    commit,
   } = context;
   const { parameters } = useTimesSquarePage(githubSlug ?? '', {
     repertoireUrl,
+    owner,
+    repo,
+    commit,
   });
 
   const ajv = new Ajv({ coerceTypes: true });

--- a/packages/times-square-client/src/hooks/useTimesSquarePage.test.tsx
+++ b/packages/times-square-client/src/hooks/useTimesSquarePage.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { mockPage } from '../mock-data';
 
@@ -35,10 +35,6 @@ function requestedUrl(fetchSpy: ReturnType<typeof mockFetch>): string {
 }
 
 describe('useTimesSquarePage', () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-  });
-
   afterEach(() => {
     vi.restoreAllMocks();
   });

--- a/packages/times-square-client/src/hooks/useTimesSquarePage.test.tsx
+++ b/packages/times-square-client/src/hooks/useTimesSquarePage.test.tsx
@@ -1,0 +1,116 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mockPage } from '../mock-data';
+
+import { useTimesSquarePage } from './useTimesSquarePage';
+
+const displayPath = 'lsst-sqre/times-square-demo/weather/summit-weather';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function mockFetch() {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(mockPage), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+}
+
+function requestedUrl(fetchSpy: ReturnType<typeof mockFetch>): string {
+  const [input] = fetchSpy.mock.calls[0];
+  return typeof input === 'string' ? input : (input as URL).toString();
+}
+
+describe('useTimesSquarePage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requests the merged-page endpoint when no PR coordinates are given', async () => {
+    const fetchSpy = mockFetch();
+
+    const { result } = renderHook(() => useTimesSquarePage(displayPath), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requestedUrl(fetchSpy)).toContain(
+      `/times-square/api/v1/github/${displayPath}`
+    );
+    expect(result.current.htmlStatusUrl).toBe(mockPage.html_status_url);
+    expect(result.current.htmlEventsUrl).toBe(mockPage.html_events_url);
+    expect(result.current.renderedUrl).toBe(mockPage.rendered_url);
+    expect(result.current.parameters).toEqual(mockPage.parameters);
+    expect(result.current.github).toEqual(mockPage.github);
+  });
+
+  it('requests the PR-page endpoint when owner, repo, and commit are all provided', async () => {
+    const fetchSpy = mockFetch();
+
+    const { result } = renderHook(
+      () =>
+        useTimesSquarePage(displayPath, {
+          owner: 'lsst-sqre',
+          repo: 'times-square-demo',
+          commit: 'abc123',
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(requestedUrl(fetchSpy)).toContain(
+      `/times-square/api/v1/github-pr/lsst-sqre/times-square-demo/abc123/${displayPath}`
+    );
+    expect(result.current.htmlStatusUrl).toBe(mockPage.html_status_url);
+    expect(result.current.htmlEventsUrl).toBe(mockPage.html_events_url);
+    expect(result.current.renderedUrl).toBe(mockPage.rendered_url);
+    expect(result.current.parameters).toEqual(mockPage.parameters);
+    expect(result.current.github).toEqual(mockPage.github);
+  });
+
+  it('falls back to the merged-page endpoint when a PR coordinate is missing', async () => {
+    const fetchSpy = mockFetch();
+
+    const { result } = renderHook(
+      () =>
+        useTimesSquarePage(displayPath, {
+          owner: 'lsst-sqre',
+          repo: 'times-square-demo',
+          // commit intentionally omitted
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const url = requestedUrl(fetchSpy);
+    expect(url).toContain(`/times-square/api/v1/github/${displayPath}`);
+    expect(url).not.toContain('github-pr');
+    expect(result.current.htmlStatusUrl).toBe(mockPage.html_status_url);
+  });
+});

--- a/packages/times-square-client/src/hooks/useTimesSquarePage.ts
+++ b/packages/times-square-client/src/hooks/useTimesSquarePage.ts
@@ -6,7 +6,10 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_TIMES_SQUARE_URL } from '../client';
-import { githubPageQueryOptions } from '../query-options';
+import {
+  githubPageQueryOptions,
+  githubPrPageQueryOptions,
+} from '../query-options';
 import type { FormattedText, GitHubSourceMetadata, Page } from '../schemas';
 
 import { useTimesSquareUrl } from './useTimesSquareUrl';
@@ -17,6 +20,16 @@ import { useTimesSquareUrl } from './useTimesSquareUrl';
 export type UseTimesSquarePageOptions = {
   /** Repertoire URL for service discovery */
   repertoireUrl?: string;
+  /**
+   * GitHub owner for a PR-preview page. When `owner`, `repo`, and `commit`
+   * are all provided, the hook fetches the PR-preview endpoint instead of the
+   * merged-page endpoint.
+   */
+  owner?: string | null;
+  /** GitHub repository for a PR-preview page. */
+  repo?: string | null;
+  /** Git commit SHA for a PR-preview page. */
+  commit?: string | null;
 };
 
 /**
@@ -57,9 +70,19 @@ export type UseTimesSquarePageReturn = {
  * This hook fetches page metadata including parameters schema, URLs for
  * HTML rendering, and GitHub source information.
  *
- * @endpoint GET /times-square/v1/github/{display_path}
+ * When PR coordinates (`owner`, `repo`, `commit`) are all provided on the
+ * options object, the hook fetches the PR-preview endpoint
+ * (`GET /times-square/v1/github-pr/{owner}/{repo}/{commit}/{path}`), using
+ * `displayPath` as the repo-relative notebook `path`. Otherwise it fetches
+ * the merged-page endpoint (`GET /times-square/v1/github/{display_path}`).
+ * Both endpoints return the identical `Page` model, so the return shape is
+ * unchanged regardless of which branch is taken.
  *
- * @param displayPath - GitHub display path (e.g., 'org/repo/dir/notebook')
+ * @endpoint GET /times-square/v1/github/{display_path}
+ * @endpoint GET /times-square/v1/github-pr/{owner}/{repo}/{commit}/{path}
+ *
+ * @param displayPath - GitHub display path (e.g., 'org/repo/dir/notebook').
+ *   On PR-preview pages this doubles as the repo-relative notebook path.
  * @param options - Hook options
  *
  * @example
@@ -83,14 +106,21 @@ export function useTimesSquarePage(
   displayPath: string,
   options?: UseTimesSquarePageOptions
 ): UseTimesSquarePageReturn {
-  const { repertoireUrl } = options ?? {};
+  const { repertoireUrl, owner, repo, commit } = options ?? {};
   const timesSquareUrl = useTimesSquareUrl(repertoireUrl);
   const effectiveUrl = repertoireUrl
     ? timesSquareUrl
     : DEFAULT_TIMES_SQUARE_URL;
 
+  // When all three PR coordinates are present, fetch the PR-preview endpoint
+  // using displayPath as the repo-relative notebook path; otherwise fall back
+  // to the merged-page endpoint. Both endpoints return the same Page model.
+  const isPrPage = !!owner && !!repo && !!commit;
+
   const { data, error, isPending, isLoading, refetch } = useQuery(
-    githubPageQueryOptions(displayPath, effectiveUrl)
+    isPrPage
+      ? githubPrPageQueryOptions(owner, repo, commit, displayPath, effectiveUrl)
+      : githubPageQueryOptions(displayPath, effectiveUrl)
   );
 
   return {

--- a/packages/times-square-client/src/hooks/useTimesSquarePage.ts
+++ b/packages/times-square-client/src/hooks/useTimesSquarePage.ts
@@ -72,9 +72,10 @@ export type UseTimesSquarePageReturn = {
  *
  * When PR coordinates (`owner`, `repo`, `commit`) are all provided on the
  * options object, the hook fetches the PR-preview endpoint
- * (`GET /times-square/v1/github-pr/{owner}/{repo}/{commit}/{path}`), using
- * `displayPath` as the repo-relative notebook `path`. Otherwise it fetches
- * the merged-page endpoint (`GET /times-square/v1/github/{display_path}`).
+ * (`GET /v1/github-pr/{owner}/{repo}/{commit}/{path}` under the Times Square
+ * base URL), using `displayPath` as the repo-relative notebook `path`.
+ * Otherwise it fetches the merged-page endpoint
+ * (`GET /v1/github/{display_path}`).
  * Both endpoints return the identical `Page` model, so the return shape is
  * unchanged regardless of which branch is taken.
  *


### PR DESCRIPTION
## Summary

- Make the Times Square page-metadata fetch PR-aware so GitHub PR-preview pages load their notebook, parameter form, live execution status, and download/edit links again.
- `useTimesSquarePage` now accepts optional `owner`/`repo`/`commit` on its options object: when all three are present it fetches `/v1/github-pr/{owner}/{repo}/{commit}/{path}`, otherwise it keeps the existing merged-page `/v1/github/{displayPath}` behavior. The new parameters are optional and additive, so existing callers are unchanged.
- The four Squareone Times Square components forward those coordinates from `TimesSquareUrlParametersContext`; on merged pages the coordinates are `null` and behavior is inert.

## Validation steps

- Open a Times Square PR-preview page (`/times-square/github-pr/[owner]/[repo]/[commit]/[...tsSlug]`) and confirm the notebook HTML, parameter form, live execution status, and download/edit-on-GitHub links all render.
- Open a merged (main-branch) Times Square page (`/times-square/github/...`) and confirm it still loads exactly as before (no regression).
- In network devtools, confirm PR-preview pages request `.../v1/github-pr/{owner}/{repo}/{commit}/{path}` and merged pages request `.../v1/github/{displayPath}` — the malformed `.../v1/github/{repo-relative-path}` 404s no longer appear.

## References

- Closes #585
- PRD: #584
- Jira: https://rubinobs.atlassian.net/browse/DM-55465