### PR TITLE
DM-55604: Bridge pino warn/error records to Sentry Logs

### DIFF
--- a/.changeset/pino-sentry-logs.md
+++ b/.changeset/pino-sentry-logs.md
@@ -1,0 +1,5 @@
+---
+"squareone": minor
+---
+
+Bridge server-side pino warn/error records to Sentry Logs (DM-55604). `sentry.server.config.js` now sets `enableLogs: true` and adds `Sentry.pinoIntegration()`, configured (via `src/lib/sentry/pinoLogsConfig.ts`) to ship pino records to Sentry **Logs** only — the issue-creating `error.levels` channel is left empty, so server-side `logger.warn`/`logger.error` records become searchable, trace-linked structured logs without creating Sentry issues or firing Slack alerts. The explicit `reportError` path remains the sole alerting channel, so there is no double-capture. A new `/admin/sentry/emit-log` route handler emits a warn+error record, and an "Emit server log" button on the `/admin/sentry` page POSTs to it, so the transport can be verified in a real server build.

--- a/apps/squareone/sentry.server.config.js
+++ b/apps/squareone/sentry.server.config.js
@@ -4,6 +4,8 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { pinoLogsIntegrationOptions } from './src/lib/sentry/pinoLogsConfig';
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
@@ -15,6 +17,17 @@ Sentry.init({
 
   // Define how likely traces are sampled.
   tracesSampleRate: parseFloat(process.env.SENTRY_TRACES_SAMPLE_RATE || '0'),
+
+  // Enable Sentry Structured Logs so the pino bridge below can ship server-side
+  // pino records to Sentry Logs (searchable, trace-linked). This does not by
+  // itself create issues or alerts.
+  enableLogs: true,
+
+  // Bridge server-side pino warn/error records to Sentry Logs only. The bridge
+  // never creates Sentry issues or fires alerts (error.levels is empty); the
+  // explicit reportError channel remains the sole alerting path, so there is no
+  // double-capture. See src/lib/sentry/pinoLogsConfig.ts.
+  integrations: [Sentry.pinoIntegration(pinoLogsIntegrationOptions)],
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/squareone/src/app/admin/sentry/emit-log/route.test.ts
+++ b/apps/squareone/src/app/admin/sentry/emit-log/route.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// Mock the route logger so we can assert warn/error are emitted without a real
+// pino/Sentry pipeline running. This is the same server-side logger the
+// pinoIntegration bridge instruments, so exercising it here is what verifies
+// the transport in the server build.
+const { warn, error } = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock('@/lib/logger', () => ({
+  createRouteLogger: () => ({ warn, error }),
+}));
+
+import { POST } from './route';
+
+describe('POST /admin/sentry/emit-log', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('emits a server-side pino warn and error record', async () => {
+    const response = await POST();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toMatchObject({ emitted: ['warn', 'error'] });
+  });
+});

--- a/apps/squareone/src/app/admin/sentry/emit-log/route.ts
+++ b/apps/squareone/src/app/admin/sentry/emit-log/route.ts
@@ -1,0 +1,23 @@
+/**
+ * Admin smoke-test endpoint that emits server-side pino warn and error records.
+ *
+ * The `Sentry.pinoIntegration()` bridge configured in `sentry.server.config.js`
+ * ships these records to Sentry **Logs** (not issues), so hitting this endpoint
+ * from the `/admin/sentry` page verifies the pino→Sentry Logs transport in a
+ * real server build. The records carry a marker so they are easy to find in the
+ * Sentry Logs UI.
+ */
+
+import { NextResponse } from 'next/server';
+
+import { createRouteLogger } from '@/lib/logger';
+
+const log = createRouteLogger('admin/sentry/emit-log');
+
+export async function POST() {
+  const marker = 'sentry-logs-smoke-test';
+  log.warn({ marker }, 'Sentry Logs smoke test (warn)');
+  log.error({ marker }, 'Sentry Logs smoke test (error)');
+
+  return NextResponse.json({ emitted: ['warn', 'error'], marker });
+}

--- a/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.test.tsx
+++ b/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.test.tsx
@@ -54,6 +54,24 @@ describe('SentryTestButtons', () => {
     ).toBeInTheDocument();
   });
 
