### PR TITLE
DM-55604: Capture token-page delete/submit errors in Sentry

### DIFF
--- a/.changeset/reportError-times-square-ui.md
+++ b/.changeset/reportError-times-square-ui.md
@@ -1,0 +1,5 @@
+---
+"squareone": minor
+---
+
+Add Sentry capture and user-facing error states to the Times Square UI (DM-55604). `ExecStats` recompute is no longer fire-and-forget: it checks the response, shows a user-facing failure message, and reports the exception via `makeReportError`. `TimesSquareHtmlEventsProviderClient` now bounds its SSE reconnect attempts and enters a terminal-failure state (surfaced to the user) after the budget is exhausted, capturing the connection error once per subscription instead of retrying silently forever.

--- a/.changeset/reportError-token-pages.md
+++ b/.changeset/reportError-token-pages.md
@@ -1,0 +1,5 @@
+---
+"squareone": minor
+---
+
+Add Sentry capture and a user-facing error state to the token pages (DM-55604). `TokenDetailsView` no longer silently closes the delete confirmation modal when a delete fails: it surfaces a user-facing error message (so the still-listed token does not look silently deleted) and reports the exception to Sentry via `makeReportError`, matching the sibling `AccessTokenItem`/`SessionTokenItem` `onDeleteError` capture pattern. `NewTokenPageClient` now reports the token-creation submit exception it previously only `console.error`ed; its existing user-facing `creationError` UX is unchanged.

