### PR TITLE
DM-55604: Add @lsst-sqre/api-client-core shared client primitives

### DIFF
--- a/.changeset/api-client-core.md
+++ b/.changeset/api-client-core.md
@@ -1,0 +1,5 @@
+---
+"@lsst-sqre/api-client-core": minor
+---
+
+Add the `@lsst-sqre/api-client-core` workspace package (DM-55604): the single source of truth for the shared `Logger` type, an error classifier that distinguishes expected errors (HTTP 401/403) from report-worthy ones (ZodError contract drift, HTTP 5xx, plus server-side network failures — log-only in the browser), and a `reportingQueryFn` wrapper that returns a caller-supplied benign fallback on any failure while logging all failures and invoking an injected, Sentry-agnostic `reportError(err, context)` hook for report-worthy ones.

--- a/.changeset/reportError-broadcasts.md
+++ b/.changeset/reportError-broadcasts.md
@@ -1,0 +1,6 @@
+---
+"@lsst-sqre/semaphore-client": minor
+"squareone": minor
+---
+
+Report handled-but-critical broadcast errors to Sentry (DM-55604). The semaphore-client broadcasts `queryFn` now runs through the shared `reportingQueryFn` from `@lsst-sqre/api-client-core`: it still degrades gracefully to an empty broadcasts list on any failure, but report-worthy failures (a `ZodError` from API contract drift — the DM-55599 scenario — a 5xx, or a server-side network error) now invoke an injectable `reportError` hook, while expected auth failures (401/403) stay quiet. The squareone app supplies that hook via a new `makeReportError` in `src/lib/sentry/`, which calls `Sentry.captureException` with site/package context tags and is guarded by an in-memory dedupe window (once per session client-side, once per ~15-minute window server-side) so 60 s polling cannot flood Sentry during an outage. It is wired at both broadcast call sites: the `layout.tsx` RSC prefetch and the client-side `BroadcastBannerStack`. `@lsst-sqre/semaphore-client` now re-exports the `Logger` type from `@lsst-sqre/api-client-core` so existing imports keep compiling.

--- a/.changeset/reportError-discovery.md
+++ b/.changeset/reportError-discovery.md
@@ -1,0 +1,8 @@
+---
+"@lsst-sqre/repertoire-client": minor
+"squareone": minor
+---
+
+Report handled-but-critical service-discovery errors to Sentry (DM-55604). The repertoire-client discovery `queryFn` now runs through the shared `reportingQueryFn` from `@lsst-sqre/api-client-core`: it still degrades gracefully to an empty discovery result on any failure, but report-worthy failures (a `ZodError` from API contract drift, a 5xx, or a server-side network error) now invoke an injectable `reportError` hook, while expected auth failures (401/403) stay quiet. `discoveryQueryOptions` gains `reportError` / `context` / `isServer` config keys (mirroring `broadcastsQueryOptions`), and `@lsst-sqre/repertoire-client` re-exports the `Logger` type from `@lsst-sqre/api-client-core` so existing imports keep compiling.
+
+The squareone app's `layout.tsx` RSC prefetch now wires `makeReportError({ isServer: true })` into the discovery prefetch, and its broadcasts-prefetch `catch` no longer silently pino-logs discovery-URL-resolution failures: a new `reportPrefetchError` helper classifies the caught error and reports the report-worthy ones (including server-side network failures) to Sentry so a silent prefetch outage surfaces rather than staying hidden in the server logs.

--- a/.changeset/reportError-times-square-client.md
+++ b/.changeset/reportError-times-square-client.md
@@ -1,0 +1,9 @@
+---
+"@lsst-sqre/times-square-client": minor
+---
+
+Report handled-but-critical Times Square query and SSE errors to Sentry (DM-55604). The `githubContentsQueryOptions` and `githubPrContentsQueryOptions` factories now run through the shared `reportingQueryFn` from `@lsst-sqre/api-client-core`: they still degrade gracefully (empty nav tree / empty-PR contents on any failure), but report-worthy failures (a `ZodError` from API contract drift, a 5xx, or a server-side network error) now invoke an injectable `reportError` hook, while expected failures (401/403) stay quiet. Both factories gain `reportError` / `context` / `isServer` config keys (mirroring `broadcastsQueryOptions` and `discoveryQueryOptions`), exposed through a new `GitHubContentsQueryConfig` type; the PR-contents query folds its `owner`/`repo`/`commit` identifiers into the forwarded context so the reporter can tag the failing PR preview.
+
+`subscribeToHtmlEvents` no longer silently drops SSE events that fail `HtmlEventSchema` validation. A JSON event that fails schema parse is API contract drift, not a benign heartbeat, so it now invokes the subscription's `onError` callback with an `Error` carrying the underlying `ZodError` as `cause` — letting the app route the failure to Sentry. Non-JSON heartbeats are still ignored.
+
+`@lsst-sqre/times-square-client` now re-exports the `Logger` type from `@lsst-sqre/api-client-core` so existing imports keep compiling.

--- a/.changeset/reportError-userinfo-logininfo.md
+++ b/.changeset/reportError-userinfo-logininfo.md
@@ -1,0 +1,8 @@
+---
+"@lsst-sqre/gafaelfawr-client": minor
+"squareone": minor
+---
+
+Report handled-but-critical auth query errors to Sentry (DM-55604). The gafaelfawr-client `userInfoQueryOptions` and `loginInfoQueryOptions` now run through the shared `reportingQueryFn` from `@lsst-sqre/api-client-core`: they still degrade gracefully (empty user info / null login info on any failure, so `isLoggedIn=false` and null-login-info behavior are unchanged), but report-worthy failures (a `ZodError` from API contract drift, a 5xx, or a server-side network error) now invoke an injectable `reportError` hook, while expected auth failures (401/403) stay quiet. This means an API outage is no longer indistinguishable from "not logged in", and a silently-null `csrfToken` from a non-auth failure becomes operator-visible. Both query options gain `reportError` / `context` / `isServer` config keys (mirroring `broadcastsQueryOptions` and `discoveryQueryOptions`), exposed through a new `AuthQueryConfig` type; `@lsst-sqre/gafaelfawr-client` now re-exports the `Logger` type from `@lsst-sqre/api-client-core` so existing imports keep compiling. The `useUserInfo` and `useLoginInfo` hooks accept an optional query config and forward it to the query options.
+
+The squareone app now injects a Sentry-backed `makeReportError` reporter at the header's `Login` (user-info) and `UserMenu` (login-info) components — the app-wide chokepoints for these queries — so report-worthy auth-query failures reach Sentry tagged with `site`/`package` context.

