### PR TITLE
Add workflow_dispatch trigger to Release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ name: Release
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to the Release workflow so it can be run manually when a push event is lost.

Context: the merge of #619 (squareone 0.38.0 version bump) coincided with a GitHub Actions incident (https://www.githubstatus.com/incidents/qcvjkzcs7j74), so the push event for `f2977acf` was dropped and no Release run was ever created — leaving 0.38.0 unpublished with nothing to re-run in the Actions UI.

Merging this PR pushes to `main`, which itself triggers the Release workflow: changesets will detect that `squareone@0.38.0` is versioned but untagged, publish it, and create the GitHub release, which in turn triggers the Docker image build. Going forward, `gh workflow run release.yaml` provides a manual escape hatch for future outages.

## Validation steps

- After merge, confirm the Release workflow runs on `main` and publishes `squareone@0.38.0` (tag + GitHub release).
- Confirm the Docker release workflow triggers off the published release and pushes the 0.38.0 image.

## References

- GitHub Actions incident: https://www.githubstatus.com/incidents/qcvjkzcs7j74
- Missed release merge: #619