### PR TITLE
DM-53296: Add accessible-teal foundation tokens (primary-650)

### DIFF
--- a/.changeset/danger-notice-contrast.md
+++ b/.changeset/danger-notice-contrast.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/squared': patch
+---
+
+Move the danger/notice colors onto darker ramp steps so their white and colored text clears the WCAG 4.5:1 contrast bar. Button danger variants now use `red-600` (`#ad1919`, 7.17:1 on white) instead of `red-500` (`#ed4c4c`, 3.66:1), with hover/active darkening to `red-700`/`red-800`. The Button solid-primary hover now darkens to `primary-700` (white text 10.07:1) rather than brightening to `primary-400` (which dropped white text to 2.40:1). The outage broadcast banner moves to `red-600` and the notice banner to `orange-600` (`#8f4d0a`, 6.49:1); the BroadcastBanner link-hover `#dddddd` dim is removed so links stay white and above 4.5:1 on the banner background.

--- a/.changeset/dark-theme-input-and-link-hover.md
+++ b/.changeset/dark-theme-input-and-link-hover.md
@@ -1,0 +1,6 @@
+---
+'@lsst-sqre/rubin-style-dictionary': patch
+'squareone': patch
+---
+
+Fix dark-theme input border and link-hover contrast for accessibility. The dark `link-hover-color` re-used the light-theme resting link color (`#146685`), which measures only 2.52:1 on the dark page (gray-800 `#1F2121`) and is *darker* than the resting dark link (blue-300 `#7BCFE8`, 9.19:1) — the wrong direction for a hover affordance. It now retargets to blue-200 (`#B8E3F2`, 11.80:1 on the dark page), lighter than the resting link and well above 4.5:1. The Times Square parameter text input (`StringInput`) border moves from fixed `gray-500` (`#6A6E6E`, a marginal 3.13:1 on the dark page) to `gray-400` (`#82898B`, 4.55:1 on dark and 3.56:1 on white), matching the sibling squared form controls and clearing the 3:1 non-text bar in both themes. Dark-theme placeholder text was already migrated to the adaptive `--rsd-component-text-secondary-color` token (gray-300, 6.45:1 on the dark page).

--- a/.changeset/form-control-borders-and-token-refs.md
+++ b/.changeset/form-control-borders-and-token-refs.md
@@ -1,0 +1,6 @@
+---
+'@lsst-sqre/squared': patch
+'squareone': patch
+---
+
+Fix form-control contrast and broken CSS token references for accessibility. Input, textarea, and select borders move from `gray-100` (`#DCE0E3`, 1.33:1 on a white page — a WCAG 1.4.11 non-text contrast failure) to `gray-400` (`#82898B`, 3.56:1). The error/success text in `TextInput`, `TextArea`, and `Select` referenced non-existent ramp steps (`--rsd-color-red-900` / `--rsd-color-green-900`), which silently resolved to nothing; those now point at the real `red-600` (`#AD1919`, 7.17:1) and `green-600` (`#237028`, 6.14:1) text steps. The wrong-hue blue fallback hexes (`#0066cc`, `#e6f3ff`, `#f0f9ff`, `#bfdbfe`) in the SidebarLayout CSS modules are corrected to the teal `primary` ramp values that back the tokens they fall back from.

--- a/.changeset/hero-scrim-contrast.md
+++ b/.changeset/hero-scrim-contrast.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+Add a scrim overlay to `FullBleedBackgroundImageSection` so white hero text meets WCAG 1.4.3 contrast over the background photo. The brightest region of the homepage hero image (`Quint-DSC1187.jpg`, ~`rgb(207, 206, 214)`) previously left white text at only ~1.6:1. A 50% black scrim (exposed as the `--scrim-color`/`--scrim-opacity` custom properties, defaulting to `#000000` at `0.5`) composites that worst-case region to ~`rgb(104, 103, 107)`, lifting white text to ~5.6:1. Content now renders in a stacking layer above the scrim so the darkening never falls on the hero text.

--- a/.changeset/inline-link-underlines.md
+++ b/.changeset/inline-link-underlines.md
@@ -1,0 +1,7 @@
+---
+'@lsst-sqre/rubin-style-dictionary': patch
+'@lsst-sqre/global-css': patch
+'squareone': patch
+---
+
+Underline links within text blocks and darken the link-hover color for WCAG contrast and identifiability. Links inside running prose (paragraphs, list items, definitions, block quotes rendered in `MainContent`) and all footer links are now underlined so they are distinguishable from surrounding body text by more than color alone (WCAG 1.4.1; resolves the axe `link-in-text-block` failure on prose pages). Nav, menu, card-as-link, and standalone call-to-action links remain underline-free. The light-theme link-hover color (`--rsd-component-text-link-hover-color`) retargets from `blue-500` (`#1c81a4`, 4.44:1 on white — failing) to `blue-600` (`#145f7a`, 7.12:1), clearing the 4.5:1 bar.

--- a/.changeset/migrate-teal-text-consumers.md
+++ b/.changeset/migrate-teal-text-consumers.md
@@ -1,0 +1,7 @@
+---
+'@lsst-sqre/rubin-style-dictionary': patch
+'@lsst-sqre/global-css': patch
+'@lsst-sqre/squared': patch
+---
+
+Migrate teal text and interactive foregrounds onto the accessible-teal semantic token so they clear the WCAG 4.5:1 contrast bar. The failing consumers now reference `--rsd-component-interactive-color` (accessible teal, `primary-650`) instead of the raw brand `primary-600` (4.14:1 on white): Button `solid`/`text`/`outline` primary variants, Badge solid/soft/outline primary, the selected Tabs label, the Select selected-option indicator, the DataTable active-sort indicator, the header dropdown `menulist-selected-background-color` (light theme), the `--sqo-primary-button-background-color` fill behind IconPill, and the BroadcastBanner info category. `primary-600` is retained for non-text accents (focus rings, borders, checked-state fills, the sidebar selected-state left bar) where the 3:1 non-text bar applies and its value is unchanged.

--- a/.changeset/primary-650-accessible-teal.md
+++ b/.changeset/primary-650-accessible-teal.md
@@ -1,0 +1,5 @@
+---
+'@lsst-sqre/rubin-style-dictionary': minor
+---
+
+Add accessible-teal foundation tokens for the color-contrast work. A new `primary-650` palette step (`#046F70`, 5.98:1 on white) is added between `primary-600` and `primary-700` for text and interactive foregrounds that need to clear the WCAG 4.5:1 bar — `primary-600` (`#058B8C`, the official brand color) is unchanged and remains for non-text accents such as focus rings, borders, and checked-state fills. A new semantic `component.interactive.color` token (`--rsd-component-interactive-color`) resolves to `primary-650` in the light theme (and `primary-400` in dark) so components can migrate off raw `primary-600` references. The headline token (`--rsd-component-text-headline-color`) now points at the body text color (gray-800, `#1F2121`) instead of brand teal, so h1/h2 render black while the teal identity stays in interactive elements and accents.

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.module.css
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.module.css
@@ -61,6 +61,8 @@
   text-decoration: underline;
 }
 