+  test('"Emit server log" POSTs to the emit-log route so the server logs a warn/error', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    render(<SentryTestButtons />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /emit server log/i })
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith('/admin/sentry/emit-log', {
+      method: 'POST',
+    });
+
+    fetchMock.mockRestore();
+  });
+
   test('"Throw uncaught error" throws "Sentry Test Error" for the error boundary to catch', async () => {
     // React logs the boundary-caught error to console.error; silence it so the
     // expected throw doesn't produce noisy output.

--- a/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.tsx
+++ b/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.tsx
@@ -15,6 +15,10 @@ import styles from './SentryTestButtons.module.css';
  *   boundaries, so the throw is deferred to the next render instead.
  * - "Capture handled exception" reports a handled exception with
  *   `Sentry.captureException` without interrupting the page.
+ * - "Emit server log" POSTs to `/admin/sentry/emit-log`, whose route handler
+ *   emits server-side pino warn/error records. The `Sentry.pinoIntegration()`
+ *   bridge ships those to Sentry Logs (not issues), so this verifies the
+ *   pino→Sentry Logs transport in the server build.
  */
 export default function SentryTestButtons() {
   const [shouldThrow, setShouldThrow] = useState(false);
@@ -36,6 +40,15 @@ export default function SentryTestButtons() {
         }
       >
         Capture handled exception
+      </Button>
+      <Button
+        type="button"
+        appearance="outline"
+        onClick={() => {
+          void fetch('/admin/sentry/emit-log', { method: 'POST' });
+        }}
+      >
+        Emit server log
       </Button>
     </div>
   );

--- a/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.tsx
+++ b/apps/squareone/src/components/SentryTestButtons/SentryTestButtons.tsx
@@ -22,10 +22,31 @@ import styles from './SentryTestButtons.module.css';
  */
 export default function SentryTestButtons() {
   const [shouldThrow, setShouldThrow] = useState(false);
+  const [emitLogStatus, setEmitLogStatus] = useState<string | null>(null);
 
   if (shouldThrow) {
     throw new Error('Sentry Test Error');
   }
+
+  const handleEmitLog = async () => {
+    setEmitLogStatus('Emitting…');
+    try {
+      const response = await fetch('/admin/sentry/emit-log', {
+        method: 'POST',
+      });
+      setEmitLogStatus(
+        response.ok
+          ? `Emitted server log (HTTP ${response.status})`
+          : `Failed to emit server log (HTTP ${response.status})`
+      );
+    } catch (error) {
+      setEmitLogStatus(
+        `Failed to emit server log: ${
+          error instanceof Error ? error.message : 'unknown error'
+        }`
+      );
+    }
+  };
 
   return (
     <div className={styles.buttons}>
@@ -45,11 +66,12 @@ export default function SentryTestButtons() {
         type="button"
         appearance="outline"
         onClick={() => {
-          void fetch('/admin/sentry/emit-log', { method: 'POST' });
+          void handleEmitLog();
         }}
       >
         Emit server log
       </Button>
+      {emitLogStatus && <output>{emitLogStatus}</output>}
     </div>
   );
 }

--- a/apps/squareone/src/lib/sentry/pinoLogsConfig.test.ts
+++ b/apps/squareone/src/lib/sentry/pinoLogsConfig.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, test } from 'vitest';
 import { pinoLogsIntegrationOptions } from './pinoLogsConfig';
 
 describe('pinoLogsIntegrationOptions', () => {
-  test('routes warn and error through the Sentry Logs (log) channel', () => {
+  test('routes exactly warn and error through the Sentry Logs (log) channel', () => {
     // The log channel is what pinoIntegration ships to Sentry Logs via
-    // _INTERNAL_captureLog. warn/error must be present so those records become
-    // searchable, trace-linked structured logs.
-    expect(pinoLogsIntegrationOptions.log?.levels).toContain('warn');
-    expect(pinoLogsIntegrationOptions.log?.levels).toContain('error');
+    // _INTERNAL_captureLog. The bridge is scoped to warn/error only, so pin the
+    // exact list: shipping lower levels (info/debug/trace) would flood Sentry
+    // Logs contrary to the documented design.
+    expect(pinoLogsIntegrationOptions.log?.levels).toEqual(['warn', 'error']);
   });
 
   test('never routes any level through the error (issue-creating) channel', () => {

--- a/apps/squareone/src/lib/sentry/pinoLogsConfig.test.ts
+++ b/apps/squareone/src/lib/sentry/pinoLogsConfig.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest';
+
+import { pinoLogsIntegrationOptions } from './pinoLogsConfig';
+
+describe('pinoLogsIntegrationOptions', () => {
+  test('routes warn and error through the Sentry Logs (log) channel', () => {
+    // The log channel is what pinoIntegration ships to Sentry Logs via
+    // _INTERNAL_captureLog. warn/error must be present so those records become
+    // searchable, trace-linked structured logs.
+    expect(pinoLogsIntegrationOptions.log?.levels).toContain('warn');
+    expect(pinoLogsIntegrationOptions.log?.levels).toContain('error');
+  });
+
+  test('never routes any level through the error (issue-creating) channel', () => {
+    // pinoIntegration's error channel calls captureException/captureMessage,
+    // which creates Sentry issues and can fire Slack alerts. The bridge must
+    // stay strictly on the Logs channel: reportError remains the sole alerting
+    // path, so there is no double-capture. An empty error.levels list is the
+    // load-bearing invariant here.
+    expect(pinoLogsIntegrationOptions.error?.levels).toEqual([]);
+  });
+});

--- a/apps/squareone/src/lib/sentry/pinoLogsConfig.ts
+++ b/apps/squareone/src/lib/sentry/pinoLogsConfig.ts
@@ -22,7 +22,7 @@ export const pinoLogsIntegrationOptions: Parameters<
   typeof Sentry.pinoIntegration
 >[0] = {
   // Sentry Logs channel: ship these levels as structured logs.
-  log: { levels: ['trace', 'debug', 'info', 'warn', 'error', 'fatal'] },
+  log: { levels: ['warn', 'error'] },
   // Issue-creating channel: intentionally empty so the bridge never opens an
   // issue or fires an alert. Do not populate — see reportError for alerting.
   error: { levels: [] },

--- a/apps/squareone/src/lib/sentry/pinoLogsConfig.ts
+++ b/apps/squareone/src/lib/sentry/pinoLogsConfig.ts
@@ -1,0 +1,29 @@
+import type * as Sentry from '@sentry/nextjs';
+
+/**
+ * Options for `Sentry.pinoIntegration()` that bridge server-side pino records
+ * to Sentry **Logs** only — never to Sentry issues/events.
+ *
+ * `pinoIntegration` has two independent channels:
+ *
+ * - `log.levels` — records at these levels are shipped to Sentry Logs
+ *   (structured, searchable, trace-linked) via `_INTERNAL_captureLog`, gated
+ *   on the client's `enableLogs` option.
+ * - `error.levels` — records at these levels are turned into Sentry issues via
+ *   `captureException`/`captureMessage`, which can also fire Slack alerts.
+ *
+ * We keep `error.levels` empty so the bridge never creates an issue or alert:
+ * `reportError` (see `./reportError`) remains the sole issue/alerting channel,
+ * so a warn/error that is both logged and reported is not double-captured.
+ * `warn` and `error` are included in `log.levels` so those records reach
+ * Sentry Logs.
+ */
+export const pinoLogsIntegrationOptions: Parameters<
+  typeof Sentry.pinoIntegration
+>[0] = {
+  // Sentry Logs channel: ship these levels as structured logs.
+  log: { levels: ['trace', 'debug', 'info', 'warn', 'error', 'fatal'] },
+  // Issue-creating channel: intentionally empty so the bridge never opens an
+  // issue or fires an alert. Do not populate — see reportError for alerting.
+  error: { levels: [] },
+};


### PR DESCRIPTION
## Summary

- Ship server-side pino `warn`/`error` records to Sentry Structured Logs via `Sentry.pinoIntegration()` in `sentry.server.config.js`, so they become searchable and trace-linked in Sentry.
- Keep the bridge strictly on the Logs channel (empty `error.levels` in `src/lib/sentry/pinoLogsConfig.ts`): it never creates Sentry issues or fires Slack alerts, so the explicit `reportError` path stays the sole alerting channel and there is no double-capture.
- Add a SentryTestButtons-style hook — a POST-only `/admin/sentry/emit-log` route handler plus an "Emit server log" button on `/admin/sentry` — to verify the transport in a real server build.

## Validation steps

- In a server build with a real `SENTRY_DSN`, open `/admin/sentry`, click "Emit server log", and confirm the warn/error records (marker `sentry-logs-smoke-test`) appear in Sentry **Logs**.
- Confirm no Sentry **issue** is created by clicking that button (the bridge is logs-only; issues should only come from the "Throw uncaught error" / "Capture handled exception" buttons).

## References

- Closes #605
- PRD: #598
- Jira: https://rubinobs.atlassian.net/browse/DM-55604