### PR TITLE
DM-55599: Fix broadcast parsing for broadcasts with a null body

### DIFF
--- a/.changeset/semaphore-null-body.md
+++ b/.changeset/semaphore-null-body.md
@@ -1,0 +1,6 @@
+---
+"@lsst-sqre/semaphore-client": patch
+"squareone": patch
+---
+
+Fix broadcast parsing for broadcasts with a null body (DM-55599). The Semaphore API always includes the `body` field and sends `null` when a broadcast has no body content, but the zod `BroadcastSchema` only allowed the field to be omitted, so any broadcast with a null body failed parsing and no broadcasts were displayed. The schema now accepts a null (or omitted) body, and the broadcast banner omits the "Show more" disclosure button when there is no body to disclose. Also refreshed the Semaphore `openapi.json` to the current production schema (2.0.0).

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.test.tsx
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBanner.test.tsx
@@ -60,6 +60,28 @@ test('falls back to a generic landmark name when the summary has no text', () =>
   ).toBeInTheDocument();
 });
 
+test('shows a disclosure button when the broadcast has a body', () => {
+  render(
+    <BroadcastBanner
+      broadcast={makeBroadcast({
+        body: { gfm: 'More details here.', html: '<p>More details here.</p>' },
+      })}
+    />
+  );
+
+  expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+});
+
+test('omits the disclosure button when the body is null', () => {
+  // The live API sends body: null for broadcasts without body content
+  // (DM-55599); there is nothing extra to disclose.
+  render(<BroadcastBanner broadcast={makeBroadcast({ body: null })} />);
+
+  expect(
+    screen.queryByRole('button', { name: /show more/i })
+  ).not.toBeInTheDocument();
+});
+
 test('does not carry its own live-region role', () => {
   // Live-region semantics live on the persistent containers rendered by
   // BroadcastBannerStack, which exist in the DOM before the fetch resolves.

--- a/packages/semaphore-client/openapi.json
+++ b/packages/semaphore-client/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Semaphore",
     "description": "Semaphore is the user message and notification system for the Rubin Science Platform.\n\nYou can find Semaphore's user and developer documentation at [https://semaphore.lsst.io](https://semaphore.lsst.io). Semaphore is developed at [https://github.com/lsst-sqre/semaphore](https://github.com/lsst-sqre/semaphore)",
-    "version": "0.1.dev1+g482752235"
+    "version": "2.0.0"
   },
   "paths": {
     "/": {
@@ -268,12 +268,12 @@
         }
       }
     },
-    "/semaphore/v1/notifications": {
+    "/semaphore/v1/notifications/messages": {
       "get": {
         "tags": ["notifications"],
         "summary": "List notifications",
         "description": "List all current notifications for the authenticated user.",
-        "operationId": "list_notifications_semaphore_v1_notifications_get",
+        "operationId": "list_notifications_semaphore_v1_notifications_messages_get",
         "parameters": [
           {
             "name": "cursor",
@@ -328,7 +328,7 @@
                   "items": {
                     "$ref": "#/components/schemas/UserNotificationSummary"
                   },
-                  "title": "Response List Notifications Semaphore V1 Notifications Get"
+                  "title": "Response List Notifications Semaphore V1 Notifications Messages Get"
                 }
               }
             }
@@ -344,12 +344,12 @@
         }
       }
     },
