### PR TITLE
DM-55470: Ignore examples order in the OpenAPI drift check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,7 @@ out/
 
 # devcontainer config files are JSONC (comments + stoker-managed sentinels)
 .devcontainer/
+
+# gitignored Playwright MCP page snapshots are YAML, so the prettier:yaml
+# glob would otherwise pick them up
+.playwright-mcp/

--- a/packages/repo-scripts/src/check-openapi-drift.js
+++ b/packages/repo-scripts/src/check-openapi-drift.js
@@ -112,10 +112,10 @@ function sortPrimitives(items) {
  * Some upstream services serialize `examples` from an unordered collection
  * (e.g. a Python set), so their element order varies from one process to the
  * next and would otherwise register as drift. The exception applies to the
- * `examples` array itself and to primitive-element arrays nested directly
- * inside it (`examples: [["58", "57"]]`); it does not reach through object
- * elements, and an `examples` array holding composite values keeps its own
- * order.
+ * `examples` array itself and to any primitive-element array reachable from it
+ * through array nesting alone (`examples: [["58", "57"]]`); it does not reach
+ * through object elements, and an `examples` array holding composite values
+ * keeps its own order.
  *
  * `inExamples` is internal recursion state — callers pass a value only.
  */

--- a/packages/repo-scripts/src/check-openapi-drift.js
+++ b/packages/repo-scripts/src/check-openapi-drift.js
@@ -10,6 +10,11 @@
  * compared against the committed `packages/<client>/openapi.json`. Both specs are
  * normalized first (parsed, then re-serialized with recursively sorted object
  * keys) so differences in key order or whitespace don't produce false positives.
+ * Array order is otherwise preserved, with one exception: primitive-element
+ * arrays inside an `examples` value are sorted, because some services serialize
+ * their examples from an unordered collection (a Python set) and so emit a
+ * different element order on each redeploy. See `canonicalize` for the exact
+ * extent of that exception.
  *
  * The comparison excludes `info.version`: an RSP service redeploy commonly bumps
  * its spec's `info.version` (e.g. a setuptools-scm dev version) with no change to
@@ -80,18 +85,51 @@ function extractSpecUrl(fetchScript) {
 }
 
 /**
- * Recursively sort object keys to produce a canonical representation. Array
- * order is preserved (it is semantically significant in OpenAPI); only object
- * keys are reordered so that key-order / whitespace differences compare equal.
+ * True for JSON scalars (string, number, boolean, null) — anything that is not
+ * an object or array.
  */
-function canonicalize(value) {
+function isPrimitive(value) {
+  return value === null || typeof value !== 'object';
+}
+
+/**
+ * Order a primitive-element array deterministically by its elements' JSON
+ * encodings, so that `1` and `"1"` remain distinguishable.
+ */
+function sortPrimitives(items) {
+  return items
+    .map((item) => ({ item, key: JSON.stringify(item) }))
+    .sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+    .map((entry) => entry.item);
+}
+
+/**
+ * Recursively sort object keys to produce a canonical representation, so that
+ * key-order / whitespace differences compare equal.
+ *
+ * Array order is preserved (it is semantically significant in OpenAPI) with one
+ * exception: primitive-element arrays inside an `examples` value are sorted.
+ * Some upstream services serialize `examples` from an unordered collection
+ * (e.g. a Python set), so their element order varies from one process to the
+ * next and would otherwise register as drift. The exception applies to the
+ * `examples` array itself and to primitive-element arrays nested directly
+ * inside it (`examples: [["58", "57"]]`); it does not reach through object
+ * elements, and an `examples` array holding composite values keeps its own
+ * order.
+ *
+ * `inExamples` is internal recursion state — callers pass a value only.
+ */
+function canonicalize(value, inExamples = false) {
   if (Array.isArray(value)) {
-    return value.map(canonicalize);
+    const items = value.map((item) => canonicalize(item, inExamples));
+    return inExamples && items.every(isPrimitive)
+      ? sortPrimitives(items)
+      : items;
   }
   if (value && typeof value === 'object') {
     const sorted = {};
     for (const key of Object.keys(value).sort()) {
-      sorted[key] = canonicalize(value[key]);
+      sorted[key] = canonicalize(value[key], key === 'examples');
     }
     return sorted;
   }

--- a/packages/repo-scripts/src/check-openapi-drift.test.ts
+++ b/packages/repo-scripts/src/check-openapi-drift.test.ts
@@ -30,6 +30,29 @@ function baseSpec() {
   };
 }
 
+// A spec shaped like the Semaphore false-drift case: a schema property whose
+// `examples` value is serialized upstream from an unordered Python collection,
+// so its element order varies from one process/pod to the next.
+function specWithIdsExamples(examples: unknown) {
+  return {
+    openapi: '3.1.0',
+    info: {
+      title: 'Semaphore',
+      version: '2.0.0',
+    },
+    components: {
+      schemas: {
+        UserNotificationRead: {
+          type: 'object',
+          properties: {
+            ids: { type: 'array', examples },
+          },
+        },
+      },
+    },
+  };
+}
+
 describe('classifySpecs', () => {
   it('returns "ok" for identical specs', () => {
     expect(classifySpecs(baseSpec(), baseSpec())).toBe('ok');
@@ -61,6 +84,61 @@ describe('classifySpecs', () => {
       name: { type: 'string' },
       title: { type: 'string' },
     };
+
+    expect(classifySpecs(committed, live)).toBe('drift');
+  });
+
+  it('returns "ok" when only the order of an examples array differs', () => {
+    const committed = specWithIdsExamples(['58', '57', '56', '59']);
+    const live = specWithIdsExamples(['58', '56', '57', '59']);
+
+    expect(classifySpecs(committed, live)).toBe('ok');
+  });
+
+  it('returns "ok" when an array nested inside examples is reordered', () => {
+    // The literal Semaphore shape: the single example *is* the id list.
+    const committed = specWithIdsExamples([['58', '57', '56', '59']]);
+    const live = specWithIdsExamples([['58', '56', '57', '59']]);
+
+    expect(classifySpecs(committed, live)).toBe('ok');
+  });
+
+  it('returns "version-only" when examples order and info.version differ', () => {
+    const committed = specWithIdsExamples([['58', '57', '56', '59']]);
+    const live = specWithIdsExamples([['58', '56', '57', '59']]);
+    live.info.version = '2.0.1';
+
+    expect(classifySpecs(committed, live)).toBe('version-only');
+  });
+
+  it('returns "drift" when examples membership changes', () => {
+    const committed = specWithIdsExamples([['58', '57', '56', '59']]);
+    const live = specWithIdsExamples([['58', '57', '56', '60']]);
+
+    expect(classifySpecs(committed, live)).toBe('drift');
+  });
+
+  it('returns "drift" when a non-examples array is reordered', () => {
+    const committed = specWithIdsExamples(['58']);
+    const live = specWithIdsExamples(['58']);
+    // `enum` order is not normalized — only `examples` gets the exception.
+    (
+      committed.components.schemas.UserNotificationRead.properties
+        .ids as Record<string, unknown>
+    ).enum = ['a', 'b'];
+    (
+      live.components.schemas.UserNotificationRead.properties.ids as Record<
+        string,
+        unknown
+      >
+    ).enum = ['b', 'a'];
+
+    expect(classifySpecs(committed, live)).toBe('drift');
+  });
+
+  it('returns "drift" when an examples array of objects is reordered', () => {
+    const committed = specWithIdsExamples([{ a: 1 }, { b: 2 }]);
+    const live = specWithIdsExamples([{ b: 2 }, { a: 1 }]);
 
     expect(classifySpecs(committed, live)).toBe('drift');
   });


### PR DESCRIPTION
## Summary

- The weekly OpenAPI drift check reported false drift for `semaphore-client`: the committed and live Semaphore specs differ only in the element order of the `UserNotificationRead` / `UserNotificationUnread` `ids` examples, which Semaphore serializes from an unordered Python collection and so emits in a different order per pod.
- `canonicalize()` now sorts primitive-element arrays inside an `examples` value, so that ordering no longer registers as drift. Every other array keeps its order — array order is semantically significant in OpenAPI — and an `examples` array holding composite values keeps its own order too, so genuine membership or content changes still classify as `drift`.
- `packages/semaphore-client/openapi.json` is deliberately **not** re-vendored: re-vendoring would only re-drift on the next Semaphore redeploy, and the committed spec is correct as-is.

## Validation steps

- Run `pnpm run check-openapi-drift` (needs open egress to `data.lsst.cloud`) and confirm `semaphore-client` reports `✓ in sync (info.version 2.0.0)` and the command exits 0.

## References

- Closes #633
- PRD: #632
- Jira: https://rubinobs.atlassian.net/browse/DM-55470