--- a/apps/squareone/src/app/settings/tokens/new/NewTokenPageClient.test.tsx
+++ b/apps/squareone/src/app/settings/tokens/new/NewTokenPageClient.test.tsx
@@ -1,0 +1,139 @@
+import * as gafaelfawrClient from '@lsst-sqre/gafaelfawr-client';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TokenFormValues } from '../../../../components/TokenForm';
+import * as useRepertoireUrlModule from '../../../../hooks/useRepertoireUrl';
+
+vi.mock('@lsst-sqre/gafaelfawr-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof gafaelfawrClient>();
+  return {
+    ...actual,
+    useLoginInfo: vi.fn(),
+    useCreateToken: vi.fn(),
+    useUserTokens: vi.fn(),
+  };
+});
+vi.mock('../../../../hooks/useRepertoireUrl');
+vi.mock('../../../../hooks/useTokenTemplateUrl', () => ({
+  default: () => 'https://example.com/template',
+}));
+
+// AuthRequired gates on user info; render children directly in tests.
+vi.mock('../../../../components/AuthRequired', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Pin the app's Sentry reporter so we can assert it fires on submit failure.
+const mockReportError = vi.fn();
+vi.mock('@/lib/sentry/reportError', () => ({
+  makeReportError: () => mockReportError,
+}));
+
+// Replace the form with a minimal control that submits fixed values so the
+// test exercises the page's submit handler, not react-hook-form.
+vi.mock('../../../../components/TokenForm', () => ({
+  TokenForm: ({
+    onSubmit,
+  }: {
+    onSubmit: (values: TokenFormValues) => Promise<void>;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onSubmit({
+          name: 'my-token',
+          scopes: ['read:tap'],
+          expiration: { type: 'never' },
+        })
+      }
+    >
+      Submit token
+    </button>
+  ),
+}));
+
+import NewTokenPageClient from './NewTokenPageClient';
+
+const mockUseLoginInfo = vi.mocked(gafaelfawrClient.useLoginInfo);
+const mockUseCreateToken = vi.mocked(gafaelfawrClient.useCreateToken);
+const mockUseUserTokens = vi.mocked(gafaelfawrClient.useUserTokens);
+const mockUseRepertoireUrl = vi.mocked(useRepertoireUrlModule.useRepertoireUrl);
+
+const mockCreateToken = vi.fn();
+
+describe('NewTokenPageClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseRepertoireUrl.mockReturnValue(undefined);
+
+    mockUseLoginInfo.mockReturnValue({
+      loginInfo: {
+        username: 'testuser',
+        scopes: ['read:tap'],
+        config: {
+          scopes: [{ name: 'read:tap', description: 'Read TAP' }],
+        },
+      },
+      error: null,
+      isLoading: false,
+    } as unknown as ReturnType<typeof gafaelfawrClient.useLoginInfo>);
+
+    mockUseCreateToken.mockReturnValue({
+      createToken: mockCreateToken,
+      isCreating: false,
+      error: null,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof gafaelfawrClient.useCreateToken>);
+
+    mockUseUserTokens.mockReturnValue({
+      tokens: [],
+      error: null,
+      isLoading: false,
+      invalidate: vi.fn(),
+    } as unknown as ReturnType<typeof gafaelfawrClient.useUserTokens>);
+  });
+
+  it('reports the exception when token creation fails', async () => {
+    const user = userEvent.setup();
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const error = new Error('Creation failed');
+    mockCreateToken.mockRejectedValue(error);
+
+    render(<NewTokenPageClient />);
+
+    await user.click(screen.getByRole('button', { name: /submit token/i }));
+
+    await waitFor(() => {
+      expect(mockReportError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ site: 'new-token-submit' })
+      );
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('does not report when token creation succeeds', async () => {
+    const user = userEvent.setup();
+    mockCreateToken.mockResolvedValue({ token: 'gt-created' });
+
+    render(<NewTokenPageClient />);
+
+    await user.click(screen.getByRole('button', { name: /submit token/i }));
+
+    await waitFor(() => {
+      expect(mockCreateToken).toHaveBeenCalled();
+    });
+    expect(mockReportError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/squareone/src/app/settings/tokens/new/NewTokenPageClient.tsx
+++ b/apps/squareone/src/app/settings/tokens/new/NewTokenPageClient.tsx
@@ -8,8 +8,9 @@ import {
 } from '@lsst-sqre/gafaelfawr-client';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
+import { makeReportError } from '@/lib/sentry/reportError';
 import AuthRequired from '../../../../components/AuthRequired';
 import { TokenCreationErrorDisplay } from '../../../../components/TokenCreationErrorDisplay';
 import {
@@ -57,6 +58,11 @@ function NewTokenContent() {
     isLoading: tokensLoading,
     invalidate: invalidateTokens,
   } = useUserTokens(loginInfo?.username, repertoireUrl);
+
+  // Inject the app's Sentry-backed reporter so a report-worthy submit failure
+  // (5xx, contract drift) reaches Sentry with site context tags. The existing
+  // user-facing `creationError` UX is unchanged.
+  const reportError = useMemo(() => makeReportError({ isServer: false }), []);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [createdToken, setCreatedToken] = useState<string | null>(null);
@@ -113,6 +119,10 @@ function NewTokenContent() {
       invalidateTokens();
     } catch (error) {
       console.error('Token creation failed:', error);
+      reportError(error, {
+        site: 'new-token-submit',
+        package: 'gafaelfawr-client',
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.module.css
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.module.css
@@ -9,3 +9,9 @@
   font-size: 0.8rem;
   margin-bottom: 0;
 }
+
+.error {
+  font-size: 0.8rem;
+  margin-bottom: 0;
+  color: var(--rsd-color-red-900);
+}

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.test.tsx
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  TimesSquareHtmlEventsContext,
+  type TimesSquareHtmlEventsContextValue,
+} from '../TimesSquareHtmlEventsProvider';
+
+// Pin the app's Sentry reporter so we can assert it fires on a failed
+// recompute request.
+const mockReportError = vi.fn();
+vi.mock('@/lib/sentry/reportError', () => ({
+  makeReportError: () => mockReportError,
+}));
+
+import ExecStats from './ExecStats';
+
+const completeContext: TimesSquareHtmlEventsContextValue = {
+  dateSubmitted: '2021-09-01T12:00:00Z',
+  dateStarted: '2021-09-01T12:00:01Z',
+  dateFinished: '2021-09-01T12:00:10Z',
+  executionStatus: 'complete',
+  executionDuration: 10.12,
+  htmlHash: 'abc123',
+  htmlUrl: 'https://example.com/html',
+  connectionFailed: false,
+};
+
+function renderExecStats(context: TimesSquareHtmlEventsContextValue) {
+  return render(
+    <TimesSquareHtmlEventsContext.Provider value={context}>
+      <ExecStats />
+    </TimesSquareHtmlEventsContext.Provider>
+  );
+}
+
+describe('ExecStats recompute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces and reports a failed (non-ok) recompute request', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(null, { status: 500, statusText: 'Internal Server Error' })
+    );
+
+    renderExecStats(completeContext);
+
+    await user.click(screen.getByRole('button', { name: /recompute/i }));
+
+    // User-facing failure indication.
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/recompute/i);
+
+    // Reported to Sentry with site context.
+    await waitFor(() => {
+      expect(mockReportError).toHaveBeenCalledTimes(1);
+    });
+    expect(mockReportError.mock.calls[0][1]).toMatchObject({
+      site: 'times-square-recompute',
+    });
+  });
+
+  it('surfaces and reports a recompute request that throws', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(global, 'fetch').mockRejectedValue(new TypeError('network down'));
+
+    renderExecStats(completeContext);
+
+    await user.click(screen.getByRole('button', { name: /recompute/i }));
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockReportError).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not report or show an error on a successful recompute', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(null, { status: 202 })
+    );
+
+    renderExecStats(completeContext);
+
+    await user.click(screen.getByRole('button', { name: /recompute/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+    expect(mockReportError).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.tsx
+++ b/apps/squareone/src/components/TimesSquareGitHubPagePanel/ExecStats.tsx
@@ -8,11 +8,22 @@
 import { Button } from '@lsst-sqre/squared';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import React from 'react';
+
+import { makeReportError } from '@/lib/sentry/reportError';
 import { TimesSquareHtmlEventsContext } from '../TimesSquareHtmlEventsProvider';
 import styles from './ExecStats.module.css';
 
 export default function ExecStats() {
   const htmlEvent = React.useContext(TimesSquareHtmlEventsContext);
+  const [recomputeFailed, setRecomputeFailed] = React.useState(false);
+
+  // Inject the app's Sentry-backed reporter so a report-worthy recompute
+  // failure (5xx, network error) reaches Sentry with site context tags,
+  // deduped by the reporter's per-session window.
+  const reportError = React.useMemo(
+    () => makeReportError({ isServer: false }),
+    []
+  );
 
   // Return null if context is not available yet
   if (!htmlEvent) {
@@ -28,12 +39,33 @@ export default function ExecStats() {
       return;
     }
 
-    await fetch(htmlEvent.htmlUrl, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+    // The recompute request is no longer fire-and-forget: check the response
+    // and surface / report any failure so a failed recompute is visible to the
+    // user rather than silently doing nothing.
+    setRecomputeFailed(false);
+    try {
+      const response = await fetch(htmlEvent.htmlUrl, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      if (!response.ok) {
+        setRecomputeFailed(true);
+        reportError(
+          new Error(
+            `Recompute request failed: ${response.status} ${response.statusText}`
+          ),
+          { site: 'times-square-recompute', package: 'times-square-client' }
+        );
+      }
+    } catch (err) {
+      setRecomputeFailed(true);
+      reportError(err, {
+        site: 'times-square-recompute',
+        package: 'times-square-client',
+      });
+    }
   };
 
   if (htmlEvent.executionStatus === 'complete') {
@@ -58,6 +90,11 @@ export default function ExecStats() {
         <Button appearance="outline" tone="primary" onClick={handleRecompute}>
           Recompute
         </Button>
+        {recomputeFailed && (
+          <p className={styles.error} role="alert">
+            Failed to request a recompute. Please try again.
+          </p>
+        )}
       </div>
     );
   }

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.tsx
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProvider.tsx
@@ -19,6 +19,11 @@ export type TimesSquareHtmlEventsContextValue = {
   executionDuration: number | null;
   htmlHash: string | null;
   htmlUrl: string | null;
+  /**
+   * True once the SSE connection has permanently failed after exhausting the
+   * bounded reconnect budget. Consumers can surface a terminal-failure state.
+   */
+  connectionFailed: boolean;
 };
 
 export const TimesSquareHtmlEventsContext = React.createContext<
@@ -40,6 +45,7 @@ const TimesSquareHtmlEventsProviderClient = dynamic(
         executionDuration: null,
         htmlHash: null,
         htmlUrl: null,
+        connectionFailed: false,
       };
       // Return a provider that will be used by parent component with children
       return (

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.module.css
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.module.css
@@ -1,0 +1,8 @@
+.connectionAlert {
+  margin-bottom: var(--sqo-space-md-fixed);
+  padding: var(--sqo-space-sm-fixed) var(--sqo-space-md-fixed);
+  background-color: var(--rsd-color-red-100);
+  border: 1px solid var(--rsd-color-red-500);
+  border-radius: var(--sqo-border-radius-2);
+  color: var(--rsd-color-red-900);
+}

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.test.tsx
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Capture the options object passed to fetchEventSource so the test can drive
+// its onerror callback directly and assert the reconnect/terminal behavior.
+type FetchEventSourceInit = {
+  onerror?: (err: unknown) => number | null | undefined;
+};
+let capturedInit: FetchEventSourceInit | null = null;
+vi.mock('@microsoft/fetch-event-source', () => {
+  function noop(): void {}
+  return {
+    fetchEventSource: vi.fn(
+      (_url: string, init: FetchEventSourceInit): Promise<void> => {
+        capturedInit = init;
+        // Never resolves; the connection stays "open" so onerror drives the test.
+        return new Promise<void>(noop);
+      }
+    ),
+  };
+});
+
+// Pin the app's Sentry reporter so we can assert connection-error captures are
+// throttled/deduped.
+const mockReportError = vi.fn();
+vi.mock('@/lib/sentry/reportError', () => ({
+  makeReportError: () => mockReportError,
+}));
+
+// Give the client a concrete html_events_url to subscribe to.
+vi.mock('@lsst-sqre/times-square-client', () => ({
+  useTimesSquarePage: () => ({
+    htmlEventsUrl: 'https://example.com/html/events',
+  }),
+}));
+vi.mock('../../hooks/useRepertoireUrl', () => ({
+  useRepertoireUrl: (): string | undefined => undefined,
+}));
+
+import TimesSquareHtmlEventsProviderClient, {
+  MAX_SSE_RECONNECT_ATTEMPTS,
+} from './TimesSquareHtmlEventsProviderClient';
+
+describe('TimesSquareHtmlEventsProviderClient SSE terminal failure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedInit = null;
+  });
+
+  it('reaches a terminal-failure state after bounded retries and throttles capture', async () => {
+    render(
+      <TimesSquareHtmlEventsProviderClient>
+        <div>child</div>
+      </TimesSquareHtmlEventsProviderClient>
+    );
+
+    // The client-only effect subscribes after the isClient flip.
+    await waitFor(() => {
+      expect(capturedInit?.onerror).toBeInstanceOf(Function);
+    });
+
+    const onerror = capturedInit?.onerror;
+    if (!onerror) {
+      throw new Error(
+        'fetchEventSource was not called with an onerror handler'
+      );
+    }
+    const connectionError = new Error('connection refused');
+
+    // While under the retry budget, onerror must request a reconnect (returns a
+    // numeric backoff) rather than throwing (which would abort permanently).
+    for (let i = 0; i < MAX_SSE_RECONNECT_ATTEMPTS - 1; i++) {
+      const result = onerror(connectionError);
+      expect(typeof result).toBe('number');
+    }
+
+    // The attempt that exhausts the budget must throw to stop fetch-event-source
+    // from reconnecting (terminal failure).
+    expect(() => onerror(connectionError)).toThrow();
+
+    // A user-facing terminal-failure state is shown.
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+    // Repeated identical connection errors are deduped to a single capture even
+    // though onerror fired MAX_SSE_RECONNECT_ATTEMPTS times.
+    expect(mockReportError).toHaveBeenCalledTimes(1);
+    expect(mockReportError.mock.calls[0][1]).toMatchObject({
+      site: 'times-square-sse',
+    });
+  });
+});

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.test.tsx
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.test.tsx
@@ -1,3 +1,4 @@
+import { fetchEventSource } from '@microsoft/fetch-event-source';
 import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -41,6 +42,8 @@ vi.mock('../../hooks/useRepertoireUrl', () => ({
 import TimesSquareHtmlEventsProviderClient, {
   MAX_SSE_RECONNECT_ATTEMPTS,
 } from './TimesSquareHtmlEventsProviderClient';
+
+const fetchEventSourceMock = vi.mocked(fetchEventSource);
 
 describe('TimesSquareHtmlEventsProviderClient SSE terminal failure', () => {
   beforeEach(() => {
@@ -88,5 +91,55 @@ describe('TimesSquareHtmlEventsProviderClient SSE terminal failure', () => {
     expect(mockReportError.mock.calls[0][1]).toMatchObject({
       site: 'times-square-sse',
     });
+  });
+
+  it('does not leak an unhandled rejection when the terminal throw rejects fetchEventSource', async () => {
+    // The real @microsoft/fetch-event-source rejects the promise it returned
+    // once onerror throws (dispose(); reject(innerErr)). Reproduce that exact
+    // shape: resolve the captured onerror to the caller, then reject with the
+    // thrown error — mirroring the library's terminal-failure path.
+    fetchEventSourceMock.mockImplementationOnce(
+      (_input, init): Promise<void> => {
+        capturedInit = init as FetchEventSourceInit;
+        return new Promise<void>((_resolve, reject) => {
+          const terminalError = new Error('connection refused');
+          // Drive onerror up to and past the retry budget synchronously, then
+          // reject exactly as the library does when onerror throws.
+          for (let i = 0; i < MAX_SSE_RECONNECT_ATTEMPTS - 1; i++) {
+            init.onerror?.(terminalError);
+          }
+          try {
+            init.onerror?.(terminalError);
+          } catch (thrown) {
+            reject(thrown);
+          }
+        });
+      }
+    );
+
+    const unhandledRejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      render(
+        <TimesSquareHtmlEventsProviderClient>
+          <div>child</div>
+        </TimesSquareHtmlEventsProviderClient>
+      );
+
+      // The terminal-failure alert renders once the effect subscribes.
+      expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+      // Give the microtask/macrotask queue a chance to flush any rejection the
+      // runtime would report as unhandled.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
   });
 });

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.tsx
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.tsx
@@ -12,12 +12,24 @@ import {
   useState,
 } from 'react';
 
+import { makeReportError } from '@/lib/sentry/reportError';
 import { useRepertoireUrl } from '../../hooks/useRepertoireUrl';
 import { TimesSquareUrlParametersContext } from '../TimesSquareUrlParametersProvider';
 import {
   TimesSquareHtmlEventsContext,
   type TimesSquareHtmlEventsContextValue,
 } from './TimesSquareHtmlEventsProvider';
+
+/**
+ * Maximum number of SSE reconnect attempts before the connection is treated as
+ * a terminal failure. `fetchEventSource` retries indefinitely by default; this
+ * bounds that so a persistently unreachable endpoint stops silently retrying
+ * and instead surfaces a user-facing error and a single Sentry capture.
+ */
+export const MAX_SSE_RECONNECT_ATTEMPTS = 5;
+
+/** Base backoff (ms) between SSE reconnect attempts. */
+const SSE_RECONNECT_BACKOFF_MS = 1000;
 
 type HtmlEvent = {
   date_submitted: string;
@@ -38,6 +50,10 @@ export default function TimesSquareHtmlEventsProviderClient({
 }: TimesSquareHtmlEventsProviderClientProps) {
   const [isClient, setIsClient] = useState(false);
   const [htmlEvent, setHtmlEvent] = useState<HtmlEvent | null>(null);
+  const [connectionFailed, setConnectionFailed] = useState(false);
+
+  // Inject the app's Sentry-backed reporter for connection failures.
+  const reportError = useMemo(() => makeReportError({ isServer: false }), []);
 
   useEffect(() => {
     setIsClient(true);
@@ -63,6 +79,15 @@ export default function TimesSquareHtmlEventsProviderClient({
     if (!isClient) return () => {};
 
     const abortController = new AbortController();
+    // Per-subscription reconnect bookkeeping. `reconnectAttempts` bounds
+    // fetchEventSource's otherwise-infinite retry loop; `reported` throttles
+    // capture so a persistent outage produces a single Sentry event rather than
+    // one per reconnect attempt.
+    let reconnectAttempts = 0;
+    let reported = false;
+
+    // Reset any prior terminal-failure state when (re)subscribing.
+    setConnectionFailed(false);
 
     async function runEffect(): Promise<void> {
       if (htmlEventsUrl && fullHtmlEventsUrl) {
@@ -96,6 +121,26 @@ export default function TimesSquareHtmlEventsProviderClient({
               `Error fetching Times Square events SSE ${fullHtmlEventsUrl}`,
               err
             );
+
+            // Capture the connection error at most once per subscription so a
+            // sustained outage does not flood Sentry across reconnect attempts.
+            if (!reported) {
+              reported = true;
+              reportError(err, {
+                site: 'times-square-sse',
+                package: 'times-square-client',
+              });
+            }
+
+            reconnectAttempts += 1;
+            if (reconnectAttempts >= MAX_SSE_RECONNECT_ATTEMPTS) {
+              // Throwing from onerror stops fetchEventSource from reconnecting:
+              // the connection is now in a terminal-failure state.
+              setConnectionFailed(true);
+              throw err instanceof Error ? err : new Error(String(err));
+            }
+            // Returning a number retries after that backoff.
+            return SSE_RECONNECT_BACKOFF_MS * reconnectAttempts;
           },
         });
       }
@@ -106,7 +151,7 @@ export default function TimesSquareHtmlEventsProviderClient({
       // Clean up: close the event source connection
       abortController.abort();
     };
-  }, [fullHtmlEventsUrl, htmlEventsUrl, isClient]);
+  }, [fullHtmlEventsUrl, htmlEventsUrl, isClient, reportError]);
 
   const contextValue = useMemo(
     (): TimesSquareHtmlEventsContextValue => ({
@@ -117,12 +162,19 @@ export default function TimesSquareHtmlEventsProviderClient({
       executionDuration: htmlEvent ? htmlEvent.execution_duration : null,
       htmlHash: htmlEvent ? htmlEvent.html_hash : null,
       htmlUrl: htmlEvent ? htmlEvent.html_url : null,
+      connectionFailed,
     }),
-    [htmlEvent]
+    [htmlEvent, connectionFailed]
   );
 
   return (
     <TimesSquareHtmlEventsContext.Provider value={contextValue}>
+      {connectionFailed && (
+        <p role="alert">
+          Lost the connection to the notebook execution status updates. Reload
+          the page to try again.
+        </p>
+      )}
       {children}
     </TimesSquareHtmlEventsContext.Provider>
   );

--- a/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.tsx
+++ b/apps/squareone/src/components/TimesSquareHtmlEventsProvider/TimesSquareHtmlEventsProviderClient.tsx
@@ -19,6 +19,7 @@ import {
   TimesSquareHtmlEventsContext,
   type TimesSquareHtmlEventsContextValue,
 } from './TimesSquareHtmlEventsProvider';
+import styles from './TimesSquareHtmlEventsProviderClient.module.css';
 
 /**
  * Maximum number of SSE reconnect attempts before the connection is treated as
@@ -91,58 +92,68 @@ export default function TimesSquareHtmlEventsProviderClient({
 
     async function runEffect(): Promise<void> {
       if (htmlEventsUrl && fullHtmlEventsUrl) {
-        await fetchEventSource(fullHtmlEventsUrl, {
-          method: 'GET',
-          signal: abortController.signal,
-          async onopen(res) {
-            if (res.status >= 400 && res.status < 500 && res.status !== 429) {
-              console.error(`Client side error ${fullHtmlEventsUrl}`, res);
-            }
-          },
-          onmessage(event) {
-            let parsedData: HtmlEvent;
-            try {
-              parsedData = JSON.parse(event.data);
-            } catch (_error) {
-              return;
-            }
-            setHtmlEvent(parsedData);
+        try {
+          await fetchEventSource(fullHtmlEventsUrl, {
+            method: 'GET',
+            signal: abortController.signal,
+            async onopen(res) {
+              if (res.status >= 400 && res.status < 500 && res.status !== 429) {
+                console.error(`Client side error ${fullHtmlEventsUrl}`, res);
+              }
+            },
+            onmessage(event) {
+              let parsedData: HtmlEvent;
+              try {
+                parsedData = JSON.parse(event.data);
+              } catch (_error) {
+                return;
+              }
+              setHtmlEvent(parsedData);
 
-            if (
-              parsedData.execution_status === 'complete' &&
-              parsedData.html_hash
-            ) {
-              abortController.abort();
-            }
-          },
-          onclose() {},
-          onerror(err) {
-            console.error(
-              `Error fetching Times Square events SSE ${fullHtmlEventsUrl}`,
-              err
-            );
+              if (
+                parsedData.execution_status === 'complete' &&
+                parsedData.html_hash
+              ) {
+                abortController.abort();
+              }
+            },
+            onclose() {},
+            onerror(err) {
+              console.error(
+                `Error fetching Times Square events SSE ${fullHtmlEventsUrl}`,
+                err
+              );
 
-            // Capture the connection error at most once per subscription so a
-            // sustained outage does not flood Sentry across reconnect attempts.
-            if (!reported) {
-              reported = true;
-              reportError(err, {
-                site: 'times-square-sse',
-                package: 'times-square-client',
-              });
-            }
+              // Capture the connection error at most once per subscription so a
+              // sustained outage does not flood Sentry across reconnect attempts.
+              if (!reported) {
+                reported = true;
+                reportError(err, {
+                  site: 'times-square-sse',
+                  package: 'times-square-client',
+                });
+              }
 
-            reconnectAttempts += 1;
-            if (reconnectAttempts >= MAX_SSE_RECONNECT_ATTEMPTS) {
-              // Throwing from onerror stops fetchEventSource from reconnecting:
-              // the connection is now in a terminal-failure state.
-              setConnectionFailed(true);
-              throw err instanceof Error ? err : new Error(String(err));
-            }
-            // Returning a number retries after that backoff.
-            return SSE_RECONNECT_BACKOFF_MS * reconnectAttempts;
-          },
-        });
+              reconnectAttempts += 1;
+              if (reconnectAttempts >= MAX_SSE_RECONNECT_ATTEMPTS) {
+                // Throwing from onerror stops fetchEventSource from reconnecting:
+                // the connection is now in a terminal-failure state.
+                setConnectionFailed(true);
+                throw err instanceof Error ? err : new Error(String(err));
+              }
+              // Returning a number retries after that backoff.
+              return SSE_RECONNECT_BACKOFF_MS * reconnectAttempts;
+            },
+          });
+        } catch (_err) {
+          // The terminal-failure path throws from onerror to stop
+          // fetchEventSource from reconnecting, which rejects this promise.
+          // That outcome is expected and already surfaced to the user via
+          // `connectionFailed` and reported to Sentry via reportError, so
+          // swallow it here to avoid an unhandled promise rejection (which
+          // would otherwise add console noise and a duplicate, untagged
+          // Sentry capture through the global onunhandledrejection handler).
+        }
       }
     }
     runEffect();
@@ -170,7 +181,7 @@ export default function TimesSquareHtmlEventsProviderClient({
   return (
     <TimesSquareHtmlEventsContext.Provider value={contextValue}>
       {connectionFailed && (
-        <p role="alert">
+        <p role="alert" className={styles.connectionAlert}>
           Lost the connection to the notebook execution status updates. Reload
           the page to try again.
         </p>

--- a/apps/squareone/src/components/TokenDetails/TokenDetailsView.module.css
+++ b/apps/squareone/src/components/TokenDetails/TokenDetailsView.module.css
@@ -69,6 +69,15 @@
   text-decoration: underline;
 }
 
+.deleteError {
+  margin-bottom: var(--sqo-space-md-fixed);
+  padding: var(--sqo-space-sm-fixed) var(--sqo-space-md-fixed);
+  background-color: var(--rsd-color-red-100);
+  border: 1px solid var(--rsd-color-red-500);
+  border-radius: var(--sqo-border-radius-2);
+  color: var(--rsd-color-red-900);
+}
+
 .scopesBadges {
   display: flex;
   flex-wrap: wrap;

--- a/apps/squareone/src/components/TokenDetails/TokenDetailsView.test.tsx
+++ b/apps/squareone/src/components/TokenDetails/TokenDetailsView.test.tsx
@@ -340,6 +340,32 @@ describe('TokenDetailsView', () => {
     expect(screen.getByText('My Laptop Token')).toBeInTheDocument();
   });
 
+  it('renders a normalized message when a non-Error throwable is thrown', async () => {
+    const user = userEvent.setup();
+    // A non-Error rejection (e.g. a thrown string) must not render
+    // "Failed to delete token: undefined".
+    mockDeleteToken.mockRejectedValue('boom');
+
+    render(
+      <TokenDetailsView
+        username="testuser"
+        tokenKey="abc123xyz456789012345"
+        onDeleteSuccess={mockOnDeleteSuccess}
+      />
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    const confirmButton = await screen.findByText('Delete token');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Unknown error/i);
+    });
+    expect(screen.getByRole('alert')).not.toHaveTextContent(/undefined/i);
+  });
+
   it('does not leave the confirmation modal open after a failed delete', async () => {
     const user = userEvent.setup();
     mockDeleteToken.mockRejectedValue(new Error('Delete failed'));

--- a/apps/squareone/src/components/TokenDetails/TokenDetailsView.test.tsx
+++ b/apps/squareone/src/components/TokenDetails/TokenDetailsView.test.tsx
@@ -18,6 +18,12 @@ vi.mock('@lsst-sqre/gafaelfawr-client', async (importOriginal) => {
 });
 vi.mock('../../hooks/useRepertoireUrl');
 
+// Pin the app's Sentry reporter so we can assert it fires on delete failure.
+const mockReportError = vi.fn();
+vi.mock('@/lib/sentry/reportError', () => ({
+  makeReportError: () => mockReportError,
+}));
+
 vi.mock('../TokenDate/formatters', () => ({
   formatTokenExpiration: vi.fn((expires) => {
     if (expires === null || expires === undefined) {
@@ -304,15 +310,16 @@ describe('TokenDetailsView', () => {
     });
   });
 
-  it('handles delete error gracefully', async () => {
+  it('surfaces a user-facing error when deletion fails', async () => {
     const user = userEvent.setup();
-    const consoleErrorSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
     mockDeleteToken.mockRejectedValue(new Error('Delete failed'));
 
     render(
-      <TokenDetailsView username="testuser" tokenKey="abc123xyz456789012345" />
+      <TokenDetailsView
+        username="testuser"
+        tokenKey="abc123xyz456789012345"
+        onDeleteSuccess={mockOnDeleteSuccess}
+      />
     );
 
     // Open modal
@@ -323,11 +330,79 @@ describe('TokenDetailsView', () => {
     const confirmButton = await screen.findByText('Delete token');
     await user.click(confirmButton);
 
+    // A user-facing error message is surfaced (not a silent close).
     await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toHaveTextContent(/Delete failed/i);
     });
 
-    consoleErrorSpy.mockRestore();
+    // The token stays listed and the success callback never fires.
+    expect(mockOnDeleteSuccess).not.toHaveBeenCalled();
+    expect(screen.getByText('My Laptop Token')).toBeInTheDocument();
+  });
+
+  it('does not leave the confirmation modal open after a failed delete', async () => {
+    const user = userEvent.setup();
+    mockDeleteToken.mockRejectedValue(new Error('Delete failed'));
+
+    render(
+      <TokenDetailsView username="testuser" tokenKey="abc123xyz456789012345" />
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    const confirmButton = await screen.findByText('Delete token');
+    await user.click(confirmButton);
+
+    // Once the error is shown, the confirmation control is gone (modal closed)
+    // but the token remains, so the delete did not silently succeed.
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Delete token')).not.toBeInTheDocument();
+  });
+
+  it('reports the exception when deletion fails', async () => {
+    const user = userEvent.setup();
+    const error = new Error('Delete failed');
+    mockDeleteToken.mockRejectedValue(error);
+
+    render(
+      <TokenDetailsView username="testuser" tokenKey="abc123xyz456789012345" />
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    const confirmButton = await screen.findByText('Delete token');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockReportError).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ site: 'token-details-delete' })
+      );
+    });
+  });
+
+  it('does not report when deletion succeeds', async () => {
+    const user = userEvent.setup();
+    mockDeleteToken.mockResolvedValue(undefined);
+
+    render(
+      <TokenDetailsView username="testuser" tokenKey="abc123xyz456789012345" />
+    );
+
+    const deleteButton = screen.getByRole('button', { name: /delete/i });
+    await user.click(deleteButton);
+
+    const confirmButton = await screen.findByText('Delete token');
+    await user.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockDeleteToken).toHaveBeenCalled();
+    });
+    expect(mockReportError).not.toHaveBeenCalled();
   });
 
   it('displays "No scopes" when token has empty scopes array', () => {

--- a/apps/squareone/src/components/TokenDetails/TokenDetailsView.tsx
+++ b/apps/squareone/src/components/TokenDetails/TokenDetailsView.tsx
@@ -2,8 +2,9 @@ import { useDeleteToken, useTokenDetails } from '@lsst-sqre/gafaelfawr-client';
 import type { BadgeColor } from '@lsst-sqre/squared';
 import { Badge, Button } from '@lsst-sqre/squared';
 import Link from 'next/link';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
+import { makeReportError } from '@/lib/sentry/reportError';
 import { useRepertoireUrl } from '../../hooks/useRepertoireUrl';
 import DeleteTokenModal from '../AccessTokensView/DeleteTokenModal';
 import TokenDate from '../TokenDate';
@@ -48,19 +49,32 @@ export default function TokenDetailsView({
   );
   const { deleteToken, isDeleting } = useDeleteToken(repertoireUrl);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<Error | null>(null);
+
+  // Inject the app's Sentry-backed reporter so a report-worthy delete failure
+  // (5xx, contract drift) reaches Sentry with site context tags, matching the
+  // sibling AccessTokenItem/SessionTokenItem capture pattern.
+  const reportError = useMemo(() => makeReportError({ isServer: false }), []);
 
   const handleDeleteClick = () => {
     setIsDeleteModalOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
+    setDeleteError(null);
     try {
       await deleteToken(username, tokenKey);
       setIsDeleteModalOpen(false);
       onDeleteSuccess?.();
     } catch (err) {
-      console.error('Failed to delete token:', err);
+      // Keep the modal closed but surface the failure so the still-listed token
+      // does not look silently deleted, and report the exception to Sentry.
       setIsDeleteModalOpen(false);
+      setDeleteError(err as Error);
+      reportError(err, {
+        site: 'token-details-delete',
+        package: 'gafaelfawr-client',
+      });
     }
   };
 
@@ -159,6 +173,12 @@ export default function TokenDetailsView({
             Delete
           </Button>
         </div>
+
+        {deleteError && (
+          <div className={styles.deleteError} role="alert">
+            Failed to delete token: {deleteError.message}
+          </div>
+        )}
 
         <div className={styles.metadataGrid}>
           <div className={styles.metadataRow}>

--- a/apps/squareone/src/components/TokenDetails/TokenDetailsView.tsx
+++ b/apps/squareone/src/components/TokenDetails/TokenDetailsView.tsx
@@ -69,8 +69,10 @@ export default function TokenDetailsView({
     } catch (err) {
       // Keep the modal closed but surface the failure so the still-listed token
       // does not look silently deleted, and report the exception to Sentry.
+      // Normalize non-Error throwables so the user-facing alert never renders
+      // "undefined"; the raw error is still forwarded to Sentry below.
       setIsDeleteModalOpen(false);
-      setDeleteError(err as Error);
+      setDeleteError(err instanceof Error ? err : new Error('Unknown error'));
       reportError(err, {
         site: 'token-details-delete',
         package: 'gafaelfawr-client',


### PR DESCRIPTION
## Summary

- `TokenDetailsView` no longer silently closes the delete confirmation modal when a token delete fails: it surfaces a user-facing error message (so the still-listed token does not look silently deleted) and reports the exception to Sentry, matching the sibling `AccessTokenItem`/`SessionTokenItem` `onDeleteError` capture pattern.
- `NewTokenPageClient` now captures the token-creation submit exception it previously only `console.error`ed; its existing user-facing `creationError` UX is unchanged.
- `ExecStats` recompute is no longer fire-and-forget: it checks the response, surfaces a user-facing "failed to recompute" message, and reports the exception to Sentry.
- `TimesSquareHtmlEventsProviderClient` now bounds its SSE reconnect attempts and enters a user-facing terminal-failure state after the budget is exhausted, capturing the connection error once per subscription instead of retrying silently forever.
- All sites wire the app's memoized `makeReportError` reporter with `site`/`package` context tags.

## Validation steps

- On the token details page, trigger a delete that fails (e.g. a 5xx from the delete endpoint) and confirm the token stays listed, the confirmation modal does not remain open, and a user-facing "Failed to delete token" message appears; confirm a Sentry event carrying the `token-details-delete` site tag.
- On the new-token page, submit a token creation that fails and confirm a Sentry event carrying the `new-token-submit` site tag is captured (existing on-page error display unchanged).
- On a Times Square page, trigger a recompute that fails (e.g. a 5xx from the html DELETE endpoint) and confirm a user-facing failure message appears and a Sentry event carrying the `times-square-recompute` site tag is captured.
- Simulate a persistently unreachable SSE endpoint and confirm the provider stops reconnecting after the bounded retry budget, shows a terminal-failure message, and captures a single Sentry event carrying the `times-square-sse` site tag (not one per retry).

## References

- Closes #606
- Closes #607
- PRD: #598
- Jira: https://rubinobs.atlassian.net/browse/DM-55604