-    "/semaphore/v1/notifications/{id}": {
+    "/semaphore/v1/notifications/messages/{id}": {
       "get": {
         "tags": ["notifications"],
-        "summary": "Get admin notification",
-        "description": "Retrieve a specific admin notification.",
-        "operationId": "get_notification_semaphore_v1_notifications__id__get",
+        "summary": "Get notification",
+        "description": "Retrieve a specific notification.",
+        "operationId": "get_notification_semaphore_v1_notifications_messages__id__get",
         "parameters": [
           {
             "name": "id",
@@ -396,6 +396,231 @@
         },
         "responses": {
           "204": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/semaphore/v1/notifications/unread": {
+      "post": {
+        "tags": ["notifications"],
+        "summary": "Mark notifications unread",
+        "description": "Mark a list of notifications unread. Notifications that do not exist or that are not marked as read are silently ignored. Returning errors for nonexistent notifications is not useful since there may be race conditions with services revoking notifications.",
+        "operationId": "post_notification_unread_semaphore_v1_notifications_unread_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserNotificationUnread"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": { "description": "Successful Response" },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/semaphore/v1/services/{service}/notifications": {
+      "post": {
+        "tags": ["notifications"],
+        "summary": "Create notification",
+        "description": "Send a notification from a service to a user.",
+        "operationId": "service_create_notification_semaphore_v1_services__service__notifications_post",
+        "parameters": [
+          {
+            "name": "service",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Service" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateUserNotification"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserNotificationWithUrl"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["notifications"],
+        "summary": "List service notifications",
+        "description": "List all current notifications from a specific service.",
+        "operationId": "service_list_notifications_semaphore_v1_services__service__notifications_get",
+        "parameters": [
+          {
+            "name": "service",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Service" }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "string", "pattern": "^p?[0-9]+_[0-9]+$" },
+                { "type": "null" }
+              ],
+              "title": "Cursor",
+              "description": "Pagination cursor",
+              "examples": ["1614985055_4234"]
+            },
+            "description": "Pagination cursor"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "type": "integer", "minimum": 1 },
+                { "type": "null" }
+              ],
+              "title": "Row limit",
+              "description": "Maximum number of notifications to return.",
+              "examples": [500]
+            },
+            "description": "Maximum number of notifications to return."
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/UtcDatetime" },
+                { "type": "null" }
+              ],
+              "title": "Not before",
+              "description": "Only show entries at or after this time.",
+              "examples": ["2021-03-05T14:59:52Z"]
+            },
+            "description": "Only show entries at or after this time."
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                { "$ref": "#/components/schemas/UtcDatetime" },
+                { "type": "null" }
+              ],
+              "title": "Not after",
+              "description": "Only show entries before or at this time.",
+              "examples": ["2021-03-05T14:59:52Z"]
+            },
+            "description": "Only show entries before or at this time."
+          },
+          {
+            "name": "recipient",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [{ "type": "string" }, { "type": "null" }],
+              "title": "Recipient",
+              "description": "Limit notifications to this recipient.",
+              "examples": ["username"]
+            },
+            "description": "Limit notifications to this recipient."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserNotificationWithUrl"
+                  },
+                  "title": "Response Service List Notifications Semaphore V1 Services  Service  Notifications Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/semaphore/v1/services/{service}/notifications/{id}": {
+      "get": {
+        "tags": ["notifications"],
+        "summary": "Get service notification",
+        "description": "Retrieve a specific notification from a service.",
+        "operationId": "service_get_notification_semaphore_v1_services__service__notifications__id__get",
+        "parameters": [
+          {
+            "name": "service",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Service" }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string", "title": "Id" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserNotification" }
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -679,7 +904,8 @@
             "type": "array",
             "uniqueItems": true,
             "title": "Notification IDs",
-            "description": "These notifications will be marked as read at the current time if they are not already marked as read."
+            "description": "These notifications will be marked as read at the current time if they are not already marked as read.",
+            "examples": [["58", "57", "56", "59"]]
           }
         },
         "type": "object",
@@ -731,6 +957,22 @@
         "required": ["id", "created", "read", "summary", "url"],
         "title": "UserNotificationSummary",
         "description": "User notification with a formatted summary but no body.\n\nReturned in lists of notifications to display to a user. Includes a URL\nfrom which the full notification including the formatted body can be\nreturned."
+      },
+      "UserNotificationUnread": {
+        "properties": {
+          "ids": {
+            "items": { "type": "string" },
+            "type": "array",
+            "uniqueItems": true,
+            "title": "Notification IDs",
+            "description": "These notifications will be marked as unread if they are currently marked as read.",
+            "examples": [["58", "57", "56", "59"]]
+          }
+        },
+        "type": "object",
+        "required": ["ids"],
+        "title": "UserNotificationUnread",
+        "description": "Notification IDs to mark as unread."
       },
       "UserNotificationWithUrl": {
         "properties": {

--- a/packages/semaphore-client/src/client.test.ts
+++ b/packages/semaphore-client/src/client.test.ts
@@ -61,6 +61,30 @@ describe('fetchBroadcasts', () => {
     ).rejects.toThrow(SemaphoreError);
   });
 
+  it('parses broadcasts with a null body (DM-55599)', async () => {
+    const broadcastWithNullBody = {
+      active: true,
+      body: null,
+      category: 'notice',
+      enabled: true,
+      id: 'github.com/lsst-sqre/rsp_broadcast/broadcasts/110_major_change.md',
+      stale: false,
+      summary: {
+        gfm: 'Platform unavailable 2026-07-27 (Monday)',
+        html: '<p>Platform unavailable 2026-07-27 (Monday)</p>\n',
+      },
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify([broadcastWithNullBody]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const result = await fetchBroadcasts('https://example.com/semaphore');
+    expect(result).toEqual([broadcastWithNullBody]);
+  });
+
   it('throws on Zod validation error for invalid data', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify([{ id: 123, summary: 'not-an-object' }]), {

--- a/packages/semaphore-client/src/mock-broadcasts.ts
+++ b/packages/semaphore-client/src/mock-broadcasts.ts
@@ -35,7 +35,8 @@ const mockInfoBroadcast: Broadcast = {
 };
 
 /**
- * A mock notice broadcast message.
+ * A mock notice broadcast message with a null body, as sent by the live API
+ * for broadcasts without body content.
  */
 const mockNoticeBroadcast: Broadcast = {
   id: 'broadcast-003',
@@ -43,6 +44,7 @@ const mockNoticeBroadcast: Broadcast = {
     gfm: 'Please review the updated [data rights policy](https://example.com/policy).',
     html: '<p>Please review the updated <a href="https://example.com/policy">data rights policy</a>.</p>',
   },
+  body: null,
   active: true,
   enabled: true,
   stale: false,

--- a/packages/semaphore-client/src/schemas.ts
+++ b/packages/semaphore-client/src/schemas.ts
@@ -19,7 +19,9 @@ export const BroadcastCategorySchema = z.enum(['outage', 'info', 'notice']);
 export const BroadcastSchema = z.object({
   id: z.string(),
   summary: FormattedTextSchema,
-  body: FormattedTextSchema.optional(),
+  // The API always includes `body` but sends null when the broadcast has no
+  // body content; also tolerate an omitted field.
+  body: FormattedTextSchema.nullish(),
   active: z.boolean(),
   enabled: z.boolean(),
   stale: z.boolean(),


### PR DESCRIPTION
## Summary

- Allow `body` to be null in `BroadcastSchema`: the Semaphore API always includes the `body` field and sends `null` when a broadcast has no body content, but the zod schema only allowed the field to be omitted, so any null-body broadcast failed parsing with a `ZodError` and broke the entire broadcasts fetch (no banners displayed).
- The broadcast banner's "Show more" disclosure button is already guarded by `broadcast.body &&`, so it correctly stays hidden for null bodies; regression tests now lock in that behavior along with schema parsing of the exact production payload shape.
- Refreshed `packages/semaphore-client/openapi.json` from production (`0.1.dev1` → `2.0.0`), which confirms `body` is required-but-nullable; the spec's other changes (the `/v1/notifications/messages` and `/v1/notifications/unread` endpoints) are already implemented by the client, so no further regeneration was needed.

## Validation steps

- [ ] Point a local squareone at the production Semaphore (`https://data.lsst.cloud/semaphore`), which currently serves a null-body notice broadcast, and confirm the banner renders with no `ZodError` / "Failed to fetch broadcasts" in the server logs
- [ ] In the dev environment, confirm a broadcast with a body shows the "Show more" / "Show less" disclosure toggle and one without a body shows no button

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55599