### PR TITLE
DM-55619: Add dp2 and alerts labels to API Aspect page

### DIFF
--- a/.changeset/alerts-service-label.md
+++ b/.changeset/alerts-service-label.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+Add a curated label for the `alerts` service ("Alerts") on the API Aspect page, replacing the raw `alerts` service name in dataset endpoint listings.

--- a/.changeset/dataset-display-order.md
+++ b/.changeset/dataset-display-order.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+Order dataset groups on the API Aspect page by release recency instead of Repertoire's discovery order. Full data releases (`dr1`, `dr2`, …) rank above data previews, releases sort newest-first within each family (DP2 > DP1 > DP0.3 > DP0.2), and the evergreen Prompt dataset is always pinned second. Unrecognized datasets append after the releases in discovery order.

--- a/.changeset/dp2-dataset-display-name.md
+++ b/.changeset/dp2-dataset-display-name.md
@@ -1,0 +1,5 @@
+---
+'squareone': patch
+---
+
+Add a display name mapping for the `dp2` dataset ("Data Preview 2") on the API Aspect page, so DP2 endpoints are grouped under a friendly title when Repertoire begins advertising the dataset.

--- a/apps/squareone/src/lib/apiEndpoints/presentation.test.ts
+++ b/apps/squareone/src/lib/apiEndpoints/presentation.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest';
+
+import { datasetReleaseRank, orderDatasetKeys } from './presentation';
+
+describe('datasetReleaseRank', () => {
+  test('ranks full data releases above every data preview', () => {
+    expect(datasetReleaseRank('dr1')).toBeGreaterThan(
+      datasetReleaseRank('dp2') as number
+    );
+  });
+
+  test('ranks releases numerically within a family, not lexicographically', () => {
+    expect(datasetReleaseRank('dr10')).toBeGreaterThan(
+      datasetReleaseRank('dr2') as number
+    );
+  });
+
+  test('treats leading-zero preview digits as fractional DP0.x versions', () => {
+    expect(datasetReleaseRank('dp03')).toBeCloseTo(0.3);
+    expect(datasetReleaseRank('dp1')).toBeGreaterThan(
+      datasetReleaseRank('dp03') as number
+    );
+    expect(datasetReleaseRank('dp03')).toBeGreaterThan(
+      datasetReleaseRank('dp02') as number
+    );
+  });
+
+  test('returns null for non-release keys', () => {
+    expect(datasetReleaseRank('prompt')).toBeNull();
+    expect(datasetReleaseRank('mystery')).toBeNull();
+    expect(datasetReleaseRank('drx')).toBeNull();
+  });
+});
+
+describe('orderDatasetKeys', () => {
+  test('orders releases newest-first with prompt pinned second', () => {
+    expect(orderDatasetKeys(['dp02', 'dp1', 'prompt', 'dp03', 'dp2'])).toEqual([
+      'dp2',
+      'prompt',
+      'dp1',
+      'dp03',
+      'dp02',
+    ]);
+  });
+
+  test('slots full data releases ahead of previews, prompt still second', () => {
+    expect(orderDatasetKeys(['dp2', 'dr1', 'prompt', 'dr2'])).toEqual([
+      'dr2',
+      'prompt',
+      'dr1',
+      'dp2',
+    ]);
+  });
+
+  test('appends unrecognized keys after releases, in given order', () => {
+    expect(orderDatasetKeys(['zebra', 'dp1', 'aardvark'])).toEqual([
+      'dp1',
+      'zebra',
+      'aardvark',
+    ]);
+  });
+
+  test('handles prompt without any releases', () => {
+    expect(orderDatasetKeys(['prompt'])).toEqual(['prompt']);
+    expect(orderDatasetKeys(['prompt', 'mystery'])).toEqual([
+      'mystery',
+      'prompt',
+    ]);
+  });
+});

--- a/apps/squareone/src/lib/apiEndpoints/presentation.ts
+++ b/apps/squareone/src/lib/apiEndpoints/presentation.ts
@@ -91,6 +91,10 @@ export const presentationMap: PresentationMap = {
       ivoaName: 'GMS',
       url: 'base',
     },
