### PR TITLE
DM-55493: Refresh vendored Repertoire and Times Square OpenAPI specs

### DIFF
--- a/.changeset/refresh-vendored-openapi-specs.md
+++ b/.changeset/refresh-vendored-openapi-specs.md
@@ -1,0 +1,9 @@
+---
+'@lsst-sqre/repertoire-client': patch
+'@lsst-sqre/times-square-client': patch
+---
+
+Refresh the vendored OpenAPI specs for the Repertoire and Times Square clients
+
+- `repertoire-client`: re-vendored `openapi.json` at Repertoire 2.1.0 (from 2.0.0). The only API-surface change is the `operationId` on `/api/registry`, which is now `get_oai_api_registry_get` for both the GET and POST operations. No schemas changed, so the Zod schemas and types are unaffected.
+- `times-square-client`: re-vendored `openapi.json` at Times Square 0.24.2.dev9+g3ee2b2a55 (from 0.23.1.dev24+g576ef1393). The `ValidationError` schema gained two optional fields, `input` and `ctx`; neither is required, and `ValidationErrorSchema` strips unknown keys, so existing parsing is unchanged.

--- a/packages/repertoire-client/openapi.json
+++ b/packages/repertoire-client/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Repertoire",
     "description": "Service discovery for the Rubin Science Platform",
-    "version": "2.0.0"
+    "version": "2.1.0"
   },
   "paths": {
     "/repertoire/": {
@@ -107,7 +107,7 @@
       "get": {
         "summary": "IVOA Publishing Registry",
         "description": "Handle an OAI-PMH request.\n\nAccepts any OAI-PMH verb as a query parameter (GET) or form field\n(POST) and returns the corresponding XML response.  All responses\n(including errors) use HTTP 200 as specified in OAI-PMH.",
-        "operationId": "get_oai_api_registry_post",
+        "operationId": "get_oai_api_registry_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -118,7 +118,7 @@
       "post": {
         "summary": "IVOA Publishing Registry",
         "description": "Handle an OAI-PMH request.\n\nAccepts any OAI-PMH verb as a query parameter (GET) or form field\n(POST) and returns the corresponding XML response.  All responses\n(including errors) use HTTP 200 as specified in OAI-PMH.",
-        "operationId": "get_oai_api_registry_post",
+        "operationId": "get_oai_api_registry_get",
         "responses": {
           "200": {
             "description": "Successful Response",

--- a/packages/times-square-client/openapi.json
+++ b/packages/times-square-client/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Times Square",
     "description": "**Times Square is a Rubin Science Platform (RSP) service for displaying parameterized Jupyter Notebooks as websites.**\n\nExcellent applications for Times Square include:\n\n- Engineering dashboards\n- Quick-look data previewing\n- Reports that incorporate live data sources\n\nThe design and architecture of Times Square is described in [The Times Square service for publishing parameterized Jupyter Notebooks in the Rubin Science platform](https://sqr-062.lsst.io).\nTimes Square uses Noteburst ([GitHub](https://github.com/lsst-sqre/noteburst), [SQR-065](https://sqr-065.lsst.io)) to execute Jupyter Notebooks in Nublado (JupyterLab) instances, thereby mechanizing the RSP's notebook aspect.\n\nThis Times Square API service is developed at [https://github.com/lsst-sqre/times-square](https://github.com/lsst-sqre/times-square).\nThe user interface is developed separately at [https://github.com/lsst-sqre/times-square-ui](https://github.com/lsst-sqre/times-square-ui).\n",
-    "version": "0.23.1.dev24+g576ef1393"
+    "version": "0.24.2.dev9+g3ee2b2a55"
   },
   "paths": {
     "/healthcheck": {
@@ -1372,7 +1372,9 @@
             "title": "Location"
           },
           "msg": { "type": "string", "title": "Message" },
-          "type": { "type": "string", "title": "Error Type" }
+          "type": { "type": "string", "title": "Error Type" },
+          "input": { "title": "Input" },
+          "ctx": { "type": "object", "title": "Context" }
         },
         "type": "object",
         "required": ["loc", "msg", "type"],


### PR DESCRIPTION
## Summary

The scheduled `Periodic CI` workflow's `openapi-drift` job ("Check for OpenAPI spec drift") has been failing since **2026-06-22** — five consecutive weekly runs. Ordinary push/PR CI on `main` is green; only the scheduled drift check is red.

Two vendored specs had drifted from their live sources:

| Client | `info.version` before | `info.version` after |
| --- | --- | --- |
| `repertoire-client` | `2.0.0` | `2.1.0` |
| `times-square-client` | `0.23.1.dev24+g576ef1393` | `0.24.2.dev9+g3ee2b2a55` |

This PR re-vendors both specs so the job goes green again.

## Regeneration command

Both specs were refreshed with the packages' own `fetch-openapi` scripts — the same commands the drift check prints in its remediation hint — rather than by hand-editing JSON:

```bash
pnpm --filter @lsst-sqre/repertoire-client fetch-openapi
pnpm --filter @lsst-sqre/times-square-client fetch-openapi
pnpm exec biome format --write \
  packages/repertoire-client/openapi.json \
  packages/times-square-client/openapi.json
```

The Biome format pass is needed because both services serve compact JSON, while the vendored copies are Biome-formatted (`biome.json` includes `**`, so `pnpm biome:format:check` would otherwise fail).

## What actually changed in the specs

There is no code generation in this repo — the Zod schemas and TypeScript types in each client's `src/` are hand-written, so the only regenerated artifacts are the two `openapi.json` files.

**Repertoire 2.0.0 -> 2.1.0** — beyond `info.version`, the sole difference is an `operationId` correction on `/api/registry`: both the GET and POST operations now report `get_oai_api_registry_get` (previously both reported `get_oai_api_registry_post`). No schemas, paths, or parameters changed, so despite the minor-version bump there is no type impact on the client.

**Times Square 0.23.1.dev24 -> 0.24.2.dev9** — beyond `info.version`, the `ValidationError` schema gained two fields, `input` and `ctx`. Neither is in `required`, and `ValidationErrorSchema` (a plain `z.object`) strips unknown keys, so existing parsing is unaffected. I deliberately left `packages/times-square-client/src/schemas.ts` alone to keep this PR a clean drift fix; mirroring the two optional fields into the Zod schema is a reasonable follow-up if we want the schema to track the spec exactly.

## Validation

All run locally on this branch:

- `pnpm run check-openapi-drift` — **passes**, exit code 0. All three vendored specs (`semaphore-client`, `repertoire-client`, `times-square-client`) report in sync; `gafaelfawr-client` is skipped as before because it vendors no spec.
- `pnpm type-check` — 8/8 tasks successful.
- `pnpm test` — 17/17 tasks successful.
- `pnpm build` — 12/12 tasks successful.
- `pnpm run biome:format:check` — clean across 862 files.

`pnpm run prettier:yaml` reports 9 warnings, but all 9 are untracked, gitignored `.playwright-mcp/page-*.yml` scratch files in my local clone. They are not part of this PR and do not exist in CI.

A patch changeset is included for both client packages.

Ticket: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)


[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