+/* Links stay white on hover: dimming to #dddddd dropped white-on-banner
+ * contrast below 4.5:1. The underline already distinguishes links. */
 .container a:hover {
-  color: #dddddd;
+  color: white;
 }

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.test.tsx
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.test.tsx
@@ -1,6 +1,6 @@
 import type { Broadcast } from '@lsst-sqre/semaphore-client';
 import { render, screen } from '@testing-library/react';
-import { expect, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { axe } from 'vitest-axe';
 import BroadcastBanner from './BroadcastBanner';
 
@@ -99,4 +99,43 @@ test('renders nothing without a broadcast', () => {
   const { container } = render(<BroadcastBanner />);
 
   expect(container).toBeEmptyDOMElement();
+});
+
+const broadcastData = {
+  id: '1234',
+  summary: {
+    gfm: 'Hello world.',
+    html: '<p>Hello world.</p>',
+  },
+  active: true,
+  enabled: true,
+  stale: false,
+  category: 'other' as const,
+};
+
+describe('BroadcastBanner', () => {
+  it('paints the info category with the accessible interactive teal token', () => {
+    // The info banner draws white text on the category color, so the
+    // background must be the accessible teal (>=4.5:1), not the raw brand
+    // primary-600 (which only reaches 4.14:1 against white).
+    const { container } = render(
+      <BroadcastBanner broadcast={{ ...broadcastData, category: 'info' }} />
+    );
+    const banner = container.firstChild as HTMLElement;
+    expect(banner.style.getPropertyValue('--banner-bg')).toBe(
+      'var(--rsd-component-interactive-color)'
+    );
+  });
+
+  it('keeps the outage category on the darker red for white-text contrast', () => {
+    const { container } = render(
+      <BroadcastBanner broadcast={{ ...broadcastData, category: 'outage' }} />
+    );
+    const banner = container.firstChild as HTMLElement;
+    // Migration of the red/orange danger/notice colors is a separate task;
+    // this only pins that the info migration did not disturb outage.
+    expect(banner.style.getPropertyValue('--banner-bg')).toBe(
+      'var(--rsd-color-red-500)'
+    );
+  });
 });

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.test.tsx
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.test.tsx
@@ -127,15 +127,27 @@ describe('BroadcastBanner', () => {
     );
   });
 