--- a/apps/squareone/next.config.js
+++ b/apps/squareone/next.config.js
@@ -19,6 +19,7 @@ module.exports = (phase) => {
       : ['tsx', 'ts', 'jsx', 'js'],
     transpilePackages: [
       '@lsst-sqre/squared',
+      '@lsst-sqre/api-client-core',
       '@lsst-sqre/repertoire-client',
       '@lsst-sqre/gafaelfawr-client',
       '@lsst-sqre/semaphore-client',

--- a/apps/squareone/package.json
+++ b/apps/squareone/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@fontsource/source-sans-pro": "^4.5.11",
+    "@lsst-sqre/api-client-core": "workspace:*",
     "@lsst-sqre/gafaelfawr-client": "workspace:*",
     "@lsst-sqre/global-css": "workspace:*",
     "@lsst-sqre/repertoire-client": "workspace:*",

--- a/apps/squareone/src/app/api-aspect/page.tsx
+++ b/apps/squareone/src/app/api-aspect/page.tsx
@@ -5,6 +5,7 @@ import { resolveApiEndpoints } from '../../lib/apiEndpoints';
 import { getStaticConfig } from '../../lib/config/rsc';
 import logger from '../../lib/logger';
 import { commonMdxComponents, compileMdxForRsc } from '../../lib/mdx/rsc';
+import { makeReportError } from '../../lib/sentry/reportError';
 
 const pageDescription =
   'Integrate Rubin data into your analysis tools with APIs.';
@@ -30,6 +31,7 @@ export default async function ApiAspectPage() {
   const apiEndpointsResult = await resolveApiEndpoints({
     repertoireUrl: config.repertoireUrl,
     logger,
+    reportError: makeReportError({ isServer: true }),
   });
 
   // Bind the resolved listing into the <ApiEndpoints/> MDX component so the

--- a/apps/squareone/src/app/layout.tsx
+++ b/apps/squareone/src/app/layout.tsx
@@ -141,8 +141,11 @@ export default async function RootLayout({ children }: RootLayoutProps) {
     logger.debug('No repertoireUrl configured, skipping service discovery');
   }
 
-  // Compile footer MDX once at layout level
-  const footerMdxContent = await compileFooterMdxForRsc();
+  // Compile footer MDX once at layout level. A missing footer file degrades to
+  // null silently; an MDX compile error also degrades but is reported.
+  const footerMdxContent = await compileFooterMdxForRsc({
+    reportError: makeReportError({ isServer: true }),
+  });
 
   // Surface the build identity in the served HTML so a running build is
   // identifiable from the page source. Revision degrades to "unknown" when

--- a/apps/squareone/src/app/layout.tsx
+++ b/apps/squareone/src/app/layout.tsx
@@ -32,6 +32,7 @@ import { getStaticConfig } from '../lib/config/rsc';
 import logger from '../lib/logger';
 import { compileFooterMdxForRsc } from '../lib/mdx/rsc';
 import { makeReportError } from '../lib/sentry/reportError';
+import { reportPrefetchError } from '../lib/sentry/reportPrefetchError';
 import { getAppVersion } from '../lib/version';
 import FooterRsc from './FooterRsc';
 import PlausibleWrapper from './PlausibleWrapper';
@@ -92,7 +93,12 @@ export default async function RootLayout({ children }: RootLayoutProps) {
   if (config.repertoireUrl) {
     logger.debug('Prefetching service discovery');
     await queryClient.prefetchQuery(
-      discoveryQueryOptions(config.repertoireUrl, { logger })
+      discoveryQueryOptions(config.repertoireUrl, {
+        logger,
+        isServer: true,
+        reportError: makeReportError({ isServer: true }),
+        context: { site: 'service-discovery', package: 'repertoire-client' },
+      })
     );
     const cachedData = queryClient.getQueryData([
       'service-discovery',
@@ -120,7 +126,16 @@ export default async function RootLayout({ children }: RootLayoutProps) {
         );
       }
     } catch (error) {
+      // This catch guards the discovery-URL resolution feeding the broadcasts
+      // prefetch (the raw `fetchServiceDiscovery` + `getSemaphoreUrl`). Log
+      // every failure, then report the report-worthy ones (contract drift,
+      // 5xx, and — server-side — network failures) so a silent prefetch
+      // outage still surfaces in Sentry rather than only in pino logs.
       logger.error({ err: error }, 'Failed to prefetch broadcasts');
+      reportPrefetchError(error, {
+        site: 'broadcasts-prefetch',
+        package: 'squareone',
+      });
     }
   } else {
     logger.debug('No repertoireUrl configured, skipping service discovery');

--- a/apps/squareone/src/app/layout.tsx
+++ b/apps/squareone/src/app/layout.tsx
@@ -31,6 +31,7 @@ import { ConfigProvider } from '../contexts/rsc';
 import { getStaticConfig } from '../lib/config/rsc';
 import logger from '../lib/logger';
 import { compileFooterMdxForRsc } from '../lib/mdx/rsc';
+import { makeReportError } from '../lib/sentry/reportError';
 import { getAppVersion } from '../lib/version';
 import FooterRsc from './FooterRsc';
 import PlausibleWrapper from './PlausibleWrapper';
@@ -112,6 +113,9 @@ export default async function RootLayout({ children }: RootLayoutProps) {
           broadcastsQueryOptions(semaphoreUrl, {
             refetchInterval: 0, // Server-side: no polling
             logger,
+            isServer: true,
+            reportError: makeReportError({ isServer: true }),
+            context: { site: 'broadcasts', package: 'semaphore-client' },
           })
         );
       }

--- a/apps/squareone/src/components/BroadcastBannerStack/BroadcastBannerStack.tsx
+++ b/apps/squareone/src/components/BroadcastBannerStack/BroadcastBannerStack.tsx
@@ -1,13 +1,24 @@
 'use client';
 
 import { useBroadcasts } from '@lsst-sqre/semaphore-client';
+import { useMemo } from 'react';
 import { useSemaphoreUrl } from '@/hooks/useSemaphoreUrl';
+import { makeReportError } from '@/lib/sentry/reportError';
 import BroadcastBanner from './BroadcastBanner';
 
 export default function BroadcastBannerStack() {
   const semaphoreUrl = useSemaphoreUrl();
 
-  const { broadcasts, isPending, isError } = useBroadcasts(semaphoreUrl ?? '');
+  // Inject the app's Sentry-backed reporter so report-worthy broadcast
+  // failures (e.g. the DM-55599 ZodError) reach Sentry with site context tags.
+  // Client-side dedupe caps this at one capture per browser session despite
+  // 60 s polling.
+  const reportError = useMemo(() => makeReportError({ isServer: false }), []);
+
+  const { broadcasts, isPending, isError } = useBroadcasts(semaphoreUrl ?? '', {
+    reportError,
+    context: { site: 'broadcasts', package: 'semaphore-client' },
+  });
 
   // ARIA polite/assertive live regions only reliably announce content that is
   // inserted after the region already exists in the DOM. Because broadcasts

--- a/apps/squareone/src/components/Header/Login.tsx
+++ b/apps/squareone/src/components/Header/Login.tsx
@@ -2,8 +2,8 @@
 
 import { useUserInfo } from '@lsst-sqre/gafaelfawr-client';
 import { getLoginUrl, PrimaryNavigation } from '@lsst-sqre/squared';
-import { useEffect, useState } from 'react';
-
+import { useEffect, useMemo, useState } from 'react';
+import { makeReportError } from '@/lib/sentry/reportError';
 import { useRepertoireUrl } from '../../hooks/useRepertoireUrl';
 import styles from './Login.module.css';
 import UserMenu from './UserMenu';
@@ -15,7 +15,18 @@ type LoginProps = {
 export default function Login({ pageUrl }: LoginProps) {
   const [hasMounted, setHasMounted] = useState(false);
   const repertoireUrl = useRepertoireUrl();
-  const { isLoggedIn, isLoading } = useUserInfo(repertoireUrl);
+
+  // Inject the app's Sentry-backed reporter so report-worthy user-info failures
+  // (ZodError contract drift, 5xx, server-side network errors) reach Sentry with
+  // site context tags — making an API outage distinguishable from a genuine
+  // not-logged-in state. Auth 401/403 stay quiet (isLoggedIn=false unchanged).
+  // This header component mounts on every page, so it is the app-wide chokepoint
+  // for the user-info query.
+  const reportError = useMemo(() => makeReportError({ isServer: false }), []);
+  const { isLoggedIn, isLoading } = useUserInfo(repertoireUrl, {
+    reportError,
+    context: { site: 'user-info', package: 'gafaelfawr-client' },
+  });
 
   useEffect(() => {
     setHasMounted(true);

--- a/apps/squareone/src/components/Header/UserMenu.tsx
+++ b/apps/squareone/src/components/Header/UserMenu.tsx
@@ -11,7 +11,8 @@ import {
 } from '@lsst-sqre/squared';
 import { ChevronDown } from 'lucide-react';
 import NextLink from 'next/link';
-
+import { useMemo } from 'react';
+import { makeReportError } from '@/lib/sentry/reportError';
 import { useRepertoireUrl } from '../../hooks/useRepertoireUrl';
 import { useSemaphoreUrl } from '../../hooks/useSemaphoreUrl';
 import { useStaticConfig } from '../../hooks/useStaticConfig';
@@ -24,7 +25,18 @@ type UserMenuProps = {
 export default function UserMenu({ pageUrl }: UserMenuProps) {
   const { user } = useGafaelfawrUser();
   const repertoireUrl = useRepertoireUrl();
-  const { query } = useLoginInfo(repertoireUrl);
+
+  // Inject the app's Sentry-backed reporter so report-worthy login-info failures
+  // (ZodError contract drift, 5xx, server-side network errors) reach Sentry —
+  // making a silently-null `csrfToken` from a non-auth failure operator-visible.
+  // Auth 401/403 stay quiet (null login info unchanged). This menu mounts for
+  // every logged-in page view, so it is the app-wide chokepoint for the
+  // login-info query.
+  const reportError = useMemo(() => makeReportError({ isServer: false }), []);
+  const { query } = useLoginInfo(repertoireUrl, {
+    reportError,
+    context: { site: 'login-info', package: 'gafaelfawr-client' },
+  });
   const logoutUrl = getLogoutUrl(pageUrl.toString());
 
   const { enableUserNotifications, userNotificationsPollIntervalSeconds } =

--- a/apps/squareone/src/lib/apiEndpoints/resolve.test.ts
+++ b/apps/squareone/src/lib/apiEndpoints/resolve.test.ts
@@ -14,6 +14,7 @@ vi.mock('@lsst-sqre/repertoire-client', async (importOriginal) => {
 import {
   fetchServiceDiscovery,
   mockDiscovery,
+  RepertoireError,
 } from '@lsst-sqre/repertoire-client';
 
 import { resolveApiEndpoints } from './resolve';
@@ -63,6 +64,57 @@ describe('resolveApiEndpoints', () => {
       expect.objectContaining({ err: error }),
       expect.any(String)
     );
+  });
+
+  test('reports a report-worthy discovery failure with call-site context', async () => {
+    const reportError = vi.fn();
+    // A 5xx is report-worthy per classifyError (upstream server failure).
+    const error = new RepertoireError('discovery exploded', 503);
+    vi.mocked(fetchServiceDiscovery).mockRejectedValue(error);
+
+    const result = await resolveApiEndpoints({
+      repertoireUrl: 'https://example.org/repertoire',
+      reportError,
+    });
+
+    // UI fallback is unchanged: still 'unavailable'.
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [reported, context] = reportError.mock.calls[0];
+    expect(reported).toBe(error);
+    expect(context).toMatchObject({ site: 'api-aspect-discovery' });
+  });
+
+  test('does not report an expected discovery failure (403)', async () => {
+    const reportError = vi.fn();
+    // A 403 is expected per classifyError (auth failures are routine).
+    vi.mocked(fetchServiceDiscovery).mockRejectedValue(
+      new RepertoireError('forbidden', 403)
+    );
+
+    const result = await resolveApiEndpoints({
+      repertoireUrl: 'https://example.org/repertoire',
+      reportError,
+    });
+
+    // UI fallback is unchanged: still 'unavailable'.
+    expect(result).toEqual({ status: 'unavailable' });
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  test('reports a server-side network failure (no status code)', async () => {
+    const reportError = vi.fn();
+    vi.mocked(fetchServiceDiscovery).mockRejectedValue(
+      new TypeError('fetch failed')
+    );
+
+    await resolveApiEndpoints({
+      repertoireUrl: 'https://example.org/repertoire',
+      reportError,
+    });
+
+    // Server-side classification: network failures are report-worthy.
+    expect(reportError).toHaveBeenCalledTimes(1);
   });
 
   test('threads the logger into the discovery fetch', async () => {

--- a/apps/squareone/src/lib/apiEndpoints/resolve.ts
+++ b/apps/squareone/src/lib/apiEndpoints/resolve.ts
@@ -1,3 +1,4 @@
+import { classifyError, type ReportError } from '@lsst-sqre/api-client-core';
 import {
   fetchServiceDiscovery,
   type Logger,
@@ -11,6 +12,12 @@ export type ResolveApiEndpointsOptions = {
   repertoireUrl?: string;
   /** Optional server-side logger for recording fetch failures. */
   logger?: Logger;
+  /**
+   * Optional error reporter (e.g. Sentry) for report-worthy discovery failures.
+   * When provided, a Repertoire outage or contract drift is forwarded so it is
+   * distinguishable from an expected/quiet failure; the UI fallback is unchanged.
+   */
+  reportError?: ReportError;
 };
 
 /**
@@ -19,7 +26,9 @@ export type ResolveApiEndpointsOptions = {
  * Mirrors `HeaderNav`'s degrade-gracefully pattern:
  * - no `repertoireUrl` -> `omitted` (the page leaves the section out);
  * - a fetch/parse failure -> `unavailable` (the page shows a brief notice) and
- *   the error is logged server-side;
+ *   the error is logged server-side; report-worthy failures (a Repertoire 5xx
+ *   outage or contract drift) are additionally forwarded to `reportError` so a
+ *   real problem is distinguishable in Sentry from a quiet, expected failure;
  * - success -> `ok` with the dataset groups from the base transform.
  *
  * Uses the repertoire-client's existing 5-minute in-process discovery cache.
@@ -27,6 +36,7 @@ export type ResolveApiEndpointsOptions = {
 export async function resolveApiEndpoints({
   repertoireUrl,
   logger,
+  reportError,
 }: ResolveApiEndpointsOptions): Promise<ApiEndpointsResult> {
   if (!repertoireUrl) {
     return { status: 'omitted' };
@@ -46,6 +56,18 @@ export async function resolveApiEndpoints({
       { err: error },
       'Failed to fetch service discovery for /api-aspect'
     );
+    // Runs during RSC rendering, so classify server-side: a Repertoire 5xx,
+    // contract drift, or a network failure is report-worthy; auth/other 4xx
+    // stays expected. The UI fallback ('unavailable') is unchanged either way.
+    if (
+      reportError &&
+      classifyError(error, { isServer: true }) === 'report-worthy'
+    ) {
+      reportError(error, {
+        site: 'api-aspect-discovery',
+        package: 'squareone',
+      });
+    }
     return { status: 'unavailable' };
   }
 }

--- a/apps/squareone/src/lib/mdx/rsc/compiler.test.ts
+++ b/apps/squareone/src/lib/mdx/rsc/compiler.test.ts
@@ -1,0 +1,73 @@
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the raw MDX loader so we can simulate a missing file (throws
+// "MDX file not found: ...") versus a present file whose source then fails to
+// compile.
+vi.mock('../../config/rsc', () => ({
+  getMdxContent: vi.fn(),
+}));
+
+// Mock the MDX compiler so a syntax error can be simulated without a real MDX
+// build, and a success path can return a placeholder element.
+vi.mock('next-mdx-remote/rsc', () => ({
+  compileMDX: vi.fn(),
+}));
+
+import { compileMDX } from 'next-mdx-remote/rsc';
+import { getMdxContent } from '../../config/rsc';
+import { compileFooterMdxForRsc } from './compiler';
+
+const mockedGetMdxContent = vi.mocked(getMdxContent);
+const mockedCompileMDX = vi.mocked(compileMDX);
+
+describe('compileFooterMdxForRsc', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns null silently when the footer MDX file is missing', async () => {
+    const reportError = vi.fn();
+    mockedGetMdxContent.mockRejectedValue(
+      new Error('MDX file not found: /content/footer.mdx')
+    );
+
+    const result = await compileFooterMdxForRsc({ reportError });
+
+    expect(result).toBeNull();
+    // A missing (optional) footer file is expected — it must not be reported.
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  test('returns null AND reports when the footer MDX fails to compile', async () => {
+    const reportError = vi.fn();
+    mockedGetMdxContent.mockResolvedValue('# Footer <broken');
+    const compileError = new Error('Could not parse expression with acorn');
+    mockedCompileMDX.mockRejectedValue(compileError);
+
+    const result = await compileFooterMdxForRsc({ reportError });
+
+    // Footer still degrades gracefully to null...
+    expect(result).toBeNull();
+    // ...but a real MDX syntax error is surfaced.
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [reported, context] = reportError.mock.calls[0];
+    expect(reported).toBe(compileError);
+    expect(context).toMatchObject({ site: 'footer-mdx' });
+  });
+
+  test('returns the compiled content on success', async () => {
+    const reportError = vi.fn();
+    const element = { type: 'div' } as unknown as ReactElement;
+    mockedGetMdxContent.mockResolvedValue('# Footer');
+    mockedCompileMDX.mockResolvedValue({
+      content: element,
+      // biome-ignore lint/suspicious/noExplicitAny: test stub for compileMDX's return shape
+    } as any);
+
+    const result = await compileFooterMdxForRsc({ reportError });
+
+    expect(result).toBe(element);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/squareone/src/lib/mdx/rsc/compiler.ts
+++ b/apps/squareone/src/lib/mdx/rsc/compiler.ts
@@ -6,6 +6,7 @@
  * serialize/hydrate, RSC MDX compilation returns React elements directly.
  */
 
+import type { ReportError } from '@lsst-sqre/api-client-core';
 import { compileMDX } from 'next-mdx-remote/rsc';
 import type { ComponentType, ReactElement } from 'react';
 
@@ -81,21 +82,46 @@ export async function compileMdxForRsc(
   };
 }
 
+/** Options for {@link compileFooterMdxForRsc}. */
+export type CompileFooterMdxOptions = {
+  /**
+   * Optional error reporter (e.g. Sentry) for report-worthy footer failures.
+   * An MDX compile error is forwarded so a broken footer template surfaces;
+   * a missing (optional) footer file is never reported.
+   */
+  reportError?: ReportError;
+};
+
+/** Message prefix thrown by the base MDX loader when the file is absent. */
+const MISSING_MDX_PREFIX = 'MDX file not found:';
+
+/** True when `error` is the loader's "file absent" signal (an optional footer). */
+function isMissingMdxFileError(error: unknown): boolean {
+  return error instanceof Error && error.message.startsWith(MISSING_MDX_PREFIX);
+}
+
 /**
  * Compile footer MDX content for RSC rendering.
  *
- * Loads and compiles footer.mdx with footer-specific components.
- * Returns null if the footer MDX file is not found (graceful fallback).
+ * Loads and compiles footer.mdx with footer-specific components. The footer is
+ * optional, so a missing file yields a `null` footer silently. Any other
+ * failure — most notably an MDX compile/syntax error in a footer that *does*
+ * exist — also degrades to a `null` footer, but is reported via `reportError`
+ * so the broken template surfaces rather than vanishing quietly.
  *
- * @returns Compiled footer content or null if not found
+ * @param options - See {@link CompileFooterMdxOptions}.
+ * @returns Compiled footer content, or null if not found or unrenderable.
  *
  * @example
  * ```tsx
- * const footerContent = await compileFooterMdxForRsc();
+ * const footerContent = await compileFooterMdxForRsc({ reportError });
  * return footerContent ? footerContent : <DefaultFooter />;
  * ```
  */
-export async function compileFooterMdxForRsc(): Promise<ReactElement | null> {
+export async function compileFooterMdxForRsc(
+  options: CompileFooterMdxOptions = {}
+): Promise<ReactElement | null> {
+  const { reportError } = options;
   const { footerMdxComponents } = await import('../../utils/mdxComponents');
 
   try {
@@ -104,8 +130,13 @@ export async function compileFooterMdxForRsc(): Promise<ReactElement | null> {
       components: footerMdxComponents,
     });
     return content;
-  } catch {
-    // Graceful fallback - footer MDX is optional
+  } catch (error) {
+    // A missing footer file is expected (the footer is optional): degrade to
+    // null silently. Anything else (e.g. an MDX syntax error in a footer that
+    // exists) is a real problem — report it, but still degrade gracefully.
+    if (!isMissingMdxFileError(error)) {
+      reportError?.(error, { site: 'footer-mdx', package: 'squareone' });
+    }
     return null;
   }
 }

--- a/apps/squareone/src/lib/sentry/reportError.test.ts
+++ b/apps/squareone/src/lib/sentry/reportError.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the Sentry SDK so the capture path can be asserted without a real
+// Sentry client being initialized.
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/nextjs';
+import { __resetReportErrorDedupe, makeReportError } from './reportError';
+
+const captureException = vi.mocked(Sentry.captureException);
+
+describe('reportError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetReportErrorDedupe();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('captures the exception with site/package context tags', () => {
+    const reportError = makeReportError({ isServer: false });
+    const err = new Error('report-worthy');
+
+    reportError(err, { site: 'broadcasts', package: 'semaphore-client' });
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [captured, hint] = captureException.mock.calls[0];
+    expect(captured).toBe(err);
+    // Tags carrying the call-site context reach Sentry.
+    expect(hint).toMatchObject({
+      tags: { site: 'broadcasts', package: 'semaphore-client' },
+    });
+  });
+
+  test('client-side: dedupes to at most one capture per session', () => {
+    const reportError = makeReportError({ isServer: false });
+    const context = { site: 'broadcasts', package: 'semaphore-client' };
+
+    // Sustained failure under polling: many calls, same call site.
+    for (let i = 0; i < 10; i++) {
+      reportError(new Error('report-worthy'), context);
+    }
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  test('server-side: dedupes to one capture per ~15-minute window', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const reportError = makeReportError({ isServer: true });
+    const context = { site: 'broadcasts', package: 'semaphore-client' };
+
+    reportError(new Error('report-worthy'), context);
+    // A minute later (well inside the window) — suppressed.
+    vi.advanceTimersByTime(60_000);
+    reportError(new Error('report-worthy'), context);
+    expect(captureException).toHaveBeenCalledTimes(1);
+
+    // Past the 15-minute window — captured again.
+    vi.advanceTimersByTime(15 * 60_000);
+    reportError(new Error('report-worthy'), context);
+    expect(captureException).toHaveBeenCalledTimes(2);
+  });
+
+  test('distinct call sites dedupe independently', () => {
+    const reportError = makeReportError({ isServer: false });
+
+    reportError(new Error('report-worthy'), { site: 'broadcasts' });
+    reportError(new Error('report-worthy'), { site: 'discovery' });
+
+    expect(captureException).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/squareone/src/lib/sentry/reportError.test.ts
+++ b/apps/squareone/src/lib/sentry/reportError.test.ts
@@ -74,4 +74,60 @@ describe('reportError', () => {
 
     expect(captureException).toHaveBeenCalledTimes(2);
   });
+
+  test('distinct error classes at the same call site each capture', () => {
+    // The DM-55599 scenario: a transient failure must not mask a later,
+    // different failure mode (e.g. contract drift) at the same call site.
+    const reportError = makeReportError({ isServer: false });
+    const context = { site: 'broadcasts', package: 'semaphore-client' };
+
+    class TransientError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'TransientError';
+      }
+    }
+    class ContractError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'ContractError';
+      }
+    }
+
+    reportError(new TransientError('503'), context);
+    reportError(new ContractError('schema drift'), context);
+
+    expect(captureException).toHaveBeenCalledTimes(2);
+  });
+
+  test('identical error classes at the same call site still dedupe', () => {
+    const reportError = makeReportError({ isServer: false });
+    const context = { site: 'broadcasts', package: 'semaphore-client' };
+
+    class ContractError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'ContractError';
+      }
+    }
+
+    reportError(new ContractError('first'), context);
+    reportError(new ContractError('second'), context);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  test('non-Error throwables dedupe by their primitive type', () => {
+    const reportError = makeReportError({ isServer: false });
+    const context = { site: 'broadcasts' };
+
+    // Two distinct strings share the `string` identity → one capture.
+    reportError('boom', context);
+    reportError('kaboom', context);
+    expect(captureException).toHaveBeenCalledTimes(1);
+
+    // A different primitive type is a distinct identity → captured.
+    reportError(42, context);
+    expect(captureException).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/squareone/src/lib/sentry/reportError.ts
+++ b/apps/squareone/src/lib/sentry/reportError.ts
@@ -1,0 +1,102 @@
+// App-side `reportError` implementation injected into the shared
+// `reportingQueryFn` (from `@lsst-sqre/api-client-core`).
+//
+// It calls `Sentry.captureException` with the call-site context forwarded as
+// Sentry tags, guarded by an in-memory dedupe window so that 60 s query polling
+// cannot flood Sentry during a sustained outage:
+//
+//   - Client-side: at most once per call site per browser session (the dedupe
+//     key never expires within the page's lifetime).
+//   - Server-side: at most once per call site per ~15-minute window, so a
+//     long-running server process re-reports periodically rather than staying
+//     silent forever.
+//
+// The package that owns `reportingQueryFn` stays Sentry-agnostic; this module
+// is where the Sentry SDK dependency lives.
+
+import type { ReportContext, ReportError } from '@lsst-sqre/api-client-core';
+import * as Sentry from '@sentry/nextjs';
+
+/** Server-side dedupe window: re-report a given call site at most this often. */
+export const SERVER_DEDUPE_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * In-memory dedupe state, keyed by a stable string derived from the report
+ * context. Client-side the value is unused (presence alone suppresses); server-
+ * side it stores the last-capture timestamp so the window can expire.
+ */
+const lastReportedAt = new Map<string, number>();
+
+/**
+ * Reset the dedupe state. Exported for tests only; there is no need to call
+ * this in production code.
+ */
+export function __resetReportErrorDedupe(): void {
+  lastReportedAt.clear();
+}
+
+/**
+ * Build a stable dedupe key from a report context. Falls back to a constant so
+ * a context-free report still dedupes against itself.
+ */
+function dedupeKey(context: ReportContext): string {
+  const keys = Object.keys(context).sort();
+  if (keys.length === 0) {
+    return '__default__';
+  }
+  return keys.map((k) => `${k}=${String(context[k])}`).join('&');
+}
+
+/** Options controlling {@link makeReportError}'s runtime-dependent behavior. */
+export type MakeReportErrorOptions = {
+  /**
+   * Whether the reporter runs server-side. Server-side uses a time-boxed dedupe
+   * window; client-side dedupes once per session. Defaults to detecting the
+   * absence of a `window` global.
+   */
+  isServer?: boolean;
+};
+
+/** Detect a server (Node) runtime by the absence of the `window` global. */
+function detectIsServer(): boolean {
+  return typeof window === 'undefined';
+}
+
+/**
+ * Create a {@link ReportError} that captures report-worthy errors to Sentry,
+ * tagging each event with the call-site context and suppressing duplicates
+ * within the runtime-appropriate dedupe window.
+ *
+ * @param options - Runtime hints; see {@link MakeReportErrorOptions}.
+ * @returns A `reportError(err, context)` hook to inject into `reportingQueryFn`.
+ */
+export function makeReportError(
+  options: MakeReportErrorOptions = {}
+): ReportError {
+  const isServer = options.isServer ?? detectIsServer();
+
+  return (err: unknown, context: ReportContext = {}): void => {
+    const key = dedupeKey(context);
+    const now = Date.now();
+    const previous = lastReportedAt.get(key);
+
+    if (previous !== undefined) {
+      // Client-side: any prior capture for this key suppresses forever (session
+      // dedupe). Server-side: suppress only while inside the window.
+      if (!isServer || now - previous < SERVER_DEDUPE_WINDOW_MS) {
+        return;
+      }
+    }
+
+    lastReportedAt.set(key, now);
+
+    // Forward the call-site context as Sentry tags so events are filterable by
+    // site/package in the Sentry UI. Tag values must be primitives.
+    const tags: Record<string, string> = {};
+    for (const [k, v] of Object.entries(context)) {
+      tags[k] = String(v);
+    }
+
+    Sentry.captureException(err, { tags });
+  };
+}

--- a/apps/squareone/src/lib/sentry/reportError.ts
+++ b/apps/squareone/src/lib/sentry/reportError.ts
@@ -36,15 +36,30 @@ export function __resetReportErrorDedupe(): void {
 }
 
 /**
- * Build a stable dedupe key from a report context. Falls back to a constant so
- * a context-free report still dedupes against itself.
+ * Identify an error for deduplication purposes. Uses the error's class name
+ * (e.g. `ZodError`, `SemaphoreError`) so distinct failure modes are told apart;
+ * falls back to the primitive type for non-`Error` throwables.
  */
-function dedupeKey(context: ReportContext): string {
+function errorIdentity(err: unknown): string {
+  return err instanceof Error ? err.name : typeof err;
+}
+
+/**
+ * Build a stable dedupe key from an error and its report context. The context
+ * (site/package tags) identifies the call site; the error's class name is
+ * folded in so that distinct failure modes at the same site each capture once
+ * per window rather than the first error masking later, different ones (e.g. a
+ * transient 503 masking a later ZodError from contract drift). Falls back to a
+ * constant context component so a context-free report still dedupes against
+ * itself.
+ */
+function dedupeKey(err: unknown, context: ReportContext): string {
   const keys = Object.keys(context).sort();
-  if (keys.length === 0) {
-    return '__default__';
-  }
-  return keys.map((k) => `${k}=${String(context[k])}`).join('&');
+  const contextKey =
+    keys.length === 0
+      ? '__default__'
+      : keys.map((k) => `${k}=${String(context[k])}`).join('&');
+  return `${errorIdentity(err)}|${contextKey}`;
 }
 
 /** Options controlling {@link makeReportError}'s runtime-dependent behavior. */
@@ -76,7 +91,7 @@ export function makeReportError(
   const isServer = options.isServer ?? detectIsServer();
 
   return (err: unknown, context: ReportContext = {}): void => {
-    const key = dedupeKey(context);
+    const key = dedupeKey(err, context);
     const now = Date.now();
     const previous = lastReportedAt.get(key);
 

--- a/apps/squareone/src/lib/sentry/reportPrefetchError.test.ts
+++ b/apps/squareone/src/lib/sentry/reportPrefetchError.test.ts
@@ -1,0 +1,52 @@
+import { RepertoireError } from '@lsst-sqre/repertoire-client';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the Sentry SDK so the capture path can be asserted without a real
+// Sentry client being initialized.
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/nextjs';
+import { __resetReportErrorDedupe } from './reportError';
+import { reportPrefetchError } from './reportPrefetchError';
+
+const captureException = vi.mocked(Sentry.captureException);
+
+describe('reportPrefetchError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetReportErrorDedupe();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('reports a 5xx RepertoireError with the call-site context', () => {
+    const err = new RepertoireError('boom', 503);
+
+    reportPrefetchError(err, { site: 'broadcasts-prefetch' });
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [captured, hint] = captureException.mock.calls[0];
+    expect(captured).toBe(err);
+    expect(hint).toMatchObject({ tags: { site: 'broadcasts-prefetch' } });
+  });
+
+  test('reports a server-side network failure (no status code)', () => {
+    reportPrefetchError(new TypeError('fetch failed'), {
+      site: 'broadcasts-prefetch',
+    });
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  test('stays quiet on an expected auth failure (403)', () => {
+    reportPrefetchError(new RepertoireError('forbidden', 403), {
+      site: 'broadcasts-prefetch',
+    });
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/apps/squareone/src/lib/sentry/reportPrefetchError.ts
+++ b/apps/squareone/src/lib/sentry/reportPrefetchError.ts
@@ -1,0 +1,33 @@
+// Server-side reporting for RSC prefetch failures in `layout.tsx`.
+//
+// The root layout prefetches service discovery and broadcasts during
+// server-side rendering. Some of those failures are handled inline (via the
+// shared `reportingQueryFn` in the client packages), but the discovery-URL
+// resolution feeding the broadcasts prefetch runs a raw `fetchServiceDiscovery`
+// inside a `try/catch` that previously only pino-logged. This helper classifies
+// such a caught error and, when it is report-worthy (contract drift, 5xx, or —
+// server-side — a network failure), forwards it to Sentry so a silent prefetch
+// outage still surfaces rather than living only in the server logs.
+
+import { classifyError, type ReportContext } from '@lsst-sqre/api-client-core';
+import { makeReportError } from './reportError';
+
+/**
+ * Report a server-side prefetch failure to Sentry when it is report-worthy.
+ *
+ * Always runs with `isServer: true`: this path only executes during RSC
+ * rendering, so network-level failures are report-worthy (unlike in the
+ * browser, where transient connectivity loss is routine). Expected failures
+ * (401/403, other 4xx) are classified out and never reported.
+ *
+ * @param error - The caught error (typed `unknown`, as caught errors are).
+ * @param context - Call-site tags forwarded to the reporter (e.g. `{ site }`).
+ */
+export function reportPrefetchError(
+  error: unknown,
+  context: ReportContext
+): void {
+  if (classifyError(error, { isServer: true }) === 'report-worthy') {
+    makeReportError({ isServer: true })(error, context);
+  }
+}

--- a/packages/api-client-core/eslint.config.mjs
+++ b/packages/api-client-core/eslint.config.mjs
@@ -1,0 +1,10 @@
+import eslintConfig from '@lsst-sqre/eslint-config';
+
+export default [
+  ...eslintConfig,
+  {
+    rules: {
+      '@next/next/no-html-link-for-pages': 'off',
+    },
+  },
+];

--- a/packages/api-client-core/package.json
+++ b/packages/api-client-core/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@lsst-sqre/api-client-core",
+  "description": "Shared primitives for Rubin Science Platform API client packages: the Logger type, error classification, and a reporting query-function wrapper",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src/**"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "test": "vitest run",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint . --ext .ts,.tsx",
+    "clean": "rm -rf node_modules"
+  },
+  "dependencies": {
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@lsst-sqre/eslint-config": "workspace:*",
+    "@lsst-sqre/tsconfig": "workspace:*",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/api-client-core/src/errors.test.ts
+++ b/packages/api-client-core/src/errors.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { classifyError } from './errors';
+
+/** A minimal HTTP-style error carrying a numeric statusCode, mirroring the
+ * `SemaphoreError` / `RepertoireError` shape used across the client packages. */
+class HttpError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+/** Produce a genuine ZodError by parsing invalid data against a schema. */
+function makeZodError(): z.ZodError {
+  const result = z.object({ name: z.string() }).safeParse({ name: 123 });
+  if (result.success) {
+    throw new Error('expected the schema parse to fail');
+  }
+  return result.error;
+}
+
+describe('classifyError', () => {
+  it('classifies HTTP 401 as expected', () => {
+    expect(classifyError(new HttpError('unauthorized', 401))).toBe('expected');
+  });
+
+  it('classifies HTTP 403 as expected', () => {
+    expect(classifyError(new HttpError('forbidden', 403))).toBe('expected');
+  });
+
+  it('classifies a ZodError as report-worthy', () => {
+    expect(classifyError(makeZodError())).toBe('report-worthy');
+  });
+
+  it('classifies HTTP 500 as report-worthy', () => {
+    expect(classifyError(new HttpError('server error', 500))).toBe(
+      'report-worthy'
+    );
+  });
+
+  it('classifies HTTP 503 as report-worthy', () => {
+    expect(classifyError(new HttpError('unavailable', 503))).toBe(
+      'report-worthy'
+    );
+  });
+
+  it('classifies a network error as report-worthy on the server', () => {
+    const err = new TypeError('fetch failed');
+    expect(classifyError(err, { isServer: true })).toBe('report-worthy');
+  });
+
+  it('classifies a network error as expected in the browser', () => {
+    const err = new TypeError('fetch failed');
+    expect(classifyError(err, { isServer: false })).toBe('expected');
+  });
+
+  it('treats a non-5xx, non-auth HTTP error (404) as expected', () => {
+    expect(classifyError(new HttpError('not found', 404))).toBe('expected');
+  });
+});

--- a/packages/api-client-core/src/errors.ts
+++ b/packages/api-client-core/src/errors.ts
@@ -1,0 +1,94 @@
+import { ZodError } from 'zod';
+
+/**
+ * The two-way classification of a caught error.
+ *
+ * - `expected` — a routine, non-alarming failure (e.g. an auth 401/403). These
+ *   are logged for diagnostics but must not page anyone.
+ * - `report-worthy` — a failure that indicates a real problem worth surfacing to
+ *   an error reporter (e.g. Sentry): API contract drift (a {@link ZodError}), a
+ *   server-side 5xx, or — server-side only — a network-level failure.
+ */
+export type ErrorClassification = 'expected' | 'report-worthy';
+
+/** Options controlling {@link classifyError}'s runtime-dependent behavior. */
+export type ClassifyErrorOptions = {
+  /**
+   * Whether classification is running server-side. Network-level failures are
+   * report-worthy on the server but only log-worthy (`expected`) in the browser,
+   * where transient connectivity loss is routine and not actionable. Defaults to
+   * detecting the absence of a `window` global.
+   */
+  isServer?: boolean;
+};
+
+/** Detect a server (Node) runtime by the absence of the `window` global. */
+function detectIsServer(): boolean {
+  return typeof window === 'undefined';
+}
+
+/**
+ * Read a numeric HTTP status code from an error, if it exposes one.
+ *
+ * The Rubin client packages' error classes (`SemaphoreError`, `RepertoireError`,
+ * …) carry an optional `statusCode` field; this duck-types on that shape without
+ * depending on any one class.
+ */
+function getStatusCode(err: unknown): number | undefined {
+  if (
+    typeof err === 'object' &&
+    err !== null &&
+    'statusCode' in err &&
+    typeof (err as { statusCode: unknown }).statusCode === 'number'
+  ) {
+    return (err as { statusCode: number }).statusCode;
+  }
+  return undefined;
+}
+
+/**
+ * Classify a caught error as `expected` (log-only) or `report-worthy`
+ * (log-and-report).
+ *
+ * Rules, in order:
+ * 1. HTTP 401 / 403 → `expected` (auth failures are routine).
+ * 2. A {@link ZodError} → `report-worthy` (API contract drift).
+ * 3. HTTP 5xx → `report-worthy` (upstream server failure).
+ * 4. Any other HTTP status (e.g. 404, 400) → `expected`.
+ * 5. A network-level failure (no numeric status code and not a ZodError — e.g. a
+ *    fetch `TypeError` or a timeout) → `report-worthy` server-side,
+ *    `expected` in the browser.
+ *
+ * @param err - The caught error (typed `unknown`, as caught errors are).
+ * @param options - Runtime hints; see {@link ClassifyErrorOptions}.
+ * @returns The error's {@link ErrorClassification}.
+ */
+export function classifyError(
+  err: unknown,
+  options: ClassifyErrorOptions = {}
+): ErrorClassification {
+  const isServer = options.isServer ?? detectIsServer();
+
+  // API contract drift is always report-worthy, regardless of runtime.
+  if (err instanceof ZodError) {
+    return 'report-worthy';
+  }
+
+  const statusCode = getStatusCode(err);
+  if (statusCode !== undefined) {
+    if (statusCode === 401 || statusCode === 403) {
+      return 'expected';
+    }
+    if (statusCode >= 500) {
+      return 'report-worthy';
+    }
+    // Other HTTP statuses (404, 400, …) are expected/log-only.
+    return 'expected';
+  }
+
+  // No HTTP status and not a ZodError: treat as a network-level failure
+  // (service unreachable, fetch TypeError, timeout). Report-worthy on the
+  // server; log-only in the browser where transient connectivity loss is
+  // routine.
+  return isServer ? 'report-worthy' : 'expected';
+}

--- a/packages/api-client-core/src/index.ts
+++ b/packages/api-client-core/src/index.ts
@@ -1,0 +1,14 @@
+// Shared logger type
+
+// Error classification
+export type { ClassifyErrorOptions, ErrorClassification } from './errors';
+export { classifyError } from './errors';
+export type { Logger } from './logger';
+export { defaultLogger } from './logger';
+// Reporting query-function wrapper
+export type {
+  ReportContext,
+  ReportError,
+  ReportingQueryFnOptions,
+} from './reporting-query-fn';
+export { reportingQueryFn } from './reporting-query-fn';

--- a/packages/api-client-core/src/logger.test.ts
+++ b/packages/api-client-core/src/logger.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { defaultLogger } from './logger';
+
+describe('defaultLogger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('routes debug to console.log with message first, object second', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    defaultLogger.debug({ a: 1 }, 'hello');
+    expect(spy).toHaveBeenCalledWith('hello', { a: 1 });
+  });
+
+  it('routes warn to console.warn', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    defaultLogger.warn({ b: 2 }, 'warned');
+    expect(spy).toHaveBeenCalledWith('warned', { b: 2 });
+  });
+
+  it('routes error to console.error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    defaultLogger.error({ c: 3 }, 'failed');
+    expect(spy).toHaveBeenCalledWith('failed', { c: 3 });
+  });
+});

--- a/packages/api-client-core/src/logger.ts
+++ b/packages/api-client-core/src/logger.ts
@@ -1,0 +1,30 @@
+/**
+ * Minimal logger interface compatible with pino's calling convention.
+ *
+ * This is the single source of truth for the `Logger` type shared across the
+ * Rubin Science Platform API client packages (gafaelfawr / repertoire /
+ * semaphore / times-square). Those packages re-export this type for backward
+ * compatibility.
+ *
+ * Each method takes a structured-context object followed by a message string,
+ * matching pino's `log.error({ err }, 'message')` signature. A browser console
+ * fallback is provided by {@link defaultLogger}.
+ */
+export type Logger = {
+  debug: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+  error: (obj: Record<string, unknown>, msg: string) => void;
+};
+
+/**
+ * A console-backed {@link Logger} used when no logger is injected.
+ *
+ * Maps `debug`/`warn`/`error` onto the corresponding `console` methods,
+ * preserving the `(obj, msg)` argument order by logging the message first and
+ * the structured object second.
+ */
+export const defaultLogger: Logger = {
+  debug: (obj, msg) => console.log(msg, obj),
+  warn: (obj, msg) => console.warn(msg, obj),
+  error: (obj, msg) => console.error(msg, obj),
+};

--- a/packages/api-client-core/src/reporting-query-fn.test.ts
+++ b/packages/api-client-core/src/reporting-query-fn.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { Logger } from './logger';
+import { reportingQueryFn } from './reporting-query-fn';
+
+class HttpError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}
+
+function makeZodError(): z.ZodError {
+  const result = z.object({ name: z.string() }).safeParse({ name: 123 });
+  if (result.success) {
+    throw new Error('expected the schema parse to fail');
+  }
+  return result.error;
+}
+
+function makeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe('reportingQueryFn', () => {
+  it('returns the fetched value on success', async () => {
+    const fn = reportingQueryFn({
+      fetchFn: async () => 'ok',
+      fallback: 'fallback',
+      logger: makeLogger(),
+    });
+    await expect(fn()).resolves.toBe('ok');
+  });
+
+  it('does not log or report on success', async () => {
+    const logger = makeLogger();
+    const reportError = vi.fn();
+    const fn = reportingQueryFn({
+      fetchFn: async () => 'ok',
+      fallback: 'fallback',
+      logger,
+      reportError,
+    });
+    await fn();
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('returns the fallback when the fetch throws an expected error', async () => {
+    const fn = reportingQueryFn({
+      fetchFn: async () => {
+        throw new HttpError('unauthorized', 401);
+      },
+      fallback: 'fallback',
+      logger: makeLogger(),
+    });
+    await expect(fn()).resolves.toBe('fallback');
+  });
+
+  it('returns the fallback when the fetch throws a report-worthy error', async () => {
+    const fn = reportingQueryFn({
+      fetchFn: async () => {
+        throw makeZodError();
+      },
+      fallback: 'fallback',
+      logger: makeLogger(),
+    });
+    await expect(fn()).resolves.toBe('fallback');
+  });
+
+  it('logs every failure', async () => {
+    const logger = makeLogger();
+    const fn = reportingQueryFn({
+      fetchFn: async () => {
+        throw new HttpError('unauthorized', 401);
+      },
+      fallback: 'fallback',
+      logger,
+    });
+    await fn();
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke reportError for an expected error', async () => {
+    const reportError = vi.fn();
+    const fn = reportingQueryFn({
+      fetchFn: async () => {
+        throw new HttpError('forbidden', 403);
+      },
+      fallback: 'fallback',
+      logger: makeLogger(),
+      reportError,
+    });
+    await fn();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('invokes reportError for a report-worthy error with the caught error and context', async () => {
+    const reportError = vi.fn();
+    const err = makeZodError();
+    const fn = reportingQueryFn({
+      fetchFn: async () => {
+        throw err;
+      },
+      fallback: 'fallback',
+      logger: makeLogger(),
+      reportError,
+      context: { site: 'broadcasts', package: 'semaphore-client' },
+    });
+    await fn();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(err, {
+      site: 'broadcasts',
+      package: 'semaphore-client',
+    });
+  });
+
+  it('still logs and returns the fallback when no reportError hook is provided', async () => {
+    const logger = makeLogger();
+    const fn = reportingQueryFn({
+      fetchFn: async () => {
+        throw makeZodError();
+      },
+      fallback: 'fallback',
+      logger,
+    });
+    await expect(fn()).resolves.toBe('fallback');
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a network error as report-worthy on the server', async () => {
+    const reportError = vi.fn();
+    const fn = reportingQueryFn({
+      fetchFn: async () => {
+        throw new TypeError('fetch failed');
+      },
+      fallback: 'fallback',
+      logger: makeLogger(),
+      reportError,
+      isServer: true,
+    });
+    await fn();
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a network error as expected in the browser', async () => {
+    const reportError = vi.fn();
+    const fn = reportingQueryFn({
+      fetchFn: async () => {
+        throw new TypeError('fetch failed');
+      },
+      fallback: 'fallback',
+      logger: makeLogger(),
+      reportError,
+      isServer: false,
+    });
+    await fn();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api-client-core/src/reporting-query-fn.ts
+++ b/packages/api-client-core/src/reporting-query-fn.ts
@@ -1,0 +1,87 @@
+import { classifyError } from './errors';
+import { defaultLogger, type Logger } from './logger';
+
+/**
+ * Structured context describing the call site a failure came from.
+ *
+ * Passed through verbatim to the {@link ReportError} hook so the reporter can
+ * tag the event (e.g. with `site` and `package`). Kept as an open record so
+ * callers can attach whatever tags their reporter understands.
+ */
+export type ReportContext = Record<string, unknown>;
+
+/**
+ * Hook invoked for report-worthy failures.
+ *
+ * The package stays reporter-agnostic: an app injects an implementation (e.g.
+ * one that calls `Sentry.captureException`) rather than this package depending
+ * on any reporting SDK.
+ *
+ * @param err - The caught error, forwarded unchanged.
+ * @param context - The {@link ReportContext} supplied to {@link reportingQueryFn}.
+ */
+export type ReportError = (err: unknown, context: ReportContext) => void;
+
+/** Configuration for {@link reportingQueryFn}. */
+export type ReportingQueryFnOptions<T> = {
+  /** The underlying async fetch to run (e.g. a client's `fetchBroadcasts`). */
+  fetchFn: () => Promise<T>;
+  /**
+   * The benign value returned on *any* failure, preserving graceful
+   * degradation (e.g. an empty broadcasts list).
+   */
+  fallback: T;
+  /** Logger for all failures. Defaults to a console-backed logger. */
+  logger?: Logger;
+  /** Hook invoked only for report-worthy failures. Optional. */
+  reportError?: ReportError;
+  /** Context forwarded to {@link reportError}. */
+  context?: ReportContext;
+  /**
+   * Runtime override forwarded to the error classifier; controls whether
+   * network-level failures are report-worthy. Defaults to auto-detection.
+   */
+  isServer?: boolean;
+};
+
+/**
+ * Build a TanStack-Query-compatible `queryFn` that degrades gracefully and
+ * routes failures to logging and (for report-worthy errors) an injected
+ * reporter.
+ *
+ * On success the fetched value is returned. On *any* failure the caller-supplied
+ * `fallback` is returned so the UI keeps working, every failure is logged, and
+ * report-worthy failures (contract drift, 5xx, server-side network errors) also
+ * invoke `reportError(err, context)`. The package itself never imports a
+ * reporting SDK — `reportError` is injected by the app.
+ *
+ * @param options - See {@link ReportingQueryFnOptions}.
+ * @returns An async function suitable for use as a query function.
+ */
+export function reportingQueryFn<T>(
+  options: ReportingQueryFnOptions<T>
+): () => Promise<T> {
+  const {
+    fetchFn,
+    fallback,
+    logger = defaultLogger,
+    reportError,
+    context = {},
+    isServer,
+  } = options;
+
+  return async (): Promise<T> => {
+    try {
+      return await fetchFn();
+    } catch (err) {
+      logger.error({ err, ...context }, 'API query failed');
+
+      const classification = classifyError(err, { isServer });
+      if (classification === 'report-worthy') {
+        reportError?.(err, context);
+      }
+
+      return fallback;
+    }
+  };
+}

--- a/packages/api-client-core/tsconfig.json
+++ b/packages/api-client-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@lsst-sqre/tsconfig/react-library.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"],
+    "moduleResolution": "bundler"
+  },
+  "include": ["."],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/api-client-core/vitest.config.ts
+++ b/packages/api-client-core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/packages/gafaelfawr-client/package.json
+++ b/packages/gafaelfawr-client/package.json
@@ -28,6 +28,7 @@
     "fetch-openapi": "curl -o openapi.json https://data.lsst.cloud/auth/openapi.json"
   },
   "dependencies": {
+    "@lsst-sqre/api-client-core": "workspace:*",
     "zod": "^3.24.0"
   },
   "peerDependencies": {

--- a/packages/gafaelfawr-client/src/hooks/useLoginInfo.ts
+++ b/packages/gafaelfawr-client/src/hooks/useLoginInfo.ts
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_GAFAELFAWR_URL } from '../client';
 import { createLoginInfoQuery, type LoginInfoQuery } from '../query';
-import { loginInfoQueryOptions } from '../query-options';
+import { type AuthQueryConfig, loginInfoQueryOptions } from '../query-options';
 import type { LoginInfo } from '../schemas';
 
 import { useGafaelfawrUrl } from './useGafaelfawrUrl';
@@ -42,6 +42,11 @@ export type UseLoginInfoReturn = {
  *
  * @param repertoireUrl - Optional repertoire URL for service discovery.
  *                        If not provided, uses default Gafaelfawr URL.
+ * @param config - Optional query config. Pass `reportError` / `context` to route
+ *                 report-worthy failures (contract drift, 5xx, server-side
+ *                 network errors) to an injected reporter; auth 401/403 stay
+ *                 quiet. This makes a silently-null `csrfToken` from a non-auth
+ *                 failure operator-visible.
  *
  * @example
  * ```tsx
@@ -59,12 +64,15 @@ export type UseLoginInfoReturn = {
  * }
  * ```
  */
-export function useLoginInfo(repertoireUrl?: string): UseLoginInfoReturn {
+export function useLoginInfo(
+  repertoireUrl?: string,
+  config?: AuthQueryConfig
+): UseLoginInfoReturn {
   const gafaelfawrUrl = useGafaelfawrUrl(repertoireUrl);
   const effectiveUrl = repertoireUrl ? gafaelfawrUrl : DEFAULT_GAFAELFAWR_URL;
 
   const { data, error, isPending, isLoading, refetch } = useQuery(
-    loginInfoQueryOptions(effectiveUrl)
+    loginInfoQueryOptions(effectiveUrl, config)
   );
 
   // Create query helper if data is available

--- a/packages/gafaelfawr-client/src/hooks/useUserInfo.ts
+++ b/packages/gafaelfawr-client/src/hooks/useUserInfo.ts
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_GAFAELFAWR_URL } from '../client';
 import { createUserInfoQuery, type UserInfoQuery } from '../query';
-import { userInfoQueryOptions } from '../query-options';
+import { type AuthQueryConfig, userInfoQueryOptions } from '../query-options';
 import type { UserInfo } from '../schemas';
 
 import { useGafaelfawrUrl } from './useGafaelfawrUrl';
@@ -43,6 +43,10 @@ export type UseUserInfoReturn = {
  *
  * @param repertoireUrl - Optional repertoire URL for service discovery.
  *                        If not provided, uses default Gafaelfawr URL.
+ * @param config - Optional query config. Pass `reportError` / `context` to route
+ *                 report-worthy failures (contract drift, 5xx, server-side
+ *                 network errors) to an injected reporter; auth 401/403 stay
+ *                 quiet. The app injects a Sentry-backed reporter here.
  *
  * @example
  * ```tsx
@@ -68,12 +72,15 @@ export type UseUserInfoReturn = {
  * }
  * ```
  */
-export function useUserInfo(repertoireUrl?: string): UseUserInfoReturn {
+export function useUserInfo(
+  repertoireUrl?: string,
+  config?: AuthQueryConfig
+): UseUserInfoReturn {
   const gafaelfawrUrl = useGafaelfawrUrl(repertoireUrl);
   const effectiveUrl = repertoireUrl ? gafaelfawrUrl : DEFAULT_GAFAELFAWR_URL;
 
   const { data, error, isPending, isLoading, refetch } = useQuery(
-    userInfoQueryOptions(effectiveUrl)
+    userInfoQueryOptions(effectiveUrl, config)
   );
 
   // Determine if user is logged in based on username presence

--- a/packages/gafaelfawr-client/src/index.ts
+++ b/packages/gafaelfawr-client/src/index.ts
@@ -113,7 +113,7 @@ export { type GafaelfawrQueryKeys, gafaelfawrKeys } from './query-keys';
 // Query Options (TanStack Query Integration)
 // =============================================================================
 
-export type { Logger } from './query-options';
+export type { AuthQueryConfig, Logger } from './query-options';
 export {
   loginInfoQueryOptions,
   tokenDetailsQueryOptions,

--- a/packages/gafaelfawr-client/src/query-options.test.ts
+++ b/packages/gafaelfawr-client/src/query-options.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
+import { getEmptyUserInfo } from './client';
+import { loginInfoQueryOptions, userInfoQueryOptions } from './query-options';
+
+/**
+ * Stub `fetch` with an OK response carrying the given JSON body. A body that
+ * does not match the schema makes the client's `.parse()` throw a ZodError.
+ */
+function mockFetchJson(body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => body,
+    }))
+  );
+}
+
+/** Stub `fetch` with a non-OK HTTP response of the given status. */
+function mockFetchStatus(status: number) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: false,
+      status,
+      statusText: 'Error',
+      json: async () => ({}),
+    }))
+  );
+}
+
+/** Stub `fetch` to reject with a network-level failure (no HTTP status). */
+function mockFetchNetworkError() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    })
+  );
+}
+
+// A minimal valid UserInfo payload (matches UserInfoSchema).
+const validUserInfo = {
+  username: 'someuser',
+  name: 'Some User',
+  email: 'someuser@example.com',
+  uid: 1234,
+  gid: 1234,
+  groups: [],
+  quota: null,
+};
+
+// A minimal valid LoginInfo payload (matches LoginInfoSchema).
+const validLoginInfo = {
+  csrf: 'csrf-token-value',
+  username: 'someuser',
+  scopes: [],
+  config: { scopes: [] },
+};
+
+const baseUrl = 'https://example.com/auth/api/v1';
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('userInfoQueryOptions', () => {
+  it('returns fetched user info on success', async () => {
+    mockFetchJson(validUserInfo);
+    const opts = userInfoQueryOptions(baseUrl);
+    // biome-ignore lint/style/noNonNullAssertion: queryFn is always defined for our factory
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toMatchObject({ username: 'someuser' });
+  });
+
+  it('falls back to empty user info and does not report on a 401', async () => {
+    mockFetchStatus(401);
+    const reportError = vi.fn();
+    const opts = userInfoQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'user-info', package: 'gafaelfawr-client' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyUserInfo());
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('does not report on a 403', async () => {
+    mockFetchStatus(403);
+    const reportError = vi.fn();
+    const opts = userInfoQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'user-info' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyUserInfo());
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('invokes reportError on a 5xx and still falls back', async () => {
+    mockFetchStatus(503);
+    const reportError = vi.fn();
+    const opts = userInfoQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'user-info', package: 'gafaelfawr-client' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyUserInfo());
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [, context] = reportError.mock.calls[0];
+    expect(context).toMatchObject({
+      site: 'user-info',
+      package: 'gafaelfawr-client',
+    });
+  });
+
+  it('invokes reportError with a ZodError on contract drift and falls back', async () => {
+    // A payload missing the required `username` field makes UserInfoSchema.parse
+    // throw a ZodError — API contract drift.
+    mockFetchJson({ name: 'no username here' });
+    const reportError = vi.fn();
+    const opts = userInfoQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'user-info' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyUserInfo());
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [err] = reportError.mock.calls[0];
+    expect(err).toBeInstanceOf(ZodError);
+  });
+
+  it('reports a server-side network failure when isServer is set', async () => {
+    mockFetchNetworkError();
+    const reportError = vi.fn();
+    const opts = userInfoQueryOptions(baseUrl, {
+      reportError,
+      isServer: true,
+      context: { site: 'user-info' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyUserInfo());
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('loginInfoQueryOptions', () => {
+  it('returns fetched login info on success', async () => {
+    mockFetchJson(validLoginInfo);
+    const opts = loginInfoQueryOptions(baseUrl);
+    // biome-ignore lint/style/noNonNullAssertion: queryFn is always defined for our factory
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toMatchObject({ csrf: 'csrf-token-value' });
+  });
+
+  it('falls back to null and does not report on a 401', async () => {
+    mockFetchStatus(401);
+    const reportError = vi.fn();
+    const opts = loginInfoQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'login-info', package: 'gafaelfawr-client' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toBeNull();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('does not report on a 403', async () => {
+    mockFetchStatus(403);
+    const reportError = vi.fn();
+    const opts = loginInfoQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'login-info' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toBeNull();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('invokes reportError on a 5xx and still falls back to null', async () => {
+    mockFetchStatus(500);
+    const reportError = vi.fn();
+    const opts = loginInfoQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'login-info', package: 'gafaelfawr-client' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toBeNull();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [, context] = reportError.mock.calls[0];
+    expect(context).toMatchObject({
+      site: 'login-info',
+      package: 'gafaelfawr-client',
+    });
+  });
+
+  it('invokes reportError with a ZodError on contract drift and falls back to null', async () => {
+    // Missing the required `csrf` field → ZodError on parse.
+    mockFetchJson({ scopes: [], config: { scopes: [] } });
+    const reportError = vi.fn();
+    const opts = loginInfoQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'login-info' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toBeNull();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [err] = reportError.mock.calls[0];
+    expect(err).toBeInstanceOf(ZodError);
+  });
+
+  it('reports a server-side network failure when isServer is set', async () => {
+    mockFetchNetworkError();
+    const reportError = vi.fn();
+    const opts = loginInfoQueryOptions(baseUrl, {
+      reportError,
+      isServer: true,
+      context: { site: 'login-info' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toBeNull();
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/gafaelfawr-client/src/query-options.ts
+++ b/packages/gafaelfawr-client/src/query-options.ts
@@ -4,22 +4,14 @@
  * These factory functions return queryOptions objects that can be used
  * with useQuery or prefetched in server components.
  */
+import {
+  defaultLogger,
+  type Logger,
+  type ReportContext,
+  type ReportError,
+  reportingQueryFn,
+} from '@lsst-sqre/api-client-core';
 import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
-
-/**
- * Minimal logger interface compatible with pino's calling convention.
- */
-export type Logger = {
-  debug: (obj: Record<string, unknown>, msg: string) => void;
-  warn: (obj: Record<string, unknown>, msg: string) => void;
-  error: (obj: Record<string, unknown>, msg: string) => void;
-};
-
-const defaultLogger: Logger = {
-  debug: (obj, msg) => console.log(msg, obj),
-  warn: (obj, msg) => console.warn(msg, obj),
-  error: (obj, msg) => console.error(msg, obj),
-};
 
 import {
   DEFAULT_GAFAELFAWR_URL,
@@ -34,6 +26,32 @@ import { gafaelfawrKeys } from './query-keys';
 import type { LoginInfo, TokenInfo, UserInfo } from './schemas';
 import type { TokenHistoryFilters, TokenHistoryPage } from './types';
 
+// Re-export Logger from api-client-core so existing
+// `import { Logger } from '@lsst-sqre/gafaelfawr-client'` sites keep compiling.
+export type { Logger };
+
+/**
+ * Configuration for the auth-related query options
+ * ({@link userInfoQueryOptions}, {@link loginInfoQueryOptions}).
+ */
+export type AuthQueryConfig = {
+  logger?: Logger;
+  /**
+   * Hook invoked for report-worthy failures (contract drift, 5xx, server-side
+   * network errors). Injected by the app so this package stays Sentry-agnostic;
+   * see `@lsst-sqre/api-client-core`'s `reportingQueryFn`. Expected auth
+   * failures (401/403) never reach this hook.
+   */
+  reportError?: ReportError;
+  /** Context (e.g. `{ site, package }`) forwarded to `reportError`. */
+  context?: ReportContext;
+  /**
+   * Runtime override forwarded to the error classifier: controls whether
+   * network-level failures are report-worthy. Defaults to auto-detection.
+   */
+  isServer?: boolean;
+};
+
 // =============================================================================
 // User Info Query
 // =============================================================================
@@ -47,22 +65,27 @@ import type { TokenHistoryFilters, TokenHistoryPage } from './types';
  */
 export const userInfoQueryOptions = (
   baseUrl: string = DEFAULT_GAFAELFAWR_URL,
-  options?: { logger?: Logger }
+  options?: AuthQueryConfig
 ) => {
-  const log = options?.logger ?? defaultLogger;
+  const logger = options?.logger ?? defaultLogger;
+  const { reportError, context, isServer } = options ?? {};
 
   return queryOptions<UserInfo>({
     queryKey: gafaelfawrKeys.userInfo(),
-    queryFn: async () => {
-      try {
-        return await fetchUserInfo(baseUrl);
-      } catch (error) {
-        // Return empty user info for unauthenticated users
-        // This allows components to check isLoggedIn without handling errors
-        log.error({ err: error }, 'Failed to fetch user info');
-        return getEmptyUserInfo();
-      }
-    },
+    // Delegate to the shared reporting wrapper: it fetches, returns empty user
+    // info on any failure (so components keep checking `isLoggedIn` — an auth
+    // 401/403 stays a quiet, expected "not logged in"), logs every failure, and
+    // invokes the injected `reportError` for report-worthy ones only (ZodError
+    // contract drift, 5xx, server-side network errors). This makes an API
+    // outage distinguishable from a genuine not-logged-in state.
+    queryFn: reportingQueryFn<UserInfo>({
+      fetchFn: () => fetchUserInfo(baseUrl),
+      fallback: getEmptyUserInfo(),
+      logger,
+      reportError,
+      context,
+      isServer,
+    }),
     staleTime: 30_000, // 30 seconds
     gcTime: 5 * 60_000, // 5 minutes
     refetchOnWindowFocus: true,
@@ -81,20 +104,26 @@ export const userInfoQueryOptions = (
  */
 export const loginInfoQueryOptions = (
   baseUrl: string = DEFAULT_GAFAELFAWR_URL,
-  options?: { logger?: Logger }
+  options?: AuthQueryConfig
 ) => {
-  const log = options?.logger ?? defaultLogger;
+  const logger = options?.logger ?? defaultLogger;
+  const { reportError, context, isServer } = options ?? {};
 
   return queryOptions<LoginInfo | null>({
     queryKey: gafaelfawrKeys.loginInfo(),
-    queryFn: async () => {
-      try {
-        return await fetchLoginInfo(baseUrl);
-      } catch (error) {
-        log.error({ err: error }, 'Failed to fetch login info');
-        return null;
-      }
-    },
+    // Delegate to the shared reporting wrapper: it returns null on any failure
+    // (an auth 401/403 stays a quiet, expected null login info), logs every
+    // failure, and reports only report-worthy ones (ZodError contract drift,
+    // 5xx, server-side network errors). A silently-null `csrfToken` from a
+    // non-auth failure is thus now operator-visible in Sentry.
+    queryFn: reportingQueryFn<LoginInfo | null>({
+      fetchFn: () => fetchLoginInfo(baseUrl),
+      fallback: null,
+      logger,
+      reportError,
+      context,
+      isServer,
+    }),
     staleTime: 30_000, // 30 seconds
     gcTime: 5 * 60_000, // 5 minutes
     refetchOnWindowFocus: true,

--- a/packages/repertoire-client/package.json
+++ b/packages/repertoire-client/package.json
@@ -28,6 +28,7 @@
     "fetch-openapi": "curl -o openapi.json https://data.lsst.cloud/repertoire/openapi.json"
   },
   "dependencies": {
+    "@lsst-sqre/api-client-core": "workspace:*",
     "zod": "^3.24.0"
   },
   "peerDependencies": {

--- a/packages/repertoire-client/src/client.ts
+++ b/packages/repertoire-client/src/client.ts
@@ -1,20 +1,10 @@
+import { defaultLogger, type Logger } from '@lsst-sqre/api-client-core';
 import { DiscoverySchema, type ServiceDiscovery } from './schemas';
 
-/**
- * Minimal logger interface compatible with pino's calling convention.
- * Accepts an optional logger; defaults to console-based output.
- */
-export type Logger = {
-  debug: (obj: Record<string, unknown>, msg: string) => void;
-  warn: (obj: Record<string, unknown>, msg: string) => void;
-  error: (obj: Record<string, unknown>, msg: string) => void;
-};
-
-const defaultLogger: Logger = {
-  debug: (obj, msg) => console.log(msg, obj),
-  warn: (obj, msg) => console.warn(msg, obj),
-  error: (obj, msg) => console.error(msg, obj),
-};
+// The `Logger` type's single source of truth now lives in
+// `@lsst-sqre/api-client-core`; re-export it here so existing
+// `@lsst-sqre/repertoire-client` imports keep compiling.
+export type { Logger } from '@lsst-sqre/api-client-core';
 
 export class RepertoireError extends Error {
   constructor(

--- a/packages/repertoire-client/src/query-options.test.ts
+++ b/packages/repertoire-client/src/query-options.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
 import { clearDiscoveryCache, getEmptyDiscovery } from './client';
 import { mockDiscovery } from './mock-discovery';
 import { discoveryQueryOptions } from './query-options';
@@ -191,7 +192,7 @@ describe('discoveryQueryOptions', () => {
       consoleError.mockRestore();
     });
 
-    it('logs error with [Discovery] prefix', async () => {
+    it('logs the failure with the caught error', async () => {
       const mockFetch = vi
         .fn()
         .mockRejectedValue(new Error('Network request failed'));
@@ -206,11 +207,124 @@ describe('discoveryQueryOptions', () => {
       await queryFn(createMockContext(url));
 
       expect(consoleError).toHaveBeenCalledWith(
-        'Failed to fetch discovery',
+        'API query failed',
         expect.objectContaining({ err: expect.any(Error) })
       );
 
       consoleError.mockRestore();
+    });
+  });
+
+  describe('reportError wiring (DM-55604)', () => {
+    afterEach(() => {
+      clearDiscoveryCache();
+      vi.restoreAllMocks();
+    });
+
+    /** Stub `fetch` with an OK response carrying the given JSON body. */
+    function mockFetchJson(body: unknown) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => body,
+        }))
+      );
+    }
+
+    /** Stub `fetch` with a non-OK HTTP response of the given status. */
+    function mockFetchStatus(status: number) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          ok: false,
+          status,
+          statusText: 'Error',
+          json: async () => ({}),
+        }))
+      );
+    }
+
+    it('invokes reportError on a ZodError (contract drift) and still falls back', async () => {
+      // A payload missing the required `services` field makes
+      // DiscoverySchema.parse throw a ZodError — API contract drift.
+      mockFetchJson({ applications: ['portal'] });
+      const reportError = vi.fn();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const opts = discoveryQueryOptions('https://example.com/repertoire', {
+        reportError,
+        context: { site: 'service-discovery', package: 'repertoire-client' },
+      });
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      const result = await opts.queryFn!({} as never);
+
+      // Graceful empty-discovery fallback preserved.
+      expect(result).toEqual(getEmptyDiscovery());
+      // reportError fired with the ZodError and the site context.
+      expect(reportError).toHaveBeenCalledTimes(1);
+      const [err, context] = reportError.mock.calls[0];
+      expect(err).toBeInstanceOf(ZodError);
+      expect(context).toMatchObject({
+        site: 'service-discovery',
+        package: 'repertoire-client',
+      });
+    });
+
+    it('invokes reportError on a 5xx and still falls back', async () => {
+      mockFetchStatus(503);
+      const reportError = vi.fn();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const opts = discoveryQueryOptions('https://example.com/repertoire', {
+        reportError,
+        context: { site: 'service-discovery' },
+      });
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      const result = await opts.queryFn!({} as never);
+
+      expect(result).toEqual(getEmptyDiscovery());
+      expect(reportError).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays quiet on an expected auth failure (401)', async () => {
+      mockFetchStatus(401);
+      const reportError = vi.fn();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const opts = discoveryQueryOptions('https://example.com/repertoire', {
+        reportError,
+        context: { site: 'service-discovery' },
+      });
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      const result = await opts.queryFn!({} as never);
+
+      expect(result).toEqual(getEmptyDiscovery());
+      expect(reportError).not.toHaveBeenCalled();
+    });
+
+    it('reports a server-side network failure when isServer is set', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => {
+          throw new TypeError('fetch failed');
+        })
+      );
+      const reportError = vi.fn();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const opts = discoveryQueryOptions('https://example.com/repertoire', {
+        reportError,
+        isServer: true,
+        context: { site: 'service-discovery' },
+      });
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      const result = await opts.queryFn!({} as never);
+
+      expect(result).toEqual(getEmptyDiscovery());
+      expect(reportError).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/repertoire-client/src/query-options.ts
+++ b/packages/repertoire-client/src/query-options.ts
@@ -1,44 +1,61 @@
-import { queryOptions } from '@tanstack/react-query';
 import {
-  fetchServiceDiscovery,
-  getEmptyDiscovery,
+  defaultLogger,
   type Logger,
-} from './client';
+  type ReportContext,
+  type ReportError,
+  reportingQueryFn,
+} from '@lsst-sqre/api-client-core';
+import { queryOptions } from '@tanstack/react-query';
+import { fetchServiceDiscovery, getEmptyDiscovery } from './client';
 import type { ServiceDiscovery } from './types';
 
-const defaultLogger: Logger = {
-  debug: (obj, msg) => console.log(msg, obj),
-  warn: (obj, msg) => console.warn(msg, obj),
-  error: (obj, msg) => console.error(msg, obj),
+/** Configuration for {@link discoveryQueryOptions}. */
+export type DiscoveryQueryConfig = {
+  logger?: Logger;
+  /**
+   * Hook invoked for report-worthy failures (contract drift, 5xx, server-side
+   * network errors). Injected by the app so this package stays Sentry-agnostic;
+   * see `@lsst-sqre/api-client-core`'s `reportingQueryFn`.
+   */
+  reportError?: ReportError;
+  /** Context (e.g. `{ site, package }`) forwarded to `reportError`. */
+  context?: ReportContext;
+  /**
+   * Runtime override forwarded to the error classifier: controls whether
+   * network-level failures are report-worthy. Defaults to auto-detection.
+   */
+  isServer?: boolean;
 };
 
 export const discoveryQueryOptions = (
   repertoireUrl: string,
-  options?: { logger?: Logger }
+  options?: DiscoveryQueryConfig
 ) => {
-  const log = options?.logger ?? defaultLogger;
+  const logger = options?.logger ?? defaultLogger;
+  const { reportError, context, isServer } = options ?? {};
 
   return queryOptions({
     queryKey: ['service-discovery', repertoireUrl] as const,
-    queryFn: async (): Promise<ServiceDiscovery> => {
-      const requestId = Math.random().toString(36).substring(7);
-      const env = typeof window === 'undefined' ? 'server' : 'client';
-      log.debug({ requestId, env, repertoireUrl }, 'Discovery queryFn called');
-      try {
-        const result = await fetchServiceDiscovery(repertoireUrl, {
-          requestId,
-          logger: log,
-        });
-        log.debug(
-          { requestId, applications: result.applications },
-          'Successfully fetched discovery'
+    // Delegate to the shared reporting wrapper: it fetches, returns the empty
+    // discovery fallback on any failure (graceful degradation preserved), logs
+    // every failure, and invokes the injected `reportError` for report-worthy
+    // ones (ZodError contract drift, 5xx, server-side network errors).
+    queryFn: reportingQueryFn<ServiceDiscovery>({
+      fetchFn: () => {
+        const requestId = Math.random().toString(36).substring(7);
+        const env = typeof window === 'undefined' ? 'server' : 'client';
+        logger.debug(
+          { requestId, env, repertoireUrl },
+          'Discovery queryFn called'
         );
-        return result;
-      } catch (error) {
-        log.error({ requestId, err: error }, 'Failed to fetch discovery');
-        return getEmptyDiscovery();
-      }
-    },
+        return fetchServiceDiscovery(repertoireUrl, { requestId, logger });
+      },
+      fallback: getEmptyDiscovery(),
+      logger,
+      reportError,
+      context,
+      isServer,
+    }),
     enabled: !!repertoireUrl,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/packages/semaphore-client/package.json
+++ b/packages/semaphore-client/package.json
@@ -28,6 +28,7 @@
     "fetch-openapi": "curl -o openapi.json https://data.lsst.cloud/semaphore/openapi.json"
   },
   "dependencies": {
+    "@lsst-sqre/api-client-core": "workspace:*",
     "zod": "^3.24.0"
   },
   "peerDependencies": {

--- a/packages/semaphore-client/src/client.ts
+++ b/packages/semaphore-client/src/client.ts
@@ -19,20 +19,12 @@ import type {
   UserNotificationsPage,
 } from './types';
 
-/**
- * Minimal logger interface compatible with pino's calling convention.
- */
-export type Logger = {
-  debug: (obj: Record<string, unknown>, msg: string) => void;
-  warn: (obj: Record<string, unknown>, msg: string) => void;
-  error: (obj: Record<string, unknown>, msg: string) => void;
-};
+// The `Logger` type's single source of truth now lives in
+// `@lsst-sqre/api-client-core`; re-export it here so existing
+// `@lsst-sqre/semaphore-client` imports keep compiling.
+export type { Logger } from '@lsst-sqre/api-client-core';
 
-const defaultLogger: Logger = {
-  debug: (obj, msg) => console.log(msg, obj),
-  warn: (obj, msg) => console.warn(msg, obj),
-  error: (obj, msg) => console.error(msg, obj),
-};
+import { defaultLogger, type Logger } from '@lsst-sqre/api-client-core';
 
 export class SemaphoreError extends Error {
   constructor(

--- a/packages/semaphore-client/src/client.ts
+++ b/packages/semaphore-client/src/client.ts
@@ -1,3 +1,4 @@
+import { defaultLogger, type Logger } from '@lsst-sqre/api-client-core';
 import { z } from 'zod';
 import {
   type BroadcastsResponse,
@@ -23,8 +24,6 @@ import type {
 // `@lsst-sqre/api-client-core`; re-export it here so existing
 // `@lsst-sqre/semaphore-client` imports keep compiling.
 export type { Logger } from '@lsst-sqre/api-client-core';
-
-import { defaultLogger, type Logger } from '@lsst-sqre/api-client-core';
 
 export class SemaphoreError extends Error {
   constructor(

--- a/packages/semaphore-client/src/query-options.test.ts
+++ b/packages/semaphore-client/src/query-options.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
+import { clearBroadcastsCache } from './client';
 import { broadcastsQueryOptions } from './query-options';
 
 describe('broadcastsQueryOptions', () => {
@@ -40,5 +42,78 @@ describe('broadcastsQueryOptions', () => {
     // biome-ignore lint/style/noNonNullAssertion: test assertion
     const result = await opts.queryFn!({} as never);
     expect(result).toEqual([]);
+  });
+
+  describe('reportError wiring (DM-55599 archetype)', () => {
+    afterEach(() => {
+      clearBroadcastsCache();
+      vi.restoreAllMocks();
+    });
+
+    /** Stub `fetch` with an OK response carrying the given JSON body. */
+    function mockFetchJson(body: unknown) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => body,
+        }))
+      );
+    }
+
+    /** Stub `fetch` with a non-OK HTTP response of the given status. */
+    function mockFetchStatus(status: number) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => ({
+          ok: false,
+          status,
+          statusText: 'Error',
+          json: async () => ({}),
+        }))
+      );
+    }
+
+    it('invokes reportError on a ZodError (contract drift) and still falls back', async () => {
+      // A malformed payload makes BroadcastsResponseSchema.parse throw a
+      // ZodError — the exact DM-55599 scenario.
+      mockFetchJson({ not: 'a broadcasts array' });
+      const reportError = vi.fn();
+
+      const opts = broadcastsQueryOptions('https://example.com/semaphore', {
+        reportError,
+        context: { site: 'broadcasts', package: 'semaphore-client' },
+      });
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      const result = await opts.queryFn!({} as never);
+
+      // Graceful fallback preserved.
+      expect(result).toEqual([]);
+      // reportError fired with the ZodError and the site context.
+      expect(reportError).toHaveBeenCalledTimes(1);
+      const [err, context] = reportError.mock.calls[0];
+      expect(err).toBeInstanceOf(ZodError);
+      expect(context).toMatchObject({
+        site: 'broadcasts',
+        package: 'semaphore-client',
+      });
+    });
+
+    it('stays quiet on an expected auth failure (401)', async () => {
+      mockFetchStatus(401);
+      const reportError = vi.fn();
+
+      const opts = broadcastsQueryOptions('https://example.com/semaphore', {
+        reportError,
+        context: { site: 'broadcasts' },
+      });
+      // biome-ignore lint/style/noNonNullAssertion: test assertion
+      const result = await opts.queryFn!({} as never);
+
+      expect(result).toEqual([]);
+      expect(reportError).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/semaphore-client/src/query-options.ts
+++ b/packages/semaphore-client/src/query-options.ts
@@ -1,3 +1,8 @@
+import {
+  type ReportContext,
+  type ReportError,
+  reportingQueryFn,
+} from '@lsst-sqre/api-client-core';
 import { infiniteQueryOptions, queryOptions } from '@tanstack/react-query';
 import {
   fetchAdminNotification,
@@ -23,9 +28,24 @@ export type BroadcastsQueryConfig = {
   refetchOnWindowFocus?: boolean;
   refetchOnReconnect?: boolean;
   logger?: Logger;
+  /**
+   * Hook invoked for report-worthy failures (contract drift, 5xx, server-side
+   * network errors). Injected by the app so this package stays Sentry-agnostic;
+   * see `@lsst-sqre/api-client-core`'s `reportingQueryFn`.
+   */
+  reportError?: ReportError;
+  /** Context (e.g. `{ site, package }`) forwarded to `reportError`. */
+  context?: ReportContext;
+  /**
+   * Runtime override forwarded to the error classifier: controls whether
+   * network-level failures are report-worthy. Defaults to auto-detection.
+   */
+  isServer?: boolean;
 };
 
-const defaultConfig: Required<Omit<BroadcastsQueryConfig, 'logger'>> = {
+const defaultConfig: Required<
+  Omit<BroadcastsQueryConfig, 'logger' | 'reportError' | 'context' | 'isServer'>
+> = {
   staleTime: 60 * 1000, // 60s
   gcTime: 10 * 60 * 1000, // 10 min
   refetchInterval: 60 * 1000, // 60s polling
@@ -44,6 +64,9 @@ export const broadcastsQueryOptions = (
     refetchOnWindowFocus,
     refetchOnReconnect,
     logger: log,
+    reportError,
+    context,
+    isServer,
   } = {
     ...defaultConfig,
     ...config,
@@ -58,14 +81,18 @@ export const broadcastsQueryOptions = (
 
   return queryOptions({
     queryKey: ['broadcasts', semaphoreUrl] as const,
-    queryFn: async (): Promise<BroadcastsResponse> => {
-      try {
-        return await fetchBroadcasts(semaphoreUrl, { logger });
-      } catch (error) {
-        logger.error({ err: error }, 'Failed to fetch broadcasts');
-        return getEmptyBroadcasts();
-      }
-    },
+    // Delegate to the shared reporting wrapper: it fetches, returns the empty
+    // fallback on any failure (graceful degradation preserved), logs every
+    // failure, and invokes the injected `reportError` for report-worthy ones
+    // (ZodError contract drift, 5xx, server-side network errors).
+    queryFn: reportingQueryFn<BroadcastsResponse>({
+      fetchFn: () => fetchBroadcasts(semaphoreUrl, { logger }),
+      fallback: getEmptyBroadcasts(),
+      logger,
+      reportError,
+      context,
+      isServer,
+    }),
     enabled: !!semaphoreUrl,
     staleTime,
     gcTime,

--- a/packages/times-square-client/package.json
+++ b/packages/times-square-client/package.json
@@ -28,6 +28,7 @@
     "fetch-openapi": "curl -o openapi.json https://times-square.lsst.io/_static/openapi.json"
   },
   "dependencies": {
+    "@lsst-sqre/api-client-core": "workspace:*",
     "@microsoft/fetch-event-source": "^2.0.1",
     "zod": "^3.24.0"
   },

--- a/packages/times-square-client/src/index.ts
+++ b/packages/times-square-client/src/index.ts
@@ -133,6 +133,7 @@ export {
   createHtmlEventsUrl,
   type HtmlEventCallback,
   type SseErrorCallback,
+  SseInvalidEventError,
   type SubscribeOptions,
   subscribeToHtmlEvents,
 } from './sse';

--- a/packages/times-square-client/src/index.ts
+++ b/packages/times-square-client/src/index.ts
@@ -113,7 +113,7 @@ export { type TimesSquareQueryKeys, timesSquareKeys } from './query-keys';
 // Query Options
 // =============================================================================
 
-export type { Logger } from './query-options';
+export type { GitHubContentsQueryConfig, Logger } from './query-options';
 export {
   githubContentsQueryOptions,
   githubPageQueryOptions,

--- a/packages/times-square-client/src/query-options.test.ts
+++ b/packages/times-square-client/src/query-options.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ZodError } from 'zod';
+import { getEmptyGitHubContents, getEmptyGitHubPrContents } from './client';
+import {
+  githubContentsQueryOptions,
+  githubPrContentsQueryOptions,
+} from './query-options';
+
+/**
+ * Stub `fetch` with an OK response carrying the given JSON body. A body that
+ * does not match the schema makes the client's `.parse()` throw a ZodError.
+ */
+function mockFetchJson(body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => body,
+    }))
+  );
+}
+
+/** Stub `fetch` with a non-OK HTTP response of the given status. */
+function mockFetchStatus(status: number) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: false,
+      status,
+      statusText: 'Error',
+      json: async () => ({}),
+    }))
+  );
+}
+
+/** Stub `fetch` to reject with a network-level failure (no HTTP status). */
+function mockFetchNetworkError() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    })
+  );
+}
+
+// A minimal valid GitHub contents payload (matches GitHubContentsRootSchema).
+const validGitHubContents = { contents: [] };
+
+// A minimal valid GitHub PR contents payload (matches GitHubPrContentsSchema).
+const validGitHubPrContents = {
+  contents: [],
+  pull_requests: [],
+  yaml_check: null,
+  nbexec_check: null,
+};
+
+const baseUrl = 'https://example.com/times-square/api/v1';
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('githubContentsQueryOptions', () => {
+  it('returns fetched contents on success', async () => {
+    mockFetchJson(validGitHubContents);
+    const opts = githubContentsQueryOptions(baseUrl);
+    // biome-ignore lint/style/noNonNullAssertion: queryFn is always defined for our factory
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual({ contents: [] });
+  });
+
+  it('falls back to empty contents and does not report on a 403', async () => {
+    mockFetchStatus(403);
+    const reportError = vi.fn();
+    const opts = githubContentsQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'github-contents', package: 'times-square-client' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyGitHubContents());
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('invokes reportError on a 5xx and still falls back to empty contents', async () => {
+    mockFetchStatus(503);
+    const reportError = vi.fn();
+    const opts = githubContentsQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'github-contents', package: 'times-square-client' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyGitHubContents());
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [, context] = reportError.mock.calls[0];
+    expect(context).toMatchObject({
+      site: 'github-contents',
+      package: 'times-square-client',
+    });
+  });
+
+  it('invokes reportError with a ZodError on contract drift and falls back', async () => {
+    // A payload missing the required `contents` field makes the schema throw.
+    mockFetchJson({ not_contents: true });
+    const reportError = vi.fn();
+    const opts = githubContentsQueryOptions(baseUrl, {
+      reportError,
+      context: { site: 'github-contents' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyGitHubContents());
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [err] = reportError.mock.calls[0];
+    expect(err).toBeInstanceOf(ZodError);
+  });
+
+  it('reports a server-side network failure when isServer is set', async () => {
+    mockFetchNetworkError();
+    const reportError = vi.fn();
+    const opts = githubContentsQueryOptions(baseUrl, {
+      reportError,
+      isServer: true,
+      context: { site: 'github-contents' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyGitHubContents());
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('githubPrContentsQueryOptions', () => {
+  const owner = 'lsst-sqre';
+  const repo = 'times-square-demo';
+  const commit = 'abc123';
+
+  it('returns fetched PR contents on success', async () => {
+    mockFetchJson(validGitHubPrContents);
+    const opts = githubPrContentsQueryOptions(owner, repo, commit, baseUrl);
+    // biome-ignore lint/style/noNonNullAssertion: queryFn is always defined for our factory
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toMatchObject({ contents: [], pull_requests: [] });
+  });
+
+  it('falls back to empty PR contents and does not report on a 403', async () => {
+    mockFetchStatus(403);
+    const reportError = vi.fn();
+    const opts = githubPrContentsQueryOptions(owner, repo, commit, baseUrl, {
+      reportError,
+      context: { site: 'github-pr-contents', package: 'times-square-client' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyGitHubPrContents());
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('invokes reportError on a 5xx and still falls back to empty PR contents', async () => {
+    mockFetchStatus(500);
+    const reportError = vi.fn();
+    const opts = githubPrContentsQueryOptions(owner, repo, commit, baseUrl, {
+      reportError,
+      context: { site: 'github-pr-contents', package: 'times-square-client' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyGitHubPrContents());
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [, context] = reportError.mock.calls[0];
+    expect(context).toMatchObject({
+      site: 'github-pr-contents',
+      package: 'times-square-client',
+    });
+  });
+
+  it('invokes reportError with a ZodError on contract drift and falls back', async () => {
+    // A payload missing required fields makes the schema throw.
+    mockFetchJson({ not_contents: true });
+    const reportError = vi.fn();
+    const opts = githubPrContentsQueryOptions(owner, repo, commit, baseUrl, {
+      reportError,
+      context: { site: 'github-pr-contents' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyGitHubPrContents());
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [err] = reportError.mock.calls[0];
+    expect(err).toBeInstanceOf(ZodError);
+  });
+
+  it('reports a server-side network failure when isServer is set', async () => {
+    mockFetchNetworkError();
+    const reportError = vi.fn();
+    const opts = githubPrContentsQueryOptions(owner, repo, commit, baseUrl, {
+      reportError,
+      isServer: true,
+      context: { site: 'github-pr-contents' },
+    });
+    // biome-ignore lint/style/noNonNullAssertion: test assertion
+    const result = await opts.queryFn!({} as never);
+
+    expect(result).toEqual(getEmptyGitHubPrContents());
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/times-square-client/src/query-options.ts
+++ b/packages/times-square-client/src/query-options.ts
@@ -4,22 +4,14 @@
  * These factory functions return queryOptions objects that can be used
  * with useQuery or prefetched in server components.
  */
+import {
+  defaultLogger,
+  type Logger,
+  type ReportContext,
+  type ReportError,
+  reportingQueryFn,
+} from '@lsst-sqre/api-client-core';
 import { queryOptions } from '@tanstack/react-query';
-
-/**
- * Minimal logger interface compatible with pino's calling convention.
- */
-export type Logger = {
-  debug: (obj: Record<string, unknown>, msg: string) => void;
-  warn: (obj: Record<string, unknown>, msg: string) => void;
-  error: (obj: Record<string, unknown>, msg: string) => void;
-};
-
-const defaultLogger: Logger = {
-  debug: (obj, msg) => console.log(msg, obj),
-  warn: (obj, msg) => console.warn(msg, obj),
-  error: (obj, msg) => console.error(msg, obj),
-};
 
 import {
   DEFAULT_TIMES_SQUARE_URL,
@@ -42,6 +34,32 @@ import type {
   Page,
   PageSummary,
 } from './schemas';
+
+// Re-export Logger from api-client-core so existing
+// `import { Logger } from '@lsst-sqre/times-square-client'` sites keep compiling.
+export type { Logger };
+
+/**
+ * Configuration for the GitHub-contents query options
+ * ({@link githubContentsQueryOptions}, {@link githubPrContentsQueryOptions}).
+ */
+export type GitHubContentsQueryConfig = {
+  logger?: Logger;
+  /**
+   * Hook invoked for report-worthy failures (contract drift, 5xx, server-side
+   * network errors). Injected by the app so this package stays Sentry-agnostic;
+   * see `@lsst-sqre/api-client-core`'s `reportingQueryFn`. Expected failures
+   * (401/403) never reach this hook.
+   */
+  reportError?: ReportError;
+  /** Context (e.g. `{ site, package }`) forwarded to `reportError`. */
+  context?: ReportContext;
+  /**
+   * Runtime override forwarded to the error classifier: controls whether
+   * network-level failures are report-worthy. Defaults to auto-detection.
+   */
+  isServer?: boolean;
+};
 
 // =============================================================================
 // Page Queries
@@ -154,20 +172,26 @@ export const htmlStatusUrlQueryOptions = (
  */
 export const githubContentsQueryOptions = (
   baseUrl: string = DEFAULT_TIMES_SQUARE_URL,
-  options?: { logger?: Logger }
+  options?: GitHubContentsQueryConfig
 ) => {
-  const log = options?.logger ?? defaultLogger;
+  const logger = options?.logger ?? defaultLogger;
+  const { reportError, context, isServer } = options ?? {};
 
   return queryOptions<GitHubContentsRoot>({
     queryKey: timesSquareKeys.githubContents(),
-    queryFn: async () => {
-      try {
-        return await fetchGitHubContents(baseUrl);
-      } catch (error) {
-        log.error({ err: error }, 'Failed to fetch GitHub contents');
-        return getEmptyGitHubContents();
-      }
-    },
+    // Delegate to the shared reporting wrapper: it returns empty contents on
+    // any failure (preserving the graceful-degradation nav tree), logs every
+    // failure, and invokes the injected `reportError` only for report-worthy
+    // ones (ZodError contract drift, 5xx, server-side network errors) — so a
+    // Times Square outage no longer silently collapses the nav tree.
+    queryFn: reportingQueryFn<GitHubContentsRoot>({
+      fetchFn: () => fetchGitHubContents(baseUrl),
+      fallback: getEmptyGitHubContents(),
+      logger,
+      reportError,
+      context,
+      isServer,
+    }),
     enabled: !!baseUrl,
     staleTime: 30_000, // 30 seconds
     gcTime: 5 * 60_000, // 5 minutes
@@ -215,23 +239,27 @@ export const githubPrContentsQueryOptions = (
   repo: string,
   commit: string,
   baseUrl: string = DEFAULT_TIMES_SQUARE_URL,
-  options?: { logger?: Logger }
+  options?: GitHubContentsQueryConfig
 ) => {
-  const log = options?.logger ?? defaultLogger;
+  const logger = options?.logger ?? defaultLogger;
+  const { reportError, context, isServer } = options ?? {};
 
   return queryOptions<GitHubPrContents>({
     queryKey: timesSquareKeys.githubPrContents(owner, repo, commit),
-    queryFn: async () => {
-      try {
-        return await fetchGitHubPrContents(baseUrl, owner, repo, commit);
-      } catch (error) {
-        log.error(
-          { err: error, owner, repo, commit },
-          'Failed to fetch GitHub PR contents'
-        );
-        return getEmptyGitHubPrContents();
-      }
-    },
+    // Delegate to the shared reporting wrapper: it returns empty PR contents on
+    // any failure (preserving the graceful-degradation empty-PR view), logs
+    // every failure, and invokes the injected `reportError` only for
+    // report-worthy ones (ZodError contract drift, 5xx, server-side network
+    // errors). The `owner`/`repo`/`commit` identifiers ride along in the
+    // forwarded context so the reporter can tag the failing PR preview.
+    queryFn: reportingQueryFn<GitHubPrContents>({
+      fetchFn: () => fetchGitHubPrContents(baseUrl, owner, repo, commit),
+      fallback: getEmptyGitHubPrContents(),
+      logger,
+      reportError,
+      context: { owner, repo, commit, ...context },
+      isServer,
+    }),
     enabled: !!owner && !!repo && !!commit && !!baseUrl,
     staleTime: 10_000, // 10 seconds
     gcTime: 5 * 60_000, // 5 minutes

--- a/packages/times-square-client/src/sse.test.ts
+++ b/packages/times-square-client/src/sse.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the options passed to fetchEventSource so tests can drive its
+// handlers (onmessage/onopen/onerror) directly without a real network call.
+const fetchEventSourceMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@microsoft/fetch-event-source', () => ({
+  fetchEventSource: fetchEventSourceMock,
+}));
+
+import { subscribeToHtmlEvents } from './sse';
+
+/** The options object handed to the most recent fetchEventSource call. */
+function lastFetchEventSourceOptions() {
+  const calls = fetchEventSourceMock.mock.calls;
+  return calls[calls.length - 1][1] as {
+    onmessage: (event: { data: string }) => void;
+    onopen: (response: Response) => Promise<void>;
+    onerror: (error: unknown) => void;
+  };
+}
+
+// A valid HtmlEvent payload (matches HtmlEventSchema).
+const validHtmlEvent = {
+  date_submitted: '2025-01-01T00:00:00Z',
+  date_started: '2025-01-01T00:00:01Z',
+  date_finished: null,
+  execution_status: 'in_progress',
+  execution_duration: null,
+  html_hash: null,
+  html_url: 'https://example.com/html',
+};
+
+beforeEach(() => {
+  fetchEventSourceMock.mockReset();
+  // fetchEventSource returns a promise that resolves when the stream ends.
+  fetchEventSourceMock.mockResolvedValue(undefined);
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('subscribeToHtmlEvents onmessage', () => {
+  it('delivers a schema-valid event to onEvent', () => {
+    const onEvent = vi.fn();
+    subscribeToHtmlEvents('https://example.com/events', undefined, { onEvent });
+
+    const { onmessage } = lastFetchEventSourceOptions();
+    onmessage({ data: JSON.stringify(validHtmlEvent) });
+
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent.mock.calls[0][0]).toMatchObject({
+      execution_status: 'in_progress',
+    });
+  });
+
+  it('ignores non-JSON events (heartbeats) without calling onError', () => {
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent,
+      onError,
+    });
+
+    const { onmessage } = lastFetchEventSourceOptions();
+    onmessage({ data: 'not json at all' });
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('invokes onError with an Error when a JSON event fails schema parse', () => {
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent,
+      onError,
+    });
+
+    const { onmessage } = lastFetchEventSourceOptions();
+    // Valid JSON, but not a valid HtmlEvent (missing required fields).
+    onmessage({ data: JSON.stringify({ unexpected: 'shape' }) });
+
+    expect(onEvent).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+});

--- a/packages/times-square-client/src/sse.test.ts
+++ b/packages/times-square-client/src/sse.test.ts
@@ -8,7 +8,7 @@ vi.mock('@microsoft/fetch-event-source', () => ({
   fetchEventSource: fetchEventSourceMock,
 }));
 
-import { subscribeToHtmlEvents } from './sse';
+import { SseInvalidEventError, subscribeToHtmlEvents } from './sse';
 
 /** The options object handed to the most recent fetchEventSource call. */
 function lastFetchEventSourceOptions() {
@@ -71,7 +71,7 @@ describe('subscribeToHtmlEvents onmessage', () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
-  it('invokes onError with an Error when a JSON event fails schema parse', () => {
+  it('invokes onError with an SseInvalidEventError when a JSON event fails schema parse', () => {
     const onEvent = vi.fn();
     const onError = vi.fn();
     subscribeToHtmlEvents('https://example.com/events', undefined, {
@@ -85,6 +85,32 @@ describe('subscribeToHtmlEvents onmessage', () => {
 
     expect(onEvent).not.toHaveBeenCalled();
     expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    const reported = onError.mock.calls[0][0];
+    // Event-level validation failures use the named, non-fatal subtype so
+    // consumers can distinguish them from connection-level errors.
+    expect(reported).toBeInstanceOf(SseInvalidEventError);
+    expect(reported.name).toBe('SseInvalidEventError');
+    // The originating ZodError rides along as `cause` for the classifier.
+    expect(reported.cause).toBeDefined();
+  });
+
+  it('fires onError once per invalid event (non-fatal, may repeat)', () => {
+    const onEvent = vi.fn();
+    const onError = vi.fn();
+    subscribeToHtmlEvents('https://example.com/events', undefined, {
+      onEvent,
+      onError,
+    });
+
+    const { onmessage } = lastFetchEventSourceOptions();
+    // A drifted stream emits several invalid events; each surfaces once and the
+    // subscription is not torn down between them.
+    onmessage({ data: JSON.stringify({ unexpected: 'shape' }) });
+    onmessage({ data: JSON.stringify({ still: 'wrong' }) });
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    for (const call of onError.mock.calls) {
+      expect(call[0]).toBeInstanceOf(SseInvalidEventError);
+    }
   });
 });

--- a/packages/times-square-client/src/sse.ts
+++ b/packages/times-square-client/src/sse.ts
@@ -16,7 +16,33 @@ import { type HtmlEvent, HtmlEventSchema } from './schemas';
 export type HtmlEventCallback = (event: HtmlEvent) => void;
 
 /**
+ * Error raised for a single SSE event whose JSON fails schema validation.
+ *
+ * Distinct from connection-level errors (which arrive as plain `Error`s from
+ * `onopen`/`onerror`) so a consumer can tell an event-level contract-drift
+ * problem apart from a transport failure. Crucially, an `SseInvalidEventError`
+ * is **non-fatal**: the SSE stream stays open, and a server emitting a run of
+ * drifted events will trigger `onError` once per invalid event. Consumers must
+ * therefore treat this subtype as non-terminal — do not tear down or reconnect
+ * the subscription on it — and are responsible for throttling any downstream
+ * side effect (e.g. Sentry capture) so a noisy stream cannot flood. The
+ * originating `ZodError` is attached as `cause`.
+ */
+export class SseInvalidEventError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'SseInvalidEventError';
+  }
+}
+
+/**
  * Callback invoked when an error occurs.
+ *
+ * May fire more than once over a subscription's lifetime. Connection-level
+ * failures arrive as plain `Error`s; per-event schema-validation failures
+ * arrive as {@link SseInvalidEventError} (non-fatal — see its docs). Consumers
+ * that treat `onError` as a fatal/connection signal should check the error
+ * subtype before acting.
  */
 export type SseErrorCallback = (error: Error) => void;
 
@@ -128,13 +154,18 @@ export function subscribeToHtmlEvents(
         }
         // A JSON event that fails schema validation is API contract drift, not
         // a benign heartbeat. Surface it through onError (rather than silently
-        // dropping it) so the app can route it to Sentry via a report hook. The
-        // ZodError is attached as `cause` so the reporter's error classifier can
-        // still see it while onError keeps its `Error` contract.
+        // dropping it) so the app can route it to Sentry via a report hook. It
+        // is emitted as a named `SseInvalidEventError` subtype so consumers can
+        // distinguish it from connection-level errors and treat it as non-fatal
+        // (the stream stays open); note this may fire once per invalid event on
+        // a drifted stream, so consumers should throttle any downstream capture.
+        // The ZodError is attached as `cause` so the reporter's error classifier
+        // can still see it while onError keeps its `Error` contract.
         onError?.(
-          new Error('Invalid SSE event data: schema validation failed', {
-            cause: result.error,
-          })
+          new SseInvalidEventError(
+            'Invalid SSE event data: schema validation failed',
+            { cause: result.error }
+          )
         );
         return;
       }

--- a/packages/times-square-client/src/sse.ts
+++ b/packages/times-square-client/src/sse.ts
@@ -126,6 +126,16 @@ export function subscribeToHtmlEvents(
         } else {
           console.warn('[TimesSquare SSE] Invalid event data:', result.error);
         }
+        // A JSON event that fails schema validation is API contract drift, not
+        // a benign heartbeat. Surface it through onError (rather than silently
+        // dropping it) so the app can route it to Sentry via a report hook. The
+        // ZodError is attached as `cause` so the reporter's error classifier can
+        // still see it while onError keeps its `Error` contract.
+        onError?.(
+          new Error('Invalid SSE event data: schema validation failed', {
+            cause: result.error,
+          })
+        );
         return;
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,25 @@ importers:
         specifier: 0.1.0
         version: 0.1.0(vitest@4.1.8)
 
+  packages/api-client-core:
+    dependencies:
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@lsst-sqre/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@lsst-sqre/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.6(@types/node@25.2.3)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))
+
   packages/eslint-config:
     dependencies:
       eslint-config-next:
@@ -842,28 +861,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.14':
     resolution: {integrity: sha512-KT67FKfzIw6DNnUNdYlBg+eU24Go3n75GWK6NwU4+yJmDYFe9i/MjiI+U/iEzKvo0g7G7MZqoyrhIYuND2w8QQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.14':
     resolution: {integrity: sha512-KQU7EkbBBuHPW3/rAcoiVmhlPtDSGOGRPv9js7qJVpYTzjQmVR+C9Rfcz+ti8YCH+zT1J52tuBybtP4IodjxZQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.14':
     resolution: {integrity: sha512-ZsZzQsl9U+wxFrGGS4f6UxREUlgHwmEfu1IrXlgNFrNnd5Th6lIJr8KmSzu/+meSa9f4rzFrbEW9LBBA6ScoMA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.14':
     resolution: {integrity: sha512-+IKYkj/pUBbnRf1G1+RlyA3LWiDgra1xpS7H2g4BuOzzRbRB+hmlw0yFsLprHhbbt7jUzbzAbAjK/Pn0FDnh1A==}
@@ -1280,105 +1295,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1661,28 +1660,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.10':
     resolution: {integrity: sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.10':
     resolution: {integrity: sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.10':
     resolution: {integrity: sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.10':
     resolution: {integrity: sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==}
@@ -1807,56 +1802,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
@@ -1929,49 +1916,41 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==}
@@ -2022,42 +2001,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -2576,79 +2549,66 @@ packages:
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.0':
     resolution: {integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==}
@@ -3302,61 +3262,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -5329,28 +5279,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-cli-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-o+fRZtX4iFkTMhSXHzWYkLuCdd8ofKwlRWf8srb/xCq6ir74DZ+S+U3TKuJX0PO/qf+7wnFTMVjUUt/u+wKn6Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-cli-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-ODSKAllCrnNEtKPadEr96u8Ch2XJLiB7mLWu6q5dpUNqW0MUNNyGm5cL2boZXTWZea40W9Ga3kg7xOF6Nekeig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-cli-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-j0HDWml30CrgZoNtIjUmnun3kaRT31bAn/L3xE1giq7C0ic3JyRCNPCt+XUXySjVHcUwoLotk0SPa14mvJ4aTg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-cli-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-JPCfe3mAt666yHvPnFlmxKSgOy9qHagi8idWTIvEY8NAfAc833lrtPbTc7exfyz5IPQS3oALjt2qaRw911EApg==}
@@ -5398,28 +5344,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -11910,7 +11852,7 @@ snapshots:
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
       eslint-plugin-react: 7.37.5(eslint@9.39.2)
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2)
@@ -11969,7 +11911,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -12009,7 +11951,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,6 +332,9 @@ importers:
 
   packages/gafaelfawr-client:
     dependencies:
+      '@lsst-sqre/api-client-core':
+        specifier: workspace:*
+        version: link:../api-client-core
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -11861,7 +11864,7 @@ snapshots:
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
       eslint-plugin-react: 7.37.5(eslint@9.39.2)
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2)
@@ -11920,7 +11923,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -11960,7 +11963,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@fontsource/source-sans-pro':
         specifier: ^4.5.11
         version: 4.5.11
+      '@lsst-sqre/api-client-core':
+        specifier: workspace:*
+        version: link:../../packages/api-client-core
       '@lsst-sqre/gafaelfawr-client':
         specifier: workspace:*
         version: link:../../packages/gafaelfawr-client
@@ -446,6 +449,9 @@ importers:
 
   packages/semaphore-client:
     dependencies:
+      '@lsst-sqre/api-client-core':
+        specifier: workspace:*
+        version: link:../api-client-core
       zod:
         specifier: ^3.24.0
         version: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,6 +391,9 @@ importers:
 
   packages/repertoire-client:
     dependencies:
+      '@lsst-sqre/api-client-core':
+        specifier: workspace:*
+        version: link:../api-client-core
       zod:
         specifier: ^3.24.0
         version: 3.25.76

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,7 +233,7 @@ importers:
         version: 9.39.2
       eslint-config-next:
         specifier: ^16.2.9
-        version: 16.2.9(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
+        version: 16.2.9(eslint@9.39.2)(typescript@5.9.3)
       eslint-plugin-storybook:
         specifier: 10.4.6
         version: 10.4.6(eslint@9.39.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@2.8.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
@@ -282,7 +282,7 @@ importers:
     dependencies:
       eslint-config-next:
         specifier: ^16.2.9
-        version: 16.2.9(eslint@9.39.5)(typescript@5.9.3)
+        version: 16.2.9(@typescript-eslint/parser@8.62.1(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3)
       eslint-config-turbo:
         specifier: ^2.10.0
         version: 2.10.0(eslint@9.39.5)(turbo@2.10.0)
@@ -664,6 +664,9 @@ importers:
 
   packages/times-square-client:
     dependencies:
+      '@lsst-sqre/api-client-core':
+        specifier: workspace:*
+        version: link:../api-client-core
       '@microsoft/fetch-event-source':
         specifier: ^2.0.1
         version: 2.0.1
@@ -10001,10 +10004,10 @@ snapshots:
       '@storybook/icons': 2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@2.8.8)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
-      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.8)
-      '@vitest/browser-playwright': 4.1.8(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(playwright@1.61.1)(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(msw@2.12.9(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(msw@2.12.9(@types/node@22.19.11)(typescript@5.9.3))(playwright@1.61.1)(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/runner': 4.1.8
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.12.9(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -10727,9 +10730,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.2.3)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.6(@types/node@25.2.3)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@25.2.3)(typescript@5.9.3))(vite@7.3.6(@types/node@25.2.3)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.1.8)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -11858,18 +11861,18 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.9(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3):
+  eslint-config-next@16.2.9(@typescript-eslint/parser@8.62.1(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.9
-      eslint: 9.39.2
+      eslint: 9.39.5
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
-      eslint-plugin-react: 7.37.5(eslint@9.39.2)
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5)
+      eslint-plugin-react: 7.37.5(eslint@9.39.5)
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5)
       globals: 16.4.0
-      typescript-eslint: 8.62.1(eslint@9.39.2)(typescript@5.9.3)
+      typescript-eslint: 8.62.1(eslint@9.39.5)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11878,18 +11881,18 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.2.9(eslint@9.39.5)(typescript@5.9.3):
+  eslint-config-next@16.2.9(eslint@9.39.2)(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.9
-      eslint: 9.39.5
+      eslint: 9.39.2
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5)
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5)
-      eslint-plugin-react: 7.37.5(eslint@9.39.5)
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
+      eslint-plugin-react: 7.37.5(eslint@9.39.2)
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2)
       globals: 16.4.0
-      typescript-eslint: 8.62.1(eslint@9.39.5)(typescript@5.9.3)
+      typescript-eslint: 8.62.1(eslint@9.39.2)(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -11912,7 +11915,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11923,7 +11926,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -11938,32 +11941,32 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.2)(typescript@5.9.3)
-      eslint: 9.39.2
-      eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.5)(typescript@5.9.3)
       eslint: 9.39.5
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
+  eslint-module-utils@2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.39.2
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11972,9 +11975,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2
+      eslint: 9.39.5
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.1(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2))(eslint@9.39.2))(eslint@9.39.2)
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.1(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -11986,13 +11989,13 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.1(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.62.1(eslint@9.39.5)(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -12001,9 +12004,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.5
+      eslint: 9.39.2
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
+      eslint-module-utils: 2.13.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -16096,7 +16099,7 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.12.9(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0))
 
   vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.19.11)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(msw@2.12.9(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.6(@types/node@22.19.11)(less@4.4.1)(lightningcss@1.31.1)(sass@1.91.0)(stylus@0.62.0)(terser@5.49.0)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Summary

- Add the `@lsst-sqre/api-client-core` workspace package: the single source of truth for the shared `Logger` type, an expected-vs-report-worthy error classifier (401/403 expected; ZodError / 5xx / server-side network report-worthy), and a Sentry-agnostic `reportingQueryFn` wrapper that returns a benign fallback on any failure, logs all failures, and invokes an injected `reportError(err, context)` hook only for report-worthy ones.
- Add the app-side `reportError` (`apps/squareone/src/lib/sentry/reportError.ts`): it captures report-worthy errors to Sentry with site/package context tags, guarded by an in-memory dedupe window (once per session client-side, once per ~15-minute window server-side) so 60 s query polling cannot flood Sentry during an outage.
- Migrate the semaphore-client broadcasts `queryFn` (the DM-55599 archetype) onto `reportingQueryFn` and wire the app's `reportError` at both call sites — the `layout.tsx` RSC prefetch (server runtime) and the client-side `BroadcastBannerStack`. `semaphore-client` now re-exports `Logger` from `api-client-core` so existing imports keep compiling; the empty-broadcasts graceful fallback is unchanged.
- Migrate the repertoire-client discovery `queryFn` onto `reportingQueryFn` (`discoveryQueryOptions` gains `reportError` / `context` / `isServer` config keys; `repertoire-client` re-exports `Logger` from `api-client-core`), and harden `layout.tsx`'s RSC prefetch so both the discovery prefetch and the broadcasts-prefetch `catch` report report-worthy server-side failures (via a new `reportPrefetchError` helper) instead of only pino-logging. The empty-discovery graceful fallback is unchanged.
- Migrate the gafaelfawr-client `userInfoQueryOptions` and `loginInfoQueryOptions` onto `reportingQueryFn` with auth-vs-failure discrimination: expected 401/403 stay quiet (`isLoggedIn=false` / null-login-info behavior unchanged) while ZodError / 5xx / server-side network failures report — so an API outage is distinguishable from "not logged in" and a silently-null `csrfToken` becomes operator-visible. `useUserInfo` / `useLoginInfo` forward an optional query config and the app injects the reporter at the header's `Login` (user-info) and `UserMenu` (login-info) chokepoints; `gafaelfawr-client` re-exports `Logger` from `api-client-core`.
- Migrate the times-square-client `githubContentsQueryOptions` and `githubPrContentsQueryOptions` onto `reportingQueryFn` (a new `GitHubContentsQueryConfig` type carries `reportError` / `context` / `isServer`; the empty-nav-tree / empty-PR fallbacks are unchanged, and the PR-contents query tags its `owner`/`repo`/`commit` in the reported context). Fix the SSE `safeParse` drop path so a schema-mismatched `HtmlEvent` invokes `subscribeToHtmlEvents`' `onError` (with the `ZodError` as the Error `cause`) instead of being silently discarded; `times-square-client` re-exports `Logger` from `api-client-core`.
- Remediate the remaining app data-layer catch sites: `resolveApiEndpoints` (`/api-aspect`) now classifies its caught discovery failure server-side and forwards report-worthy ones (Repertoire 5xx, contract drift, server-side network) to an injected `reportError`, so a Repertoire outage is distinguishable in Sentry from a quiet/expected failure (the "unavailable" notice stays); and `compileFooterMdxForRsc`'s bare `catch { return null }` is narrowed so a missing (optional) footer file still yields a null footer silently while an MDX compile/syntax error is reported before the footer degrades to null.

## Validation steps

- In idfdev, force a broadcasts contract-drift failure (the DM-55599 ZodError scenario) and confirm a Sentry issue appears carrying the `site` / `package` context tags.
- With broadcasts failing under the 60 s poll, confirm at most one Sentry event is produced per dedupe window per runtime, and that the broadcast banner area degrades gracefully to no banners (no error surfaced to users).
- In idfdev, make the Repertoire discovery endpoint return a contract-drift payload or a 5xx and confirm a Sentry issue appears with the `service-discovery` context; confirm the page still renders with an empty discovery (graceful fallback intact).
- Make the server-side discovery/broadcasts prefetch fail (e.g. an unreachable Repertoire URL) and confirm the RSC prefetch failure reports server-side to Sentry rather than only appearing in the pino logs.
- Make the user-info or login-info endpoint return a 5xx or contract-drift payload and confirm a Sentry issue appears with the `user-info` / `login-info` context; then return a 401/403 and confirm no Sentry event fires and the header still shows the logged-out state (graceful fallback intact).
- Make the Times Square `github` / `github-pr` contents endpoint return a 5xx or contract-drift payload and confirm the report-worthy failure reaches the injected `reportError` (with `site` / `owner`/`repo`/`commit` context) while the nav tree / PR view degrades gracefully to empty; confirm a 401/403 stays quiet.
- Drive a Times Square notebook SSE stream that emits a schema-mismatched event and confirm it now surfaces through the subscription's `onError` (rather than being silently dropped), while non-JSON heartbeats are still ignored.
- On `/api-aspect`, make Repertoire discovery return a 5xx (or contract-drift payload) and confirm a Sentry issue appears with the `api-aspect-discovery` context while the page still shows the brief "unavailable" notice; then make it a 403 and confirm no Sentry event fires (notice still shown).
- Introduce a syntax error into a present `footer.mdx` and confirm a Sentry issue is reported while the footer degrades to null; then remove `footer.mdx` entirely and confirm the footer is null with no Sentry event.

## References

- Closes #599
- Closes #600
- Closes #601
- Closes #602
- Closes #603
- Closes #604
- PRD: #598
- Jira: https://rubinobs.atlassian.net/browse/DM-55604