+    alerts: {
+      label: 'Alerts',
+      url: 'base',
+    },
   },
   datasetDisplayNames: {
     dp1: 'Data Preview 1',

--- a/apps/squareone/src/lib/apiEndpoints/presentation.ts
+++ b/apps/squareone/src/lib/apiEndpoints/presentation.ts
@@ -105,6 +105,58 @@ export const presentationMap: PresentationMap = {
   },
 };
 
+/** Full data releases outrank every data preview regardless of number. */
+const DR_FAMILY_OFFSET = 1_000_000;
+
+/**
+ * Rank a release dataset key for display ordering; higher ranks sort earlier.
+ *
+ * Full data releases (`dr1`, `dr2`, …) outrank all data previews; within a
+ * family, newer releases outrank older. Data preview digits with a leading
+ * zero are fractional DP0.x releases (`dp03` -> 0.3), so `dp2` > `dp1` >
+ * `dp03` > `dp02`. Returns null for keys that don't match a release pattern
+ * (including `prompt`, which {@link orderDatasetKeys} pins specially).
+ */
+export function datasetReleaseRank(key: string): number | null {
+  const dr = /^dr(\d+)$/.exec(key);
+  if (dr) {
+    return DR_FAMILY_OFFSET + Number(dr[1]);
+  }
+  const dp = /^dp(\d+)$/.exec(key);
+  if (dp) {
+    const digits = dp[1];
+    return digits.startsWith('0')
+      ? Number(`0.${digits.slice(1)}`)
+      : Number(digits);
+  }
+  return null;
+}
+
+/**
+ * Order dataset keys for `/api-aspect` display.
+ *
+ * Recognized releases sort newest-first per {@link datasetReleaseRank}, with
+ * keys that don't match a release pattern following in their given (discovery)
+ * order. The evergreen `prompt` dataset is then pinned to the second position.
+ */
+export function orderDatasetKeys(keys: string[]): string[] {
+  const releases = keys
+    .map((key) => ({ key, rank: datasetReleaseRank(key) }))
+    .filter(
+      (entry): entry is { key: string; rank: number } => entry.rank !== null
+    )
+    .sort((a, b) => b.rank - a.rank)
+    .map((entry) => entry.key);
+  const unrecognized = keys.filter(
+    (key) => key !== 'prompt' && datasetReleaseRank(key) === null
+  );
+  const ordered = [...releases, ...unrecognized];
+  if (keys.includes('prompt')) {
+    ordered.splice(1, 0, 'prompt');
+  }
+  return ordered;
+}
+
 /**
  * Select the endpoint URL for a discovered service per its curated selector.
  *

--- a/apps/squareone/src/lib/apiEndpoints/presentation.ts
+++ b/apps/squareone/src/lib/apiEndpoints/presentation.ts
@@ -94,6 +94,7 @@ export const presentationMap: PresentationMap = {
   },
   datasetDisplayNames: {
     dp1: 'Data Preview 1',
+    dp2: 'Data Preview 2',
     dp02: 'Data Preview 0.2',
     dp03: 'Data Preview 0.3',
     prompt: 'Prompt',

--- a/apps/squareone/src/lib/apiEndpoints/transform.test.ts
+++ b/apps/squareone/src/lib/apiEndpoints/transform.test.ts
@@ -9,13 +9,77 @@ import type { PresentationMap } from './presentation';
 import { serviceDiscoveryToApiEndpointGroups } from './transform';
 
 describe('serviceDiscoveryToApiEndpointGroups', () => {
-  test('produces one group per dataset, in discovery order', () => {
+  test('produces one group per dataset, in curated dataset order', () => {
     const groups = serviceDiscoveryToApiEndpointGroups(mockDiscovery);
 
     expect(groups.map((group) => group.datasetKey)).toEqual([
       'dp1',
-      'dp02',
       'dp03',
+      'dp02',
+    ]);
+  });
+
+  test('orders datasets newest-first with prompt pinned second', () => {
+    const discovery = {
+      ...getEmptyDiscovery(),
+      // Discovery order is deliberately scrambled relative to the curated
+      // order.
+      datasets: {
+        dp02: { services: {} },
+        dp1: { services: {} },
+        prompt: { services: {} },
+        dp03: { services: {} },
+        dp2: { services: {} },
+      },
+    } as ServiceDiscovery;
+
+    const groups = serviceDiscoveryToApiEndpointGroups(discovery);
+    expect(groups.map((group) => group.datasetKey)).toEqual([
+      'dp2',
+      'prompt',
+      'dp1',
+      'dp03',
+      'dp02',
+    ]);
+  });
+
+  test('ranks future full data releases above all data previews', () => {
+    const discovery = {
+      ...getEmptyDiscovery(),
+      datasets: {
+        dp2: { services: {} },
+        dr1: { services: {} },
+        prompt: { services: {} },
+        dr2: { services: {} },
+        dp1: { services: {} },
+      },
+    } as ServiceDiscovery;
+
+    const groups = serviceDiscoveryToApiEndpointGroups(discovery);
+    expect(groups.map((group) => group.datasetKey)).toEqual([
+      'dr2',
+      'prompt',
+      'dr1',
+      'dp2',
+      'dp1',
+    ]);
+  });
+
+  test('appends datasets absent from the curated order, in discovery order', () => {
+    const discovery = {
+      ...getEmptyDiscovery(),
+      datasets: {
+        zebra: { services: {} },
+        dp1: { services: {} },
+        aardvark: { services: {} },
+      },
+    } as ServiceDiscovery;
+
+    const groups = serviceDiscoveryToApiEndpointGroups(discovery);
+    expect(groups.map((group) => group.datasetKey)).toEqual([
+      'dp1',
+      'zebra',
+      'aardvark',
     ]);
   });
 

--- a/apps/squareone/src/lib/apiEndpoints/transform.test.ts
+++ b/apps/squareone/src/lib/apiEndpoints/transform.test.ts
@@ -38,6 +38,30 @@ describe('serviceDiscoveryToApiEndpointGroups', () => {
     expect(group.displayName).toBe('Data Preview 2');
   });
 
+  test('maps the alerts service to its curated label', () => {
+    const discovery = {
+      ...getEmptyDiscovery(),
+      datasets: {
+        dp1: {
+          services: {
+            alerts: {
+              url: 'https://data.lsst.cloud/api/alerts',
+              versions: {},
+            },
+          },
+        },
+      },
+    } as unknown as ServiceDiscovery;
+
+    const [group] = serviceDiscoveryToApiEndpointGroups(discovery);
+    expect(group.endpoints[0]).toEqual({
+      label: 'Alerts',
+      url: 'https://data.lsst.cloud/api/alerts',
+      ivoaUrl: null,
+      ivoaName: null,
+    });
+  });
+
   test('falls back to the raw dataset key for an unmapped dataset', () => {
     const discovery = {
       ...getEmptyDiscovery(),

--- a/apps/squareone/src/lib/apiEndpoints/transform.test.ts
+++ b/apps/squareone/src/lib/apiEndpoints/transform.test.ts
@@ -28,6 +28,16 @@ describe('serviceDiscoveryToApiEndpointGroups', () => {
     expect(dp1?.description).toContain('Data Preview 1 contains');
   });
 
+  test('maps the dp2 dataset key to its display name', () => {
+    const discovery = {
+      ...getEmptyDiscovery(),
+      datasets: { dp2: { services: {} } },
+    } as ServiceDiscovery;
+
+    const [group] = serviceDiscoveryToApiEndpointGroups(discovery);
+    expect(group.displayName).toBe('Data Preview 2');
+  });
+
   test('falls back to the raw dataset key for an unmapped dataset', () => {
     const discovery = {
       ...getEmptyDiscovery(),

--- a/apps/squareone/src/lib/apiEndpoints/transform.ts
+++ b/apps/squareone/src/lib/apiEndpoints/transform.ts
@@ -2,6 +2,7 @@ import type { ServiceDiscovery } from '@lsst-sqre/repertoire-client';
 
 import {
   presentationMap as defaultPresentationMap,
+  orderDatasetKeys,
   type PresentationMap,
   selectServiceUrl,
 } from './presentation';
@@ -11,9 +12,11 @@ import type { ApiEndpointGroup } from './types';
  * Transform Repertoire service discovery into the `/api-aspect` listing,
  * applying the curated {@link PresentationMap}.
  *
- * Emits one {@link ApiEndpointGroup} per discovered dataset, in discovery
- * order. Each group resolves the dataset display name (falling back to the raw
- * key) and carries the dataset `docs_url` and `description`. Every service
+ * Emits one {@link ApiEndpointGroup} per discovered dataset, ordered by
+ * {@link orderDatasetKeys} (releases newest-first, `prompt` pinned second,
+ * unrecognized datasets after in discovery order). Each group resolves the
+ * dataset display name (falling back to the raw key) and carries the dataset
+ * `docs_url` and `description`. Every service
  * under a dataset is rendered: mapped services get the curated label, IVOA
  * standard link and name, and version-selected URL; services absent from the
  * map fall back to the raw service name, the base URL, and a null IVOA link.
@@ -29,31 +32,34 @@ export function serviceDiscoveryToApiEndpointGroups(
 ): ApiEndpointGroup[] {
   const datasets = discovery.datasets ?? {};
 
-  return Object.entries(datasets).map(([datasetKey, dataset]) => ({
-    datasetKey,
-    displayName: presentation.datasetDisplayNames[datasetKey] ?? datasetKey,
-    docsUrl: dataset.docs_url ?? null,
-    description: dataset.description ?? null,
-    endpoints: Object.entries(dataset.services ?? {}).map(
-      ([serviceName, service]) => {
-        const curated = presentation.services[serviceName];
-        if (!curated) {
+  return orderDatasetKeys(Object.keys(datasets)).map((datasetKey) => {
+    const dataset = datasets[datasetKey];
+    return {
+      datasetKey,
+      displayName: presentation.datasetDisplayNames[datasetKey] ?? datasetKey,
+      docsUrl: dataset.docs_url ?? null,
+      description: dataset.description ?? null,
+      endpoints: Object.entries(dataset.services ?? {}).map(
+        ([serviceName, service]) => {
+          const curated = presentation.services[serviceName];
+          if (!curated) {
+            return {
+              label: serviceName,
+              url: service.url,
+              ivoaUrl: null,
+              ivoaName: null,
+            };
+          }
           return {
-            label: serviceName,
-            url: service.url,
-            ivoaUrl: null,
-            ivoaName: null,
+            label: curated.label,
+            url: selectServiceUrl(service, curated.url),
+            ivoaUrl: curated.ivoaUrl ?? null,
+            ivoaName: curated.ivoaName ?? null,
           };
         }
-        return {
-          label: curated.label,
-          url: selectServiceUrl(service, curated.url),
-          ivoaUrl: curated.ivoaUrl ?? null,
-          ivoaName: curated.ivoaName ?? null,
-        };
-      }
-    ),
-  }));
+      ),
+    };
+  });
 }
 
 export type { ApiEndpoint, ApiEndpointGroup } from './types';


### PR DESCRIPTION
## Summary

- Add a display name mapping for the `dp2` dataset ("Data Preview 2") so DP2 endpoints are grouped under a friendly title when Repertoire begins advertising the dataset.
- Add a curated label for the `alerts` service ("Alerts") so it no longer appears under its raw service name in dataset endpoint listings.
- Order dataset groups by release recency instead of Repertoire's discovery order: full data releases (`dr1`, `dr2`, …) rank above data previews, releases sort newest-first within each family (DP2 > DP1 > DP0.3 > DP0.2), and the evergreen Prompt dataset is always pinned second. Unrecognized datasets append after in discovery order. The ranking is rule-based, so future DR datasets order correctly without a code change.

## Validation steps

- On an environment where Repertoire advertises the `alerts` service (e.g. data-int.lsst.cloud), open `/api-aspect` and confirm the endpoint is listed as "Alerts" with no IVOA doc link.
- On `/api-aspect`, confirm dataset sections appear newest-first (currently DP1 before DP0.3 before DP0.2 on production-like data).
- Once Repertoire advertises the `dp2` dataset, confirm its section is titled "Data Preview 2" and appears first, with Prompt second.

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-55619