-  it('keeps the outage category on the darker red for white-text contrast', () => {
+  it('paints the outage category with red-600 for white-text contrast', () => {
     const { container } = render(
       <BroadcastBanner broadcast={{ ...broadcastData, category: 'outage' }} />
     );
     const banner = container.firstChild as HTMLElement;
-    // Migration of the red/orange danger/notice colors is a separate task;
-    // this only pins that the info migration did not disturb outage.
+    // White banner text sits on this color, so use red-600 (#ad1919, 7.17:1
+    // on white) rather than red-500 (#ed4c4c, only 3.66:1).
     expect(banner.style.getPropertyValue('--banner-bg')).toBe(
-      'var(--rsd-color-red-500)'
+      'var(--rsd-color-red-600)'
+    );
+  });
+
+  it('paints the notice category with orange-600 for white-text contrast', () => {
+    const { container } = render(
+      <BroadcastBanner broadcast={{ ...broadcastData, category: 'notice' }} />
+    );
+    const banner = container.firstChild as HTMLElement;
+    // White banner text sits on this color, so use orange-600 (#8f4d0a,
+    // 6.49:1 on white) rather than orange-500 (#e08d35, only 2.61:1).
+    expect(banner.style.getPropertyValue('--banner-bg')).toBe(
+      'var(--rsd-color-orange-600)'
     );
   });
 });

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.tsx
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.tsx
@@ -16,9 +16,13 @@ function getCategoryColor(category: Broadcast['category']): string {
       // (>=4.5:1) rather than the raw brand primary-600 (4.14:1 on white).
       return 'var(--rsd-component-interactive-color)';
     case 'outage':
-      return 'var(--rsd-color-red-500)';
+      // White banner text sits on this color, so use red-600 (#ad1919,
+      // 7.17:1 on white) rather than red-500 (#ed4c4c, only 3.66:1).
+      return 'var(--rsd-color-red-600)';
     case 'notice':
-      return 'var(--rsd-color-orange-500)';
+      // White banner text sits on this color, so use orange-600 (#8f4d0a,
+      // 6.49:1 on white) rather than orange-500 (#e08d35, only 2.61:1).
+      return 'var(--rsd-color-orange-600)';
     default:
       return 'var(--rsd-color-gray-500)';
   }

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.tsx
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.tsx
@@ -12,7 +12,9 @@ type BroadcastBannerProps = {
 function getCategoryColor(category: Broadcast['category']): string {
   switch (category) {
     case 'info':
-      return 'var(--rsd-color-primary-600)';
+      // White banner text sits on this color, so use the accessible teal
+      // (>=4.5:1) rather than the raw brand primary-600 (4.14:1 on white).
+      return 'var(--rsd-component-interactive-color)';
     case 'outage':
       return 'var(--rsd-color-red-500)';
     case 'notice':

--- a/apps/squareone/src/components/Footer/Footer.module.css
+++ b/apps/squareone/src/components/Footer/Footer.module.css
@@ -29,9 +29,13 @@
 }
 
 /* Link styling */
+/*
+ * Footer links are underlined at rest so they are distinguishable from
+ * surrounding text by more than color alone (WCAG 1.4.1).
+ */
 .footer a {
   color: var(--rsd-component-text-link-color);
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 .footer a:hover {

--- a/apps/squareone/src/components/FullBleedBackgroundImageSection/FullBleedBackgroundImageSection.module.css
+++ b/apps/squareone/src/components/FullBleedBackgroundImageSection/FullBleedBackgroundImageSection.module.css
@@ -2,6 +2,14 @@
  * Section with a full-bleed background image for content areas.
  */
 .section {
+  /* Scrim defaults. A 50% black scrim composites the brightest region of the
+   * background photo (~rgb(207, 206, 214)) to ~rgb(104, 103, 107), lifting
+   * white hero text to ~5.6:1 — above the WCAG 1.4.3 4.5:1 bar. Both are CSS
+   * variables so a consumer can tune the treatment, but the defaults must
+   * keep white text accessible over any region of the image. */
+  --scrim-color: #000000;
+  --scrim-opacity: 0.5;
+
   color: var(--text-color, #ffffff);
   background-color: var(--fallback-color, #333333);
   background-image: var(--image-path, url("/lsst-stills-0014.jpg"));
@@ -16,4 +24,28 @@
   margin-left: -50vw;
   margin-right: -50vw;
   margin-top: 0;
+}
+
+/*
+ * Scrim overlay: an absolutely-positioned darkening layer between the
+ * background image and the content, so white text meets contrast over bright
+ * image regions without changing the photo itself.
+ */
+.section::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-color: var(--scrim-color, #000000);
+  opacity: var(--scrim-opacity, 0.5);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/*
+ * Content layer stacks above the scrim so the darkening never falls on top of
+ * the hero text.
+ */
+.content {
+  position: relative;
+  z-index: 1;
 }

--- a/apps/squareone/src/components/FullBleedBackgroundImageSection/FullBleedBackgroundImageSection.stories.tsx
+++ b/apps/squareone/src/components/FullBleedBackgroundImageSection/FullBleedBackgroundImageSection.stories.tsx
@@ -1,0 +1,85 @@
+import FullBleedBackgroundImageSection from './FullBleedBackgroundImageSection';
+
+export default {
+  title: 'Components/FullBleedBackgroundImageSection',
+  component: FullBleedBackgroundImageSection,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+/*
+ * Hero-style white text over the section, mirroring the homepage hero. The
+ * scrim behind the content keeps the white heading readable (>=4.5:1) even
+ * over the brightest regions of the background photo.
+ */
+function HeroContent() {
+  return (
+    <div
+      style={{
+        maxWidth: '60rem',
+        margin: '0 auto',
+        padding: '4rem 2rem',
+        color: '#ffffff',
+      }}
+    >
+      <h1
+        style={{
+          // The homepage <h1> forces white via `--c-component-text-reverse-
+          // color`; mirror that here so the story reflects real hero styling
+          // (the global headline color is otherwise body-black).
+          color: '#ffffff',
+          fontSize: '3rem',
+          textAlign: 'center',
+          margin: 0,
+        }}
+      >
+        Rubin Science Platform
+      </h1>
+      <p style={{ textAlign: 'center', fontSize: '1.125rem' }}>
+        White hero text stays legible over the background image thanks to the
+        scrim overlay.
+      </p>
+    </div>
+  );
+}
+
+/*
+ * The default background photo used across the app, exercising the scrim over
+ * a real image with bright regions.
+ */
+export const Default = {
+  render: () => (
+    <FullBleedBackgroundImageSection
+      imagePath="/Quint-DSC1187.jpg"
+      fallbackColor="#333333"
+      textColor="#ffffff"
+    >
+      <HeroContent />
+    </FullBleedBackgroundImageSection>
+  ),
+};
+
+/*
+ * Desktop viewport: the scrim should keep the heading readable across the
+ * full width of the image.
+ */
+export const Desktop = {
+  ...Default,
+  parameters: {
+    ...Default.parameters,
+    viewport: { defaultViewport: 'responsive' },
+  },
+};
+
+/*
+ * Mobile viewport: verify the treatment still reads well and does not cause
+ * horizontal overflow at narrow widths.
+ */
+export const Mobile = {
+  ...Default,
+  parameters: {
+    ...Default.parameters,
+    viewport: { defaultViewport: 'mobile1' },
+  },
+};

--- a/apps/squareone/src/components/FullBleedBackgroundImageSection/FullBleedBackgroundImageSection.test.tsx
+++ b/apps/squareone/src/components/FullBleedBackgroundImageSection/FullBleedBackgroundImageSection.test.tsx
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import FullBleedBackgroundImageSection from './FullBleedBackgroundImageSection';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Static assertion over the FullBleedBackgroundImageSection CSS module source.
+ *
+ * White hero text (the homepage <h1> site name) sits directly over the
+ * background photo. The brightest region of `Quint-DSC1187.jpg` is roughly
+ * rgb(207, 206, 214), against which white text measures only ~1.6:1 — far
+ * below the WCAG 1.4.3 4.5:1 bar. A 50% black scrim composites that worst-case
+ * region to ~rgb(104, 103, 107), lifting white text to ~5.6:1 (>=4.5:1). The
+ * scrim opacity is exposed as `--scrim-opacity` (default 0.5) so hosts can
+ * tune it, but the default must satisfy the contrast bar. JSDOM cannot
+ * resolve composited pixels or CSS custom-property defaults, so reading the
+ * module source and asserting the scrim contract is the durable check.
+ */
+const source = readFileSync(
+  path.join(__dirname, 'FullBleedBackgroundImageSection.module.css'),
+  'utf8'
+);
+
+describe('FullBleedBackgroundImageSection', () => {
+  it('renders children above the scrim in a content layer', () => {
+    const { getByTestId } = render(
+      <FullBleedBackgroundImageSection>
+        <p data-testid="hero-child">Rubin Science Platform</p>
+      </FullBleedBackgroundImageSection>
+    );
+    const child = getByTestId('hero-child');
+    // Children must be wrapped in a content layer (not direct children of the
+    // <section>) so they stack above the absolutely-positioned scrim.
+    const contentLayer = child.parentElement;
+    expect(contentLayer).not.toBeNull();
+    expect(contentLayer?.className).toMatch(/content/i);
+  });
+});
+
+describe('FullBleedBackgroundImageSection scrim CSS', () => {
+  it('defines a scrim overlay with a black base color', () => {
+    // The scrim darkens bright image regions so white text clears 4.5:1.
+    expect(source).toMatch(/--scrim-color/);
+    expect(source).toMatch(/--scrim-color[^;]*#000000/);
+  });
+
+  it('defaults the scrim opacity to 0.5 (>=4.5:1 over the brightest region)', () => {
+    // 0.5 composites the brightest pixel (~rgb(207,206,214)) to ~rgb(104,
+    // 103,107), giving white text ~5.6:1. A lighter scrim (e.g. 0.4 -> 4.17:1)
+    // would drop below the bar, so lock the accessible default.
+    expect(source).toMatch(/--scrim-opacity[^;]*0\.5/);
+  });
+
+  it('layers content above the scrim', () => {
+    // The content layer needs a stacking context above the scrim pseudo-
+    // element so the darkening never falls on top of the hero text.
+    expect(source).toMatch(/\.content/);
+    expect(source).toMatch(/z-index/);
+  });
+});

--- a/apps/squareone/src/components/FullBleedBackgroundImageSection/FullBleedBackgroundImageSection.tsx
+++ b/apps/squareone/src/components/FullBleedBackgroundImageSection/FullBleedBackgroundImageSection.tsx
@@ -29,7 +29,7 @@ export default function FullBleedBackgroundImageSection({
         } as React.CSSProperties
       }
     >
-      {children}
+      <div className={styles.content}>{children}</div>
     </section>
   );
 }

--- a/apps/squareone/src/components/MainContent/MainContent.module.css
+++ b/apps/squareone/src/components/MainContent/MainContent.module.css
@@ -13,3 +13,17 @@
     padding: 0;
   }
 }
+
+/*
+ * Underline links that appear inside running text (paragraphs, list items,
+ * definitions, block quotes) so they are distinguishable from surrounding
+ * body text by more than color alone (WCAG 1.4.1; axe link-in-text-block).
+ *
+ * Scoping to text-block elements deliberately excludes the homepage service
+ * cards and other card-as-link patterns rendered in MainContent, whose <a>
+ * wraps a heading/illustration rather than sitting inside a text block —
+ * those remain underline-free. Nav/menu links live outside MainContent.
+ */
+.main :is(p, li, dd, blockquote) a {
+  text-decoration: underline;
+}

--- a/apps/squareone/src/components/SidebarLayout/MobileMenuToggle.module.css
+++ b/apps/squareone/src/components/SidebarLayout/MobileMenuToggle.module.css
@@ -13,17 +13,17 @@
 }
 
 .toggleButton:hover {
-  background-color: var(--rsd-color-primary-100, #e6f3ff);
+  background-color: var(--rsd-color-primary-100, #f5f5f5);
 }
 
 .toggleButton:focus {
   outline: none;
-  border-color: var(--rsd-color-primary-600, #0066cc);
-  background-color: var(--rsd-color-primary-50, #f0f9ff);
+  border-color: var(--rsd-color-primary-600, #058b8c);
+  background-color: var(--rsd-color-primary-50, #fbfefe);
 }
 
 .toggleButton:active {
-  background-color: var(--rsd-color-primary-200, #bfdbfe);
+  background-color: var(--rsd-color-primary-200, #d9f7f6);
 }
 
 /* Desktop: completely hidden. 66rem matches SidebarLayout's grid breakpoint

--- a/apps/squareone/src/components/SidebarLayout/Sidebar.module.css
+++ b/apps/squareone/src/components/SidebarLayout/Sidebar.module.css
@@ -52,7 +52,7 @@
 }
 
 .titleLink:focus {
-  outline: 2px solid var(--rsd-color-primary-600, #0066cc);
+  outline: 2px solid var(--rsd-color-primary-600, #058b8c);
   outline-offset: 2px;
   border-radius: 2px;
 }

--- a/apps/squareone/src/components/SidebarLayout/SidebarLayout.module.css
+++ b/apps/squareone/src/components/SidebarLayout/SidebarLayout.module.css
@@ -133,7 +133,7 @@
 }
 
 .mobileHeaderTitleLink:focus {
-  outline: 2px solid var(--rsd-color-primary-600, #0066cc);
+  outline: 2px solid var(--rsd-color-primary-600, #058b8c);
   outline-offset: 2px;
   border-radius: 2px;
 }

--- a/apps/squareone/src/components/SidebarLayout/SidebarNavItem.module.css
+++ b/apps/squareone/src/components/SidebarLayout/SidebarNavItem.module.css
@@ -12,12 +12,12 @@
 }
 
 .link:hover {
-  background-color: var(--rsd-color-primary-100, #e6f3ff);
+  background-color: var(--rsd-color-primary-100, #f5f5f5);
   text-decoration: none;
 }
 
 .link:focus-visible {
-  outline: 2px solid var(--rsd-color-primary-600, #0066cc);
+  outline: 2px solid var(--rsd-color-primary-600, #058b8c);
   outline-offset: -2px;
 }
 
@@ -37,12 +37,12 @@
 }
 
 .linkActive:hover {
-  background-color: var(--rsd-color-primary-100, #e6f3ff);
+  background-color: var(--rsd-color-primary-100, #f5f5f5);
   text-decoration: none;
 }
 
 .linkActive:focus-visible {
-  outline: 2px solid var(--rsd-color-primary-600, #0066cc);
+  outline: 2px solid var(--rsd-color-primary-600, #058b8c);
   outline-offset: -2px;
 }
 
@@ -54,6 +54,6 @@
   top: 0;
   bottom: 0;
   width: 4px;
-  background-color: var(--rsd-color-primary-600, #0066cc);
+  background-color: var(--rsd-color-primary-600, #058b8c);
   border-radius: 2px;
 }

--- a/apps/squareone/src/components/SidebarLayout/sidebarLayoutTokens.test.ts
+++ b/apps/squareone/src/components/SidebarLayout/sidebarLayoutTokens.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Static assertions over the SidebarLayout CSS module sources.
+ *
+ * These files style themselves with `--rsd-color-primary-*` custom properties
+ * — the Rubin brand teal ramp — but their inline fallbacks (used only if the
+ * token fails to resolve) were copied from a blue palette: #0066cc, #e6f3ff,
+ * #f0f9ff, #bfdbfe. A wrong-hue fallback silently paints the wrong color
+ * whenever the token is absent. The fallbacks must match the teal ramp value
+ * of the token they back.
+ */
+
+const sidebarCss = [
+  'SidebarLayout.module.css',
+  'SidebarNavItem.module.css',
+  'MobileMenuToggle.module.css',
+  'Sidebar.module.css',
+].map((relative) => ({
+  relative,
+  source: readFileSync(path.join(__dirname, relative), 'utf8'),
+}));
+
+// Blue fallback hexes that do not belong to the teal `primary` ramp.
+const wrongHueFallbacks = ['#0066cc', '#e6f3ff', '#f0f9ff', '#bfdbfe'];
+
+describe('SidebarLayout CSS fallback hexes match the teal brand ramp', () => {
+  for (const { relative, source } of sidebarCss) {
+    const normalized = source.toLowerCase();
+    for (const hex of wrongHueFallbacks) {
+      it(`${relative} does not use the blue fallback ${hex}`, () => {
+        expect(normalized).not.toContain(hex);
+      });
+    }
+  }
+});

--- a/apps/squareone/src/components/TimesSquareParameters/StringInput.module.css
+++ b/apps/squareone/src/components/TimesSquareParameters/StringInput.module.css
@@ -1,7 +1,10 @@
 .input {
   border-width: 2px;
   border-style: solid;
-  border-color: var(--rsd-color-gray-500);
+  /* gray-400 (#82898B) is 4.55:1 on the dark page and 3.56:1 on white —
+     >=3:1 in both themes and consistent with the squared form controls.
+     gray-500 was only 3.13:1 on dark (a marginal non-text pass). */
+  border-color: var(--rsd-color-gray-400);
   padding: 5px 10px;
   border-radius: 5px;
   appearance: none;

--- a/apps/squareone/src/components/TimesSquareParameters/StringInput.test.ts
+++ b/apps/squareone/src/components/TimesSquareParameters/StringInput.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Static assertion over the StringInput CSS module source.
+ *
+ * The Times Square parameter text input styles its border with a raw
+ * design-token custom property. On the dark page (gray-800 #1F2121) a
+ * gray-500 (#6A6E6E) border is only 3.13:1 — a marginal pass of the 3:1
+ * non-text bar and darker than the sibling squared form controls. Moving to
+ * gray-400 (#82898B) lifts it to 4.55:1 on dark (and stays 3.56:1 on white),
+ * matching TextInput/TextArea/Select and giving a robust >=3:1 in both
+ * themes. JSDOM cannot resolve CSS-module custom-property values, so reading
+ * the source and asserting the border token is the durable check.
+ */
+const source = readFileSync(
+  path.join(__dirname, 'StringInput.module.css'),
+  'utf8'
+);
+
+describe('StringInput CSS design tokens', () => {
+  it('does not use gray-500 for the input border', () => {
+    // gray-500 border is 3.13:1 on the dark page — a marginal 3:1 pass.
+    expect(source).not.toContain('--rsd-color-gray-500');
+  });
+
+  it('uses gray-400 for the input border (>=3:1 in both themes)', () => {
+    expect(source).toContain('border-color: var(--rsd-color-gray-400)');
+  });
+});

--- a/apps/squareone/src/components/UserNotifications/UserNotificationsTableView.module.css
+++ b/apps/squareone/src/components/UserNotifications/UserNotificationsTableView.module.css
@@ -149,7 +149,8 @@
 }
 
 .summaryToggle:hover .summaryText {
-  color: var(--rsd-color-primary-600);
+  /* Teal summary text on hover: accessible teal for 4.5:1. */
+  color: var(--rsd-component-interactive-color);
 }
 
 /* The chevron sits at the top of the (potentially wrapping) summary. */
@@ -217,7 +218,8 @@
   padding: 0;
   border: none;
   background: none;
-  color: var(--rsd-color-primary-600);
+  /* Link-style teal text: accessible teal for 4.5:1. */
+  color: var(--rsd-component-interactive-color);
   font: inherit;
   text-decoration: underline;
   cursor: pointer;

--- a/packages/global-css/src/tokens.css
+++ b/packages/global-css/src/tokens.css
@@ -10,7 +10,10 @@
 
   /* Colors */
   --sqo-doc-card-background-color: var(--rsd-color-gray-000);
-  --sqo-primary-button-background-color: var(--rsd-color-primary-600);
+  /* White text sits on this fill (IconPill, dev auth panel), so use the
+   * accessible teal (>=4.5:1) rather than the raw brand primary-600 (4.14:1
+   * on white). The hover step is a separate contrast concern. */
+  --sqo-primary-button-background-color: var(--rsd-component-interactive-color);
   --sqo-primary-button-background-color-hover: var(--rsd-color-primary-400);
   --sqo-primary-button-background-color-active: var(--rsd-color-primary-300);
   --sqo-primary-button-text-color: var(--rsd-component-text-reverse-color);

--- a/packages/rubin-style-dictionary/package.json
+++ b/packages/rubin-style-dictionary/package.json
@@ -11,12 +11,14 @@
   "devDependencies": {
     "lodash": "^4.18.1",
     "style-dictionary": "^3.7.1",
+    "vitest": "^4.1.0",
     "yaml": "^2.8.3"
   },
   "scripts": {
     "build": "node ./build.js",
     "clean": "rm -rf dist",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "vitest run"
   },
   "repository": "https://github.com/lsst-sqre/squareone",
   "keywords": [

--- a/packages/rubin-style-dictionary/src/color/primary.yaml
+++ b/packages/rubin-style-dictionary/src/color/primary.yaml
@@ -23,6 +23,9 @@ color:
     '600':
       value: '{color.imagotype.dark.value}'
       comment: 'Base dark teal from imagotype'
+    '650':
+      value: '#046F70' # H:181 S:96 B:44 — 5.98:1 on white
+      comment: 'Accessible teal for text/interactive foregrounds (>=4.5:1 on white)'
     '700':
       value: '#0C4A47' # H:177 S:84 B:29
       comment: 'Dark teal'

--- a/packages/rubin-style-dictionary/src/component/header.yaml
+++ b/packages/rubin-style-dictionary/src/component/header.yaml
@@ -32,6 +32,9 @@ component:
             color:
               themed:
                 light:
-                  value: '{color.primary.600.value}'
+                  # Selected menulist items draw white text on this fill, so it
+                  # must clear 4.5:1: primary-650 (accessible teal, 5.98:1 on
+                  # white) rather than the raw brand primary-600 (4.14:1).
+                  value: '{color.primary.650.value}'
                 dark:
                   value: '{color.primary.700.value}'

--- a/packages/rubin-style-dictionary/src/component/interactive.yaml
+++ b/packages/rubin-style-dictionary/src/component/interactive.yaml
@@ -1,0 +1,17 @@
+component:
+  # Semantic accent color for text and interactive foregrounds.
+  #
+  # Resolves to primary-650, the accessible teal (>=4.5:1 on white), so
+  # components can migrate off raw `color.primary.600` references (which
+  # only reach 4.14:1) for text and interactive uses. The brand teal
+  # (primary-600) is retained for non-text accents such as focus rings,
+  # borders, and checked-state fills where the 3:1 non-text bar applies.
+  interactive:
+    color:
+      themed:
+        light:
+          value: '{color.primary.650.value}'
+          comment: 'Accessible teal accent for text/interactive foregrounds.'
+        dark:
+          value: '{color.primary.400.value}'
+          comment: 'Accessible teal accent for text/interactive foregrounds in dark theme.'

--- a/packages/rubin-style-dictionary/src/component/text.yaml
+++ b/packages/rubin-style-dictionary/src/component/text.yaml
@@ -44,6 +44,8 @@ component:
       color:
         themed:
           light:
-            value: '{color.primary.600.value}'
+            value: '{component.text.color.themed.light.value}'
+            comment: 'Headlines render in body text color (gray-800) so h1/h2 are black, not brand teal.'
           dark:
-            value: '{color.primary.600.value}'
+            value: '{component.text.color.themed.dark.value}'
+            comment: 'Headlines render in dark-theme body text color, not brand teal.'

--- a/packages/rubin-style-dictionary/src/component/text.yaml
+++ b/packages/rubin-style-dictionary/src/component/text.yaml
@@ -33,7 +33,7 @@ component:
         color:
           themed:
             light:
-              value: '{color.blue.500.value}'
+              value: '{color.blue.600.value}' # blue-500 (4.44:1) fails; blue-600 clears 4.5:1
             dark:
               value: '{component.text.link.color.themed.light.value}'
       reverse:

--- a/packages/rubin-style-dictionary/src/component/text.yaml
+++ b/packages/rubin-style-dictionary/src/component/text.yaml
@@ -35,7 +35,11 @@ component:
             light:
               value: '{color.blue.600.value}' # blue-500 (4.44:1) fails; blue-600 clears 4.5:1
             dark:
-              value: '{component.text.link.color.themed.light.value}'
+              # Hover must go *lighter* than the resting dark link (blue-300,
+              # 9.19:1 on the dark page) — the old value re-used the light
+              # resting link (#146685), only 2.52:1 on dark and the wrong
+              # direction. blue-200 is 11.80:1 on the dark page.
+              value: '{color.blue.200.value}'
       reverse:
         color:
           value: '{component.text.link.color.themed.dark.value}'

--- a/packages/rubin-style-dictionary/src/tokens.test.js
+++ b/packages/rubin-style-dictionary/src/tokens.test.js
@@ -1,0 +1,73 @@
+/**
+ * Tests for the generated design-token CSS output.
+ *
+ * The rubin-style-dictionary has no build step in the usual sense — it
+ * compiles the YAML token sources into `dist/tokens.css` (light/default
+ * theme) and `dist/tokens.dark.css` (dark theme) via `build.js`. These
+ * tests run that build once and assert on the generated CSS custom
+ * properties, so token contracts that downstream packages depend on
+ * (e.g. `--rsd-color-primary-600` never changing) are guarded.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(dirname, '..');
+const distDir = path.join(packageDir, 'dist');
+
+let lightCss = '';
+let darkCss = '';
+
+/**
+ * Extract the value of a CSS custom property from a `:root`-style block.
+ *
+ * Returns the trimmed value (without the trailing `;` or any comment) or
+ * `undefined` if the variable is not declared.
+ */
+function cssVar(css, name) {
+  const match = css.match(new RegExp(`${name}\\s*:\\s*([^;]+);`, 'i'));
+  return match ? match[1].trim() : undefined;
+}
+
+beforeAll(() => {
+  execFileSync('node', ['build.js'], { cwd: packageDir, stdio: 'pipe' });
+  lightCss = fs.readFileSync(path.join(distDir, 'tokens.css'), 'utf8');
+  darkCss = fs.readFileSync(path.join(distDir, 'tokens.dark.css'), 'utf8');
+});
+
+describe('primary color ramp', () => {
+  it('adds a primary-650 step at #046f70 (>=4.5:1 on white)', () => {
+    expect(cssVar(lightCss, '--rsd-color-primary-650')).toBe('#046f70');
+  });
+
+  it('leaves primary-600 (official brand color) unchanged at #058b8c', () => {
+    expect(cssVar(lightCss, '--rsd-color-primary-600')).toBe('#058b8c');
+  });
+});
+
+describe('semantic interactive token', () => {
+  it('exposes a component interactive color that resolves to primary-650', () => {
+    expect(cssVar(lightCss, '--rsd-component-interactive-color')).toBe(
+      '#046f70'
+    );
+  });
+});
+
+describe('headline token', () => {
+  it('renders headlines in body black (#1f2121) in the light theme', () => {
+    expect(cssVar(lightCss, '--rsd-component-text-headline-color')).toBe(
+      '#1f2121'
+    );
+  });
+
+  it('renders headlines in the dark-theme body text color, not teal', () => {
+    const headline = cssVar(darkCss, '--rsd-component-text-headline-color');
+    expect(headline).toBeDefined();
+    // Dark-theme body text is gray-100; must not fall back to brand teal.
+    expect(headline).not.toBe('#058b8c');
+    expect(headline).toBe('#dce0e3');
+  });
+});

--- a/packages/rubin-style-dictionary/src/tokens.test.js
+++ b/packages/rubin-style-dictionary/src/tokens.test.js
@@ -79,6 +79,20 @@ describe('link hover token', () => {
       '#145f7a'
     );
   });
+
+  it('lightens the dark-theme link-hover color above the resting link (>=4.5:1 on dark bg)', () => {
+    // On dark backgrounds hover must move *lighter* than the resting link so
+    // the affordance reads as "brighter on hover" and stays legible. The old
+    // value re-used the light-theme resting color (#146685) — 2.52:1 on the
+    // dark page (gray-800 #1f2121) and darker than the resting blue-300
+    // (#7bcfe8, 9.19:1), i.e. the wrong direction. It retargets to blue-200
+    // (#b8e3f2, 11.80:1 on dark bg), lighter than the resting link.
+    const hover = cssVar(darkCss, '--rsd-component-text-link-hover-color');
+    expect(hover).toBeDefined();
+    // Must not fall back to the light-theme resting link color.
+    expect(hover).not.toBe('#146685');
+    expect(hover).toBe('#b8e3f2');
+  });
 });
 
 describe('headline token', () => {

--- a/packages/rubin-style-dictionary/src/tokens.test.js
+++ b/packages/rubin-style-dictionary/src/tokens.test.js
@@ -56,6 +56,20 @@ describe('semantic interactive token', () => {
   });
 });
 
+describe('header menulist selected background', () => {
+  it('resolves to the accessible teal (primary-650) in the light theme', () => {
+    // The selected menulist item draws white text on this background, so it
+    // must clear 4.5:1 — primary-650 (5.98:1 on white), not the raw brand
+    // primary-600 (4.14:1).
+    expect(
+      cssVar(
+        lightCss,
+        '--rsd-component-header-nav-menulist-selected-background-color'
+      )
+    ).toBe('#046f70');
+  });
+});
+
 describe('headline token', () => {
   it('renders headlines in body black (#1f2121) in the light theme', () => {
     expect(cssVar(lightCss, '--rsd-component-text-headline-color')).toBe(

--- a/packages/rubin-style-dictionary/src/tokens.test.js
+++ b/packages/rubin-style-dictionary/src/tokens.test.js
@@ -70,6 +70,17 @@ describe('header menulist selected background', () => {
   });
 });
 
+describe('link hover token', () => {
+  it('darkens the light-theme link-hover color to blue-600 (>=4.5:1 on white)', () => {
+    // The resting link color is already blue-600-dark (#146685); the hover
+    // color must also clear 4.5:1 on white. blue-500 (#1c81a4) is only
+    // 4.44:1 and fails, so hover retargets to blue-600 (#145f7a, 7.12:1).
+    expect(cssVar(lightCss, '--rsd-component-text-link-hover-color')).toBe(
+      '#145f7a'
+    );
+  });
+});
+
 describe('headline token', () => {
   it('renders headlines in body black (#1f2121) in the light theme', () => {
     expect(cssVar(lightCss, '--rsd-component-text-headline-color')).toBe(

--- a/packages/rubin-style-dictionary/vitest.config.ts
+++ b/packages/rubin-style-dictionary/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/packages/squared/src/components/Badge/Badge.module.css
+++ b/packages/squared/src/components/Badge/Badge.module.css
@@ -50,7 +50,8 @@
 
 /* Solid variant - primary */
 .solid.primary {
-  background-color: var(--rsd-color-primary-600);
+  /* White text on teal: accessible teal (>=4.5:1), not raw primary-600. */
+  background-color: var(--rsd-component-interactive-color);
   color: var(--rsd-color-gray-000);
 }
 
@@ -99,7 +100,8 @@
 /* Soft variant - primary */
 .soft.primary {
   background-color: var(--rsd-color-primary-200);
-  color: var(--rsd-color-primary-600);
+  /* Teal text on the light-teal tint: accessible teal lifts 3.66:1 -> 5.29:1. */
+  color: var(--rsd-component-interactive-color);
 }
 
 /* Soft variant - blue */
@@ -147,8 +149,10 @@
 /* Outline variant - primary */
 .outline.primary {
   background-color: var(--rsd-component-page-background-color);
+  /* Border is a non-text accent (3:1 bar) and keeps the brand teal; the
+   * label text uses the accessible teal to clear 4.5:1. */
   border-color: var(--rsd-color-primary-600);
-  color: var(--rsd-color-primary-600);
+  color: var(--rsd-component-interactive-color);
 }
 
 /* Outline variant - blue */

--- a/packages/squared/src/components/Button/Button.module.css
+++ b/packages/squared/src/components/Button/Button.module.css
@@ -71,7 +71,9 @@
 }
 
 .solid.primary:hover:not(:disabled):not(.disabled) {
-  background-color: var(--rsd-color-primary-400);
+  /* Darken on hover: brightening to primary-400 dropped white text to
+   * 2.40:1. primary-700 keeps white label text at 10.07:1. */
+  background-color: var(--rsd-color-primary-700);
 }
 
 .solid.primary:active:not(:disabled):not(.disabled) {
@@ -108,16 +110,19 @@
 
 /* Solid + Danger */
 .solid.danger {
-  background-color: var(--rsd-color-red-500);
+  /* White label on red: use red-600 (7.17:1 on white), not red-500
+   * (#ed4c4c, only 3.66:1). */
+  background-color: var(--rsd-color-red-600);
   color: white;
 }
 
 .solid.danger:hover:not(:disabled):not(.disabled) {
-  background-color: #dc3232;
+  /* Darken on hover to red-700 (white text 8.06:1). */
+  background-color: var(--rsd-color-red-700);
 }
 
 .solid.danger:active:not(:disabled):not(.disabled) {
-  background-color: #c92a2a;
+  background-color: var(--rsd-color-red-800);
 }
 
 /* Appearance: Outline */
@@ -172,12 +177,15 @@
 
 /* Outline + Danger */
 .outline.danger {
-  border-color: var(--rsd-color-red-500);
-  color: var(--rsd-color-red-500);
+  /* Label text on the page background: red-600 (7.17:1 on white), not
+   * red-500 (#ed4c4c, only 3.66:1). Border keeps the same token. */
+  border-color: var(--rsd-color-red-600);
+  color: var(--rsd-color-red-600);
 }
 
 .outline.danger:hover:not(:disabled):not(.disabled) {
-  background-color: var(--rsd-color-red-500);
+  /* Hover fills with red under white text: red-600 for 7.17:1. */
+  background-color: var(--rsd-color-red-600);
   color: white;
 }
 
@@ -227,11 +235,14 @@
 
 /* Text + Danger */
 .text.danger {
-  color: var(--rsd-color-red-500);
+  /* Danger label on the page background: red-600 (7.17:1 on white), not
+   * red-500 (#ed4c4c, only 3.66:1). */
+  color: var(--rsd-color-red-600);
 }
 
 .text.danger:hover:not(:disabled):not(.disabled) {
-  background-color: rgba(237, 76, 76, 0.1);
+  /* red-600 (#ad1919) at 10% opacity to match the darker label. */
+  background-color: rgba(173, 25, 25, 0.1);
 }
 
 /* Icons */

--- a/packages/squared/src/components/Button/Button.module.css
+++ b/packages/squared/src/components/Button/Button.module.css
@@ -64,7 +64,9 @@
 
 /* Solid + Primary */
 .solid.primary {
-  background-color: var(--rsd-color-primary-600);
+  /* White label on teal: use the accessible teal (>=4.5:1), not raw
+   * primary-600 (4.14:1 on white). */
+  background-color: var(--rsd-component-interactive-color);
   color: white;
 }
 
@@ -135,12 +137,15 @@
 
 /* Outline + Primary */
 .outline.primary {
+  /* Border is a non-text accent (3:1 bar) so it keeps the brand teal; the
+   * label text uses the accessible teal to clear 4.5:1. */
   border-color: var(--rsd-color-primary-600);
-  color: var(--rsd-color-primary-600);
+  color: var(--rsd-component-interactive-color);
 }
 
 .outline.primary:hover:not(:disabled):not(.disabled) {
-  background-color: var(--rsd-color-primary-600);
+  /* Hover fills with teal under white text: accessible teal for 4.5:1. */
+  background-color: var(--rsd-component-interactive-color);
   color: white;
 }
 
@@ -194,7 +199,8 @@
 
 /* Text + Primary */
 .text.primary {
-  color: var(--rsd-color-primary-600);
+  /* Teal label on the page background: accessible teal for 4.5:1. */
+  color: var(--rsd-component-interactive-color);
 }
 
 .text.primary:hover:not(:disabled):not(.disabled) {

--- a/packages/squared/src/components/DataTable/DataTable.module.css
+++ b/packages/squared/src/components/DataTable/DataTable.module.css
@@ -75,7 +75,8 @@
 
 .sortIcon {
   flex-shrink: 0;
-  color: var(--rsd-color-primary-600);
+  /* Active-sort indicator glyph: accessible teal so it reads as text (>=4.5:1). */
+  color: var(--rsd-component-interactive-color);
 }
 
 /* Inactive (sortable but not currently sorted) indicator is muted. */

--- a/packages/squared/src/components/Select/Select.module.css
+++ b/packages/squared/src/components/Select/Select.module.css
@@ -238,7 +238,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--rsd-color-primary-600);
+  /* Selected-option checkmark glyph: accessible teal so it reads as text. */
+  color: var(--rsd-component-interactive-color);
 }
 
 .itemIndicator svg {

--- a/packages/squared/src/components/Select/Select.module.css
+++ b/packages/squared/src/components/Select/Select.module.css
@@ -13,7 +13,7 @@
 .trigger {
   /* Consistent with TextInput and Button components */
   font-family: inherit;
-  border: 1px solid var(--rsd-color-gray-100);
+  border: 1px solid var(--rsd-color-gray-400);
   border-radius: var(--sqo-border-radius-1);
   background: var(--rsd-component-page-background-color);
   color: var(--rsd-component-text-color);
@@ -51,7 +51,7 @@
 
 .trigger[aria-invalid="true"] {
   border-color: var(--rsd-color-red-500);
-  color: var(--rsd-color-red-900);
+  color: var(--rsd-color-red-600);
 }
 
 .trigger[aria-invalid="true"]:focus-visible {

--- a/packages/squared/src/components/Tabs/Tabs.module.css
+++ b/packages/squared/src/components/Tabs/Tabs.module.css
@@ -63,7 +63,9 @@
 
 /* Active/Selected state */
 .trigger[data-state="active"] {
-  color: var(--rsd-color-primary-600);
+  /* Selected tab label text uses the accessible teal (>=4.5:1); the
+   * underline is a non-text accent (3:1 bar) and keeps the brand teal. */
+  color: var(--rsd-component-interactive-color);
   border-bottom-color: var(--rsd-color-primary-600);
 }
 

--- a/packages/squared/src/components/TextArea/TextArea.module.css
+++ b/packages/squared/src/components/TextArea/TextArea.module.css
@@ -36,7 +36,7 @@
 
   /* Consistent with TextInput */
   font-family: inherit;
-  border: 1px solid var(--rsd-color-gray-100);
+  border: 1px solid var(--rsd-color-gray-400);
   border-radius: var(--sqo-border-radius-1);
   background: var(--rsd-component-page-background-color);
   color: var(--rsd-component-text-color);
@@ -87,12 +87,12 @@
 
 /* Appearance variants */
 .default {
-  border-color: var(--rsd-color-gray-100);
+  border-color: var(--rsd-color-gray-400);
 }
 
 .error {
   border-color: var(--rsd-color-red-500);
-  color: var(--rsd-color-red-900);
+  color: var(--rsd-color-red-600);
 }
 
 .error:focus-visible {
@@ -102,7 +102,7 @@
 
 .success {
   border-color: var(--rsd-color-green-500);
-  color: var(--rsd-color-green-900);
+  color: var(--rsd-color-green-600);
 }
 
 .success:focus-visible {

--- a/packages/squared/src/components/TextInput/TextInput.module.css
+++ b/packages/squared/src/components/TextInput/TextInput.module.css
@@ -20,7 +20,7 @@
 .input {
   /* Consistent with Button component */
   font-family: inherit;
-  border: 1px solid var(--rsd-color-gray-100);
+  border: 1px solid var(--rsd-color-gray-400);
   border-radius: var(--sqo-border-radius-1);
   background: var(--rsd-component-page-background-color);
   color: var(--rsd-component-text-color);
@@ -68,12 +68,12 @@
 
 /* Appearance variants */
 .default {
-  border-color: var(--rsd-color-gray-100);
+  border-color: var(--rsd-color-gray-400);
 }
 
 .error {
   border-color: var(--rsd-color-red-500);
-  color: var(--rsd-color-red-900);
+  color: var(--rsd-color-red-600);
 }
 
 .error:focus-visible {
@@ -83,7 +83,7 @@
 
 .success {
   border-color: var(--rsd-color-green-500);
-  color: var(--rsd-color-green-900);
+  color: var(--rsd-color-green-600);
 }
 
 .success:focus-visible {

--- a/packages/squared/src/components/formControlTokens.test.ts
+++ b/packages/squared/src/components/formControlTokens.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Static assertions over the form-control CSS module sources.
+ *
+ * These components (TextInput, TextArea, Select) style themselves with raw
+ * design-token custom properties. Two classes of defect are invisible to
+ * JSDOM-rendered tests but caught here by reading the CSS source directly:
+ *
+ * 1. References to tokens that do not exist in rubin-style-dictionary
+ *    (`--rsd-color-red-900`, `--rsd-color-green-900`) silently resolve to
+ *    nothing, so error/success text never gets its intended color.
+ * 2. Borders keyed to `--rsd-color-gray-100` (#DCE0E3) measure only 1.33:1
+ *    against a white page — a WCAG 1.4.11 non-text contrast failure. The
+ *    accessible replacement is `--rsd-color-gray-400` (#82898B, 3.56:1).
+ */
+
+const formControlCss = [
+  'TextInput/TextInput.module.css',
+  'TextArea/TextArea.module.css',
+  'Select/Select.module.css',
+].map((relative) => ({
+  relative,
+  source: readFileSync(path.join(__dirname, relative), 'utf8'),
+}));
+
+describe('form-control CSS design tokens', () => {
+  describe('no references to non-existent color-ramp steps', () => {
+    // The red and green ramps stop at step 800; there is no 900 step.
+    for (const brokenToken of [
+      '--rsd-color-red-900',
+      '--rsd-color-green-900',
+    ]) {
+      for (const { relative, source } of formControlCss) {
+        it(`${relative} does not reference ${brokenToken}`, () => {
+          expect(source).not.toContain(brokenToken);
+        });
+      }
+    }
+  });
+
+  describe('borders meet the 3:1 non-text contrast bar', () => {
+    // gray-100 (#DCE0E3) is only 1.33:1 on white; gray-400 (#82898B) is 3.56:1.
+    for (const { relative, source } of formControlCss) {
+      it(`${relative} does not use gray-100 for control borders`, () => {
+        // gray-100 is legitimate elsewhere (e.g. surfaces), but these files
+        // only use it for the control border/appearance, so it should be gone.
+        expect(source).not.toContain('--rsd-color-gray-100');
+      });
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
       style-dictionary:
         specifier: ^3.7.1
         version: 3.9.2
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.6(@types/node@25.2.3)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.48.0)(yaml@2.9.0))
       yaml:
         specifier: ^2.8.3
         version: 2.9.0


### PR DESCRIPTION
## Summary

- Add the WCAG color-contrast foundation in `rubin-style-dictionary`: a new `primary-650` step (`#046f70`, 5.98:1 on white) and a semantic `--rsd-component-interactive-color` token for text/interactive teal, plus a retargeted headline token so h1/h2 render body-black instead of brand teal. `primary-600` (the official brand color) is unchanged and kept for non-text accents at the 3:1 bar.
- Migrate the failing teal text and interactive foregrounds enumerated in PRD #550 stream 1 onto `--rsd-component-interactive-color` rather than raw `primary-600`: Button/Badge primary variants, the selected Tabs label, the Select selected-option indicator, the DataTable active-sort indicator, the header dropdown selected background (light theme), the IconPill/dev-panel fill, and the BroadcastBanner info category.
- Move the danger/notice colors onto darker ramp steps: Button danger variants and the outage banner to `red-600` (`#ad1919`, 7.17:1 on white); the notice banner to `orange-600` (`#8f4d0a`, 6.49:1). Darken the Button solid-primary hover to `primary-700` (white text 10.07:1, was brightening to 2.40:1) and remove the BroadcastBanner `#dddddd` link-hover dim so links stay white and above 4.5:1.
- Underline links inside running prose (paragraphs, list items, definitions, block quotes in `MainContent`) and all footer links so they are distinguishable from body text by more than color (WCAG 1.4.1, resolving the axe `link-in-text-block` failure); nav, menu, card-as-link, and standalone call-to-action links stay underline-free. Darken the light-theme link-hover color from `blue-500` (`#1c81a4`, 4.44:1) to `blue-600` (`#145f7a`, 7.12:1) so it clears 4.5:1 on white.
- Fix form-control contrast and broken CSS token references: input/textarea/select borders move from `gray-100` (`#dce0e3`, 1.33:1 on white — WCAG 1.4.11) to `gray-400` (`#82898b`, 3.56:1); the error/success text in TextInput/TextArea/Select that referenced non-existent `red-900`/`green-900` steps (silently no-op) now points at `red-600`/`green-600`; and the wrong-hue blue fallback hexes in the SidebarLayout CSS modules are corrected to the teal `primary` ramp values they back.
- Fix dark-theme contrast: retarget the dark `link-hover-color` from the light-theme resting link (`#146685`, 2.52:1 on the dark page and *darker* than the resting link — the wrong direction) to `blue-200` (`#b8e3f2`, 11.80:1, lighter than the resting `blue-300`), and move the Times Square parameter input border off the marginal `gray-500` (3.13:1 on dark) to `gray-400` (4.55:1 dark / 3.56:1 light). Dark-theme placeholder text was already on the adaptive `--rsd-component-text-secondary-color` (gray-300, 6.45:1 on dark).
- Add a scrim overlay to `FullBleedBackgroundImageSection` so white hero text clears 4.5:1 over the background photo: a black `::before` layer at 50% opacity (exposed as `--scrim-color`/`--scrim-opacity`) composites the brightest region of the homepage image (~`rgb(207,206,214)`, where white text was only ~1.6:1) to ~`rgb(104,103,107)`, lifting white text to ~5.6:1. Content now renders in a stacking layer above the scrim.

## Validation steps

- Spot-check that primary buttons, badges, selected tabs, and the info/outage/notice broadcast banners all render normal-size text at >=4.5:1 contrast; confirm `primary-600` is still used for non-text accents (focus rings, borders, checked-state fills) and its value is unchanged.
- Confirm h1/h2 headings render in body black rather than brand teal.
- Hover a primary button and a danger button and confirm the fill darkens (never brightens) and the white label stays legible; hover a link inside a broadcast banner and confirm it stays white (no dim).
- On a prose page (e.g. `/support`, `/docs`, `/api-aspect`), confirm inline links inside paragraphs and lists are underlined and footer links are underlined, while header nav, menu, homepage service-card, and call-to-action links are not; confirm axe `link-in-text-block` no longer fires.
- Confirm input, textarea, and Select trigger borders read as a visible medium gray (>=3:1) against the page rather than the near-invisible former light gray; trigger error/success states on a TextInput/TextArea/Select and confirm the message text now renders in a dark red / dark green (not defaulting to body color).
- With the SidebarLayout mobile menu and nav items, confirm hover/focus/active accents are brand teal, not blue, if the design tokens ever fail to load (the inline fallbacks now match the teal ramp).
- In dark theme: confirm placeholder text in inputs/textareas is legible (>=4.5:1) and input borders read as a visible gray (>=3:1); hover a link and confirm the hover color goes *lighter* than the resting link (not darker) and stays legible on the dark page.
- On the homepage hero, confirm the white site-name heading and any text over the background photo stay legible (>=4.5:1) across the full width of the image at both desktop and 320 px mobile widths, with no horizontal overflow.

## References

- Closes #557
- Closes #558
- Closes #559
- Closes #560
- Closes #561
- Closes #562
- Closes #563
- PRD: #550
- Jira: https://rubinobs.atlassian.net/browse/DM